### PR TITLE
Fix error handling of HTTP error codes

### DIFF
--- a/webprotege-gwt-ui-server-core/src/main/java/edu/stanford/bmir/protege/web/server/dispatch/impl/DispatchServiceExecutorImpl.java
+++ b/webprotege-gwt-ui-server-core/src/main/java/edu/stanford/bmir/protege/web/server/dispatch/impl/DispatchServiceExecutorImpl.java
@@ -7,6 +7,7 @@ import edu.stanford.bmir.protege.web.server.dispatch.ExecutionContext;
 import edu.stanford.bmir.protege.web.server.jackson.ObjectMapperProvider;
 import edu.stanford.bmir.protege.web.server.rpc.JsonRpcHttpRequestBuilder;
 import edu.stanford.bmir.protege.web.server.rpc.JsonRpcHttpResponseHandler;
+import edu.stanford.bmir.protege.web.server.rpc.JsonRpcRequest;
 import edu.stanford.bmir.protege.web.shared.dispatch.*;
 import edu.stanford.bmir.protege.web.shared.dispatch.actions.GetUserInfoAction;
 import edu.stanford.bmir.protege.web.shared.dispatch.actions.GetUserInfoResult;
@@ -124,6 +125,10 @@ public class DispatchServiceExecutorImpl implements DispatchServiceExecutor {
             else if(httpResponse.statusCode() == 504) {
                 logger.error("Gateway timeout when executing action: {} {}", action.getClass().getSimpleName(), httpResponse.body());
                 throw new ActionExecutionException("Gateway Timeout (504)");
+            }
+            else if(httpResponse.statusCode() >= 400) {
+                logger.error("Error response code returned when executing action.  Check the API gateway service for potential logs.  Details: {} {}", action.getClass().getSimpleName(), httpResponse.body());
+                throw new ActionExecutionException("An error occurred.  This error has been logged by the UI server.");
             }
             return responseHandler.getResultForResponse(action, httpResponse, userId);
         } catch (ConnectException e) {

--- a/webprotege-gwt-ui-server-core/src/main/java/edu/stanford/bmir/protege/web/server/rpc/JsonRpcHttpResponseHandler.java
+++ b/webprotege-gwt-ui-server-core/src/main/java/edu/stanford/bmir/protege/web/server/rpc/JsonRpcHttpResponseHandler.java
@@ -42,6 +42,10 @@ public class JsonRpcHttpResponseHandler {
             if(httpResponse.statusCode() == HttpStatus.SC_UNAUTHORIZED) {
                 throw new PermissionDeniedException(userId);
             }
+            if(httpResponse.statusCode() >= 400) {
+                logger.error("Error response code returned: (" + httpResponse.statusCode() + ") " + httpResponse.body());
+                throw new ActionExecutionException("An error occurred on the server");
+            }
             var responseBody = httpResponse.body();
             var jsonRpcResponse = objectMapper.readValue(responseBody, JsonRpcResponse.class);
             if(jsonRpcResponse.getError().isPresent()) {

--- a/webprotege-gwt-ui-server-core/src/test/java/edu/stanford/bmir/protege/web/server/rpc/JsonRpcErrorTest.java
+++ b/webprotege-gwt-ui-server-core/src/test/java/edu/stanford/bmir/protege/web/server/rpc/JsonRpcErrorTest.java
@@ -1,0 +1,20 @@
+package edu.stanford.bmir.protege.web.server.rpc;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.stanford.bmir.protege.web.server.jackson.ObjectMapperProvider;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class JsonRpcErrorTest {
+
+    @Test
+    public void shouldDeserializeError() throws JsonProcessingException {
+        String json = "{\"timestamp\":\"2025-06-04T00:14:04.871+00:00\",\"status\":500,\"error\":\"Internal Server Error\",\"path\":\"/api/execute\"}";
+        ObjectMapper objectMapper = new ObjectMapperProvider().get();
+        JsonRpcError rpcError = objectMapper.readValue(json, JsonRpcError.class);
+        assertEquals(rpcError.getMessage(), "Internal Server Error");
+        assertEquals(rpcError.getCode(), 500);
+    }
+}


### PR DESCRIPTION
RPC application errors, that are supposed to be handled by the application, are returned with an HTTP success response code.  All other internal errors are returned with an HTTP status code >= 400.  These kinds of errors are not genuine RPC application errors.  Fixes this.