### PR TITLE
Deprecated entities search filter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>edu.stanford.protege</groupId>
     <artifactId>webprotege-gwt-ui</artifactId>
-    <version>8.2.1</version>
+    <version>8.3.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/webprotege-gwt-ui-client/pom.xml
+++ b/webprotege-gwt-ui-client/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>edu.stanford.protege</groupId>
         <artifactId>webprotege-gwt-ui</artifactId>
-        <version>8.2.1</version>
+        <version>8.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>webprotege-gwt-ui-client</artifactId>

--- a/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/search/SearchPresenter.java
+++ b/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/search/SearchPresenter.java
@@ -178,7 +178,8 @@ public class SearchPresenter implements HasInitialFocusable {
                                                                         entityTypes,
                                                                         langTagFilter,
                                                                         searchFilters,
-                                                                        PageRequest.requestPage(pageNumber)),
+                                                                        PageRequest.requestPage(pageNumber),
+                        view.getDeprecatedEntitiesTreatment()),
                                        view,
                                        this::displaySearchResult);
     }

--- a/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/search/SearchView.java
+++ b/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/search/SearchView.java
@@ -5,6 +5,7 @@ import com.google.gwt.user.client.ui.IsWidget;
 import edu.stanford.bmir.protege.web.client.library.dlg.AcceptKeyHandler;
 import edu.stanford.bmir.protege.web.client.library.dlg.HasInitialFocusable;
 import edu.stanford.bmir.protege.web.client.progress.HasBusy;
+import edu.stanford.bmir.protege.web.shared.search.DeprecatedEntitiesTreatment;
 
 import javax.annotation.Nonnull;
 
@@ -34,6 +35,10 @@ public interface SearchView extends HasBusy, IsWidget, HasInitialFocusable {
     void setSearchStringChangedHandler(SearchStringChangedHandler handler);
 
     void setLangTagFilterVisible(boolean visible);
+
+    void setDeprecatedEntitiesTreatment(DeprecatedEntitiesTreatment deprecatedEntitiesTreatment);
+
+    DeprecatedEntitiesTreatment getDeprecatedEntitiesTreatment();
 
     @Nonnull
     AcceptsOneWidget getLangTagFilterContainer();

--- a/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/search/SearchViewImpl.java
+++ b/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/search/SearchViewImpl.java
@@ -8,14 +8,12 @@ import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
 import com.google.gwt.uibinder.client.UiHandler;
 import com.google.gwt.user.client.Element;
-import com.google.gwt.user.client.ui.AcceptsOneWidget;
-import com.google.gwt.user.client.ui.Composite;
-import com.google.gwt.user.client.ui.HTMLPanel;
-import com.google.gwt.user.client.ui.SimplePanel;
+import com.google.gwt.user.client.ui.*;
 import edu.stanford.bmir.protege.web.client.library.dlg.AcceptKeyHandler;
 import edu.stanford.bmir.protege.web.client.library.dlg.HasRequestFocus;
 import edu.stanford.bmir.protege.web.client.library.text.PlaceholderTextBox;
 import edu.stanford.bmir.protege.web.client.progress.BusyViewImpl;
+import edu.stanford.bmir.protege.web.shared.search.DeprecatedEntitiesTreatment;
 
 import javax.annotation.Nonnull;
 import javax.inject.Inject;
@@ -53,6 +51,9 @@ public class SearchViewImpl extends Composite implements SearchView {
     @UiField
     HTMLPanel langTagsFilterPanel;
 
+    @UiField
+    CheckBox includeDeprecatedEntitiesCheckBox;
+
     @Nonnull
     private IncrementSelectionHandler incrementSelectionHandler = () -> {};
 
@@ -75,6 +76,10 @@ public class SearchViewImpl extends Composite implements SearchView {
         element.setPropertyString("autocorrect", "off");
         element.setPropertyString("autocapitalize", "off");
         element.setPropertyString("spellcheck", "off");
+        includeDeprecatedEntitiesCheckBox.addValueChangeHandler(evt -> {
+            previousSearchString = "";
+            performSearchIfChanged();
+        });
     }
 
     @Nonnull
@@ -87,6 +92,16 @@ public class SearchViewImpl extends Composite implements SearchView {
     @Override
     public AcceptsOneWidget getSearchResultsContainer() {
         return searchResultsContainer;
+    }
+
+    @Override
+    public void setDeprecatedEntitiesTreatment(DeprecatedEntitiesTreatment deprecatedEntitiesTreatment) {
+        includeDeprecatedEntitiesCheckBox.setValue(deprecatedEntitiesTreatment.equals(DeprecatedEntitiesTreatment.INCLUDE_DEPRECATED_ENTITIES));
+    }
+
+    @Override
+    public DeprecatedEntitiesTreatment getDeprecatedEntitiesTreatment() {
+        return includeDeprecatedEntitiesCheckBox.getValue() ? DeprecatedEntitiesTreatment.INCLUDE_DEPRECATED_ENTITIES : DeprecatedEntitiesTreatment.EXCLUDE_DEPRECATED_ENTITIES;
     }
 
     @Override

--- a/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/search/SearchViewImpl.ui.xml
+++ b/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/search/SearchViewImpl.ui.xml
@@ -39,6 +39,10 @@
             display: flex;
             flex-direction: row;
         }
+        .deprecatedEntitiesToggle {
+            margin-top: 1em;
+            margin-bottom: 0.5em;
+        }
     </ui:style>
 
     <g:HTMLPanel addStyleNames="{style.main} {wp.style.form}">
@@ -54,6 +58,9 @@
         </g:HTMLPanel>
         <text:PlaceholderTextBox ui:field="searchStringField" placeholder="{msg.search_hint}" addStyleNames="{style.searchField}"/>
         <g:Label text="{msg.search_help}" addStyleNames="{wp.style.formHelpText} {style.helpText}"/>
+        <g:HTMLPanel addStyleNames="{style.deprecatedEntitiesToggle}">
+            <g:CheckBox ui:field="includeDeprecatedEntitiesCheckBox" text="Include deprecated entities"/>
+        </g:HTMLPanel>
         <progress:BusyViewImpl ui:field="busyView" visible="false" addStyleNames="{style.busyView}"/>
         <g:SimplePanel ui:field="searchResultsContainer"/>
     </g:HTMLPanel>

--- a/webprotege-gwt-ui-server-core/pom.xml
+++ b/webprotege-gwt-ui-server-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>webprotege-gwt-ui</artifactId>
         <groupId>edu.stanford.protege</groupId>
-        <version>8.2.1</version>
+        <version>8.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/webprotege-gwt-ui-server-core/src/test/java/edu/stanford/bmir/protege/web/shared/search/PerformEntitySearch_Serialization_TestCase.java
+++ b/webprotege-gwt-ui-server-core/src/test/java/edu/stanford/bmir/protege/web/shared/search/PerformEntitySearch_Serialization_TestCase.java
@@ -28,7 +28,8 @@ public class PerformEntitySearch_Serialization_TestCase {
         var action = PerformEntitySearchAction.create(mockProjectId(),
                                                       "Test", Collections.emptySet(),
                                                       LangTagFilter.get(ImmutableSet.of()), ImmutableList.of(),
-                                                      PageRequest.requestFirstPage());
+                                                      PageRequest.requestFirstPage(),
+                DeprecatedEntitiesTreatment.EXCLUDE_DEPRECATED_ENTITIES);
         JsonSerializationTestUtil.testSerialization(action, Action.class);
     }
 

--- a/webprotege-gwt-ui-server/pom.xml
+++ b/webprotege-gwt-ui-server/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>edu.stanford.protege</groupId>
         <artifactId>webprotege-gwt-ui</artifactId>
-        <version>8.2.1</version>
+        <version>8.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>webprotege-gwt-ui-server</artifactId>

--- a/webprotege-gwt-ui-shared-core/pom.xml
+++ b/webprotege-gwt-ui-shared-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>webprotege-gwt-ui</artifactId>
         <groupId>edu.stanford.protege</groupId>
-        <version>8.2.1</version>
+        <version>8.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/webprotege-gwt-ui-shared/pom.xml
+++ b/webprotege-gwt-ui-shared/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>edu.stanford.protege</groupId>
         <artifactId>webprotege-gwt-ui</artifactId>
-        <version>8.2.1</version>
+        <version>8.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>webprotege-gwt-ui-shared</artifactId>

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/dispatch/RpcWhiteList.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/dispatch/RpcWhiteList.java
@@ -598,6 +598,7 @@ public class RpcWhiteList implements IsSerializable, Action, Result {
     GetProjectHierarchyDescriptorRulesResult _GetProjectHierarchyDescriptorRulesResult;
     SetProjectHierarchyDescriptorRulesAction _SetProjectHierarchyDescriptorRulesAction;
     SetProjectHierarchyDescriptorRulesResult _SetProjectHierarchyDescriptorRulesResult;
+    DeprecatedEntitiesTreatment _DeprecatedEntitiesTreatment;
 
 
     public RpcWhiteList() {

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/search/DeprecatedEntitiesTreatment.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/search/DeprecatedEntitiesTreatment.java
@@ -1,0 +1,8 @@
+package edu.stanford.bmir.protege.web.shared.search;
+
+public enum DeprecatedEntitiesTreatment {
+
+    INCLUDE_DEPRECATED_ENTITIES,
+
+    EXCLUDE_DEPRECATED_ENTITIES;
+}

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/search/PerformEntitySearchAction.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/search/PerformEntitySearchAction.java
@@ -35,13 +35,15 @@ public abstract class PerformEntitySearchAction implements ProjectAction<Perform
                                                    @JsonProperty("entityTypes") @Nonnull Set<EntityType<?>> entityTypes,
                                                    @JsonProperty("langTagFilter") @Nonnull LangTagFilter langTagFilter,
                                                    @JsonProperty("searchFilters") @Nonnull ImmutableList<EntitySearchFilter> searchFilters,
-                                                   @JsonProperty("pageRequest") @Nonnull PageRequest pageRequest) {
+                                                   @JsonProperty("pageRequest") @Nonnull PageRequest pageRequest,
+                                                   @JsonProperty("deprecatedEntitiesTreatment") @Nonnull DeprecatedEntitiesTreatment deprecatedEntitiesTreatment) {
         return new AutoValue_PerformEntitySearchAction(projectId,
                                              entityTypes,
                                                        searchString,
                                                        langTagFilter,
                                              searchFilters,
-                                             pageRequest);
+                                             pageRequest,
+                deprecatedEntitiesTreatment);
     }
 
     @Nonnull
@@ -62,4 +64,7 @@ public abstract class PerformEntitySearchAction implements ProjectAction<Perform
 
     @Nonnull
     public abstract PageRequest getPageRequest();
+
+    @Nonnull
+    public abstract DeprecatedEntitiesTreatment getDeprecatedEntitiesTreatment();
 }


### PR DESCRIPTION
Added a check box to the search dialog that allows search results to be filtered to exclude deprecated entities.  This requires backend-api and then backend-service to be updated too.