### PR TITLE
Hierarchy descriptor fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>edu.stanford.protege</groupId>
     <artifactId>webprotege-gwt-ui</artifactId>
-    <version>8.2.0</version>
+    <version>8.2.1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/webprotege-gwt-ui-client/pom.xml
+++ b/webprotege-gwt-ui-client/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>edu.stanford.protege</groupId>
         <artifactId>webprotege-gwt-ui</artifactId>
-        <version>8.2.0</version>
+        <version>8.2.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>webprotege-gwt-ui-client</artifactId>

--- a/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/role/CapabilityContextPresenter.java
+++ b/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/role/CapabilityContextPresenter.java
@@ -18,6 +18,8 @@ public class CapabilityContextPresenter {
 
     private final CapabilityContextView view;
 
+    private Optional<CompositeRootCriteria> initialCriteria = Optional.empty();
+
     @Inject
     public CapabilityContextPresenter(EntityCriteriaPresenter criteriaPresenter, CapabilityContextView view) {
         this.criteriaPresenter = criteriaPresenter;
@@ -29,7 +31,12 @@ public class CapabilityContextPresenter {
         criteriaPresenter.setDisplayAtLeastOneCriteria(true);
         criteriaPresenter.setMatchTextPrefix("matches");
         criteriaPresenter.start(view.getCriteriaContainer());
-        criteriaPresenter.setCriteria(createBlankCriteria());
+        if(initialCriteria.isPresent()) {
+            criteriaPresenter.setCriteria(initialCriteria.get());
+        }
+        else {
+            criteriaPresenter.setCriteria(createBlankCriteria());
+        }
     }
 
     private static CompositeRootCriteria createBlankCriteria() {
@@ -42,6 +49,7 @@ public class CapabilityContextPresenter {
     }
 
     public void setCriteria(CompositeRootCriteria criteria) {
+        this.initialCriteria = Optional.of(criteria);
         if(criteria.equals(CompositeRootCriteria.any())) {
             view.setForAnyEntity(true);
         }
@@ -62,6 +70,7 @@ public class CapabilityContextPresenter {
     }
 
     public void clearCriteria() {
+        initialCriteria = Optional.empty();
         criteriaPresenter.clear();
     }
 }

--- a/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/role/CapabilityPresenterSelector.java
+++ b/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/role/CapabilityPresenterSelector.java
@@ -34,21 +34,21 @@ public class CapabilityPresenterSelector {
         capabilityPresenterFactories.forEach(pf -> {
             view.addTypeId(pf.getTypeId(), pf.getLabel());
         });
+        selectedTypeId = f0.getTypeId();
         view.setSelectedTypeIdChangedHandler(this::handleSelectedTypeIdChanged);
     }
 
     public void start(AcceptsOneWidget container) {
         container.setWidget(view);
+        updateSelectedPresenter();
     }
 
     private void handleSelectedTypeIdChanged(String nextSelectedTypeId) {
-        logger.info("Selected type id changed: " + nextSelectedTypeId);
         this.selectedTypeId = nextSelectedTypeId;
         updateSelectedPresenter();
     }
 
     private void updateSelectedPresenter() {
-        logger.info("Updating selected presenter");
         view.setSelectedTypeId(selectedTypeId);
         view.clearPresenter();
         if(selectedTypeId.isEmpty()) {

--- a/webprotege-gwt-ui-server-core/pom.xml
+++ b/webprotege-gwt-ui-server-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>webprotege-gwt-ui</artifactId>
         <groupId>edu.stanford.protege</groupId>
-        <version>8.2.0</version>
+        <version>8.2.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/webprotege-gwt-ui-server/pom.xml
+++ b/webprotege-gwt-ui-server/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>edu.stanford.protege</groupId>
         <artifactId>webprotege-gwt-ui</artifactId>
-        <version>8.2.0</version>
+        <version>8.2.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>webprotege-gwt-ui-server</artifactId>

--- a/webprotege-gwt-ui-shared-core/pom.xml
+++ b/webprotege-gwt-ui-shared-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>webprotege-gwt-ui</artifactId>
         <groupId>edu.stanford.protege</groupId>
-        <version>8.2.0</version>
+        <version>8.2.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/webprotege-gwt-ui-shared/pom.xml
+++ b/webprotege-gwt-ui-shared/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>edu.stanford.protege</groupId>
         <artifactId>webprotege-gwt-ui</artifactId>
-        <version>8.2.0</version>
+        <version>8.2.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>webprotege-gwt-ui-shared</artifactId>


### PR DESCRIPTION
Fixes the case where context criteria would be set to the default (SubClassOf owl:Thing) if methods on the context criteria presenter were not called in a specific order.