### PR TITLE
Fix improperly disposed projects and only respond to selection changes for the project that the selection model belongs to

### DIFF
--- a/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/editor/ClassEditorPortletPresenter.java
+++ b/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/editor/ClassEditorPortletPresenter.java
@@ -49,4 +49,10 @@ public class ClassEditorPortletPresenter extends AbstractWebProtegePortletPresen
     protected void handleReloadRequest() {
         editorPresenter.handleReloadRequest();
     }
+
+    @Override
+    public void dispose() {
+        editorPresenter.dispose();
+        super.dispose();
+    }
 }

--- a/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/inject/ClientProjectComponent.java
+++ b/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/inject/ClientProjectComponent.java
@@ -10,8 +10,10 @@ import edu.stanford.bmir.protege.web.client.project.ProjectPrefixDeclarationsPre
 import edu.stanford.bmir.protege.web.client.project.ProjectPresenter;
 import edu.stanford.bmir.protege.web.client.projectsettings.ProjectSettingsPresenter;
 import edu.stanford.bmir.protege.web.client.search.EntitySearchSettingsPresenter;
+import edu.stanford.bmir.protege.web.client.selection.SelectionModel;
 import edu.stanford.bmir.protege.web.client.sharing.SharingSettingsPresenter;
 import edu.stanford.bmir.protege.web.client.tag.ProjectTagsPresenter;
+import edu.stanford.bmir.protege.web.shared.HasDispose;
 import edu.stanford.bmir.protege.web.shared.inject.ProjectSingleton;
 import edu.stanford.bmir.protege.web.shared.project.ProjectId;
 
@@ -28,7 +30,7 @@ import edu.stanford.bmir.protege.web.shared.project.ProjectId;
         }
 )
 @ProjectSingleton
-public interface ClientProjectComponent {
+public interface ClientProjectComponent extends HasDispose {
 
     ProjectId getProjectId();
 
@@ -51,4 +53,11 @@ public interface ClientProjectComponent {
     EntitySearchSettingsPresenter getEntitySearchSettingsPresenter();
 
     PerspectivesManagerPresenter getPerspectivesManagerPresenter();
+
+    SelectionModel getProjectSelectionModel();
+
+    default void dispose() {
+        getProjectPresenter().dispose();
+        getProjectSelectionModel().dispose();
+    }
 }

--- a/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/perspective/PerspectiveImpl.java
+++ b/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/perspective/PerspectiveImpl.java
@@ -138,6 +138,7 @@ public final class PerspectiveImpl extends Composite implements IsWidget, Perspe
 
     @Override
     public void dispose() {
+        widgetMapper.dispose();
     }
 
 

--- a/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/perspective/PerspectivePresenter.java
+++ b/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/perspective/PerspectivePresenter.java
@@ -6,6 +6,7 @@ import com.google.gwt.user.client.Timer;
 import com.google.gwt.user.client.ui.AcceptsOneWidget;
 import com.google.gwt.user.client.ui.Label;
 import com.google.web.bindery.event.shared.EventBus;
+import com.google.web.bindery.event.shared.HandlerRegistration;
 import edu.stanford.bmir.protege.web.client.dispatch.DispatchServiceManager;
 import edu.stanford.bmir.protege.web.client.form.LanguageMapCurrentLocaleMapper;
 import edu.stanford.bmir.protege.web.client.library.msgbox.MessageBox;
@@ -66,6 +67,8 @@ public class PerspectivePresenter implements HasDispose {
 
     private final LanguageMapCurrentLocaleMapper localeMapper;
 
+    private HandlerRegistration placeChangedHandlerRegistration;
+
 
     @Inject
     public PerspectivePresenter(final PerspectiveView perspectiveView,
@@ -91,8 +94,8 @@ public class PerspectivePresenter implements HasDispose {
 
     public void start(AcceptsOneWidget container, EventBus eventBus, ProjectViewPlace place) {
         GWT.log("[PerspectivePresenter] Starting at place " + place);
-        eventBus.addHandler(PlaceChangeEvent.TYPE, event -> {
-            if(event.getNewPlace() instanceof ProjectViewPlace) {
+        placeChangedHandlerRegistration = eventBus.addHandler(PlaceChangeEvent.TYPE, event -> {
+            if (event.getNewPlace() instanceof ProjectViewPlace) {
                 displayPerspective(((ProjectViewPlace) event.getNewPlace()).getPerspectiveId());
             }
         });
@@ -213,6 +216,9 @@ public class PerspectivePresenter implements HasDispose {
 
     @Override
     public void dispose() {
+        if(placeChangedHandlerRegistration != null) {
+            placeChangedHandlerRegistration.removeHandler();
+        }
         for(Perspective tab : perspectiveCache.values()) {
             tab.dispose();
         }

--- a/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/place/WebProtegeActivityMapper.java
+++ b/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/place/WebProtegeActivityMapper.java
@@ -22,6 +22,7 @@ import edu.stanford.bmir.protege.web.client.projectmanager.ProjectManagerPresent
 import edu.stanford.bmir.protege.web.client.projectsettings.ProjectSettingsActivity;
 import edu.stanford.bmir.protege.web.client.search.EntitySearchSettingsActivity;
 import edu.stanford.bmir.protege.web.client.search.EntitySearchSettingsPresenter;
+import edu.stanford.bmir.protege.web.client.selection.SelectionModel;
 import edu.stanford.bmir.protege.web.client.sharing.SharingSettingsActivity;
 import edu.stanford.bmir.protege.web.client.sharing.SharingSettingsPresenter;
 import edu.stanford.bmir.protege.web.client.signup.SignUpPresenter;
@@ -44,6 +45,7 @@ import java.util.logging.Logger;
  * 12/02/16
  */
 public class WebProtegeActivityMapper implements ActivityMapper {
+    
     Logger logger = Logger.getLogger("WebProtegeActivityMapper");
 
     private final ClientApplicationComponent applicationComponent;
@@ -86,9 +88,9 @@ public class WebProtegeActivityMapper implements ActivityMapper {
     }
 
     public void start() {
-        GWT.log("[WebProtegeActivityMapper] Started activity mapper.");
+        logger.info("Started activity mapper.");
         eventBus.addHandler(UserLoggedOutEvent.ON_USER_LOGGED_OUT, event -> {
-            GWT.log("[WebProtegeActivityMapper] User logged out.  Going to the Login Place.");
+            logger.info("User logged out.  Going to the Login Place.");
             LoginPlace loginPlace;
             Place currentPlace = placeController.getWhere();
             if (!(currentPlace instanceof LoginPlace)) {
@@ -102,16 +104,18 @@ public class WebProtegeActivityMapper implements ActivityMapper {
     }
 
     private ClientProjectComponent getClientProjectComponentForProjectAndLoggedInUser(@Nonnull ProjectId projectId) {
+        logger.info("Getting project component for " + projectId + ".  The current project is " + currentClientProjectComponent);
         if(currentClientProjectComponent.isPresent()) {
             ClientProjectComponent projectComponent = currentClientProjectComponent.get();
             if(isProjectComponentForProject(projectComponent, projectId) && isLastUserSameAsLoggedInUser()) {
                 return projectComponent;
             }
-            projectComponent.getProjectPresenter().dispose();
+            logger.info("Disposing of project component for " + projectComponent.getProjectId());
+            projectComponent.dispose();
         }
         ClientProjectComponent nextProjectComponent = instantiateClientProjectComponent(projectId);
         // Reset project component and user
-        GWT.log("[WebProtegeActivityMapper] Instantiating new project component");
+        logger.info("Instantiating new project component");
         lastUser = Optional.of(loggedInUserProvider.getCurrentUserId());
         currentClientProjectComponent = Optional.of(nextProjectComponent);
         return nextProjectComponent;
@@ -131,10 +135,10 @@ public class WebProtegeActivityMapper implements ActivityMapper {
     }
 
     public Activity getActivity(final Place place) {
-        GWT.log("[WebProtegeActivityMapper] Map place: " + place);
+        logger.info("Map place: " + place);
         if (shouldRedirectToLogin(place)) {
-            GWT.log("[WebProtegeActivityMapper] User is not logged in.  Redirecting to login.");
-            logger.info("[WebProtegeActivityMapper] User is not logged in.  Redirecting to login.");
+            logger.info("User is not logged in.  Redirecting to login.");
+            logger.info("User is not logged in.  Redirecting to login.");
             loginPresenter.setNextPlace(place);
             Scheduler.get().scheduleFinally(() -> placeController.goTo(new LoginPlace(place)));
             return new LoginActivity(loginPresenter);
@@ -168,7 +172,7 @@ public class WebProtegeActivityMapper implements ActivityMapper {
         }
         if (place instanceof LoginPlace) {
             if (!loggedInUserProvider.getCurrentUserId().isGuest()) {
-                logger.info("[WebProtegeActivityMapper] Schedule to project list after login.");
+                logger.info("Schedule to project list after login.");
 
                 Scheduler.get().scheduleFinally(() -> placeController.goTo(new ProjectListPlace()));
             }
@@ -193,7 +197,7 @@ public class WebProtegeActivityMapper implements ActivityMapper {
         }
 
         if (place instanceof ProjectListPlace) {
-            logger.info("[WebProtegeActivityMapper] Route to project list activity");
+            logger.info("Route to project list activity");
             return new ProjectListActivity(projectManagerPresenter);
         }
 

--- a/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/portlet/AbstractWebProtegePortletPresenter.java
+++ b/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/portlet/AbstractWebProtegePortletPresenter.java
@@ -17,11 +17,13 @@ import edu.stanford.bmir.protege.web.shared.event.WebProtegeEventBus;
 import edu.stanford.bmir.protege.web.shared.lang.DisplayNameSettingsChangedEvent;
 import edu.stanford.bmir.protege.web.shared.place.ProjectViewPlace;
 import edu.stanford.bmir.protege.web.shared.project.ProjectId;
+import edu.stanford.protege.widgetmap.client.view.HasViewTitle;
 import org.semanticweb.owlapi.model.OWLEntity;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Optional;
+import java.util.logging.Logger;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -29,6 +31,8 @@ import static edu.stanford.bmir.protege.web.shared.event.BrowserTextChangedEvent
 
 
 public abstract class AbstractWebProtegePortletPresenter implements WebProtegePortletPresenter, EntityDisplay {
+
+    private static final Logger logger = Logger.getLogger("AbstractWebProtegePortletPresenter");
 
     private final SelectionModel selectionModel;
 
@@ -51,6 +55,8 @@ public abstract class AbstractWebProtegePortletPresenter implements WebProtegePo
     @Nullable
     private Place lastPlace = null;
 
+    private boolean disposed = false;
+
     public AbstractWebProtegePortletPresenter(@Nonnull SelectionModel selectionModel,
                                               @Nonnull ProjectId projectId,
                                               @Nonnull DisplayNameRenderer displayNameRenderer,
@@ -60,6 +66,7 @@ public abstract class AbstractWebProtegePortletPresenter implements WebProtegePo
         this.projectId = checkNotNull(projectId);
         this.displayNameRenderer = displayNameRenderer;
         selectionModelHandlerRegistration = selectionModel.addSelectionChangedHandler(e -> {
+            logger.info("Handling selection changed in " + projectId + " (disposed=" + disposed  + ") in " + portletUi.map(HasViewTitle::getViewTitle).orElse("(not set)"));
                                                                                           if (trackSelection) {
                                                                                               handleBeforeSetEntity(e.getPreviousSelection());
                                                                                               handleAfterSetEntity(e.getLastSelection());
@@ -201,6 +208,8 @@ public abstract class AbstractWebProtegePortletPresenter implements WebProtegePo
 
     @Override
     public void dispose() {
+        disposed = true;
+        logger.info("Disposing of portlet " + getClass().getSimpleName() + " in project " + projectId);
         selectionModelHandlerRegistration.removeHandler();
         portletUi.ifPresent(HasDispose::dispose);
     }

--- a/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/project/ProjectPresenter.java
+++ b/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/project/ProjectPresenter.java
@@ -143,6 +143,7 @@ public class ProjectPresenter implements HasDispose, HasProjectId {
         linkBarPresenter.dispose();
         perspectivePresenter.dispose();
         eventPollingManager.stop();
+        eventBus.dispose();
     }
 
     @Override

--- a/webprotege-gwt-ui-client/src/test/java/edu/stanford/bmir/protege/web/client/selection/SelectionModel_TestCase.java
+++ b/webprotege-gwt-ui-client/src/test/java/edu/stanford/bmir/protege/web/client/selection/SelectionModel_TestCase.java
@@ -7,6 +7,7 @@ import com.google.web.bindery.event.shared.EventBus;
 import edu.stanford.bmir.protege.web.client.dispatch.DispatchServiceManager;
 import edu.stanford.bmir.protege.web.shared.place.ItemSelection;
 import edu.stanford.bmir.protege.web.shared.place.ProjectViewPlace;
+import edu.stanford.bmir.protege.web.shared.project.ProjectId;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -60,9 +61,12 @@ public class SelectionModel_TestCase {
 
     private OWLClass cls = new OWLClassImpl(IRI.create("urn:entity:cls"));
 
+    private ProjectId projectId = ProjectId.getNil();
+
     @Before
     public void setUp() {
         selectionModel = new SelectionModel(
+                projectId,
                 dispatch, eventBus,
                 placeController,
                 selectedClassManager,


### PR DESCRIPTION
This pull request makes some changes to ensure that project objects, especially those that register listeners, are properly disposed of.  This fixes a problem where if a project, ProjectA, was switch out for another project, ProjectB, in the same browser window calls to update the UI for both ProjectA and ProjectB would be made when any selection change was made.