### PR TITLE
Support direct links with authentication flow

### DIFF
--- a/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/WebProtege.java
+++ b/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/WebProtege.java
@@ -3,6 +3,7 @@ package edu.stanford.bmir.protege.web.client;
 
 import com.google.gwt.core.client.EntryPoint;
 import com.google.gwt.core.client.GWT;
+import com.google.gwt.http.client.URL;
 import com.google.gwt.place.shared.PlaceHistoryHandler;
 import com.google.gwt.storage.client.Storage;
 import com.google.gwt.user.client.Window;
@@ -10,6 +11,7 @@ import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.gwt.user.client.ui.RootLayoutPanel;
 import edu.stanford.bmir.protege.web.client.app.ApplicationPresenter;
 import edu.stanford.bmir.protege.web.client.app.ApplicationView;
+import edu.stanford.bmir.protege.web.client.app.FragmentManager;
 import edu.stanford.bmir.protege.web.client.app.WebProtegeInitializer;
 import edu.stanford.bmir.protege.web.client.inject.WebProtegeClientInjector;
 import edu.stanford.bmir.protege.web.client.place.WebProtegeActivityManager;
@@ -28,7 +30,7 @@ public class WebProtege implements EntryPoint {
     private static final Logger logger = Logger.getLogger(WebProtege.class.getName());
 
     public void onModuleLoad() {
-        handlePostLoginHashIfNecessary();
+        FragmentManager.handlePostLoginFragment();
 
         WebProtegeInitializer initializer = WebProtegeClientInjector.get().getWebProtegeInitializer();
         initializer.init(new AsyncCallback<Void>() {
@@ -43,19 +45,6 @@ public class WebProtege implements EntryPoint {
                 handleUIInitialization();
             }
         });
-    }
-
-    private static void handlePostLoginHashIfNecessary() {
-        Storage localStorage = Storage.getLocalStorageIfSupported();
-        if (localStorage != null) {
-            String savedHash = localStorage.getItem("post-login-hash");
-            if (savedHash != null && !savedHash.isEmpty()) {
-                logger.info("Applying post-login hash and redirecting: " + savedHash);
-                localStorage.removeItem("post-login-hash");
-                // Reapply the hash to the URL
-                Window.Location.assign(Window.Location.getPath() + "#" + savedHash.replace("#", ""));
-            }
-        }
     }
 
     private void handleUIInitialization() {

--- a/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/app/FragmentManager.java
+++ b/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/app/FragmentManager.java
@@ -1,0 +1,101 @@
+package edu.stanford.bmir.protege.web.client.app;
+
+import com.google.gwt.http.client.URL;
+import com.google.gwt.storage.client.Storage;
+import com.google.gwt.user.client.Window;
+
+import java.util.logging.Logger;
+
+/**
+ * Utility class for managing URL fragment restoration after user authentication redirects to keycloak.
+ * This is needed because GWT uses URL fragments to store place/location information but fragments
+ * get stripped by the browser.
+ * <p>
+ * This class checks for a URL fragment passed as a query parameter or stored in local storage,
+ * and applies it to the current URL to restore user navigation state on the client-side.
+ */
+public class FragmentManager {
+
+    private static final Logger logger = Logger.getLogger(FragmentManager.class.getName());
+
+    /**
+     * The name of the query parameter and localStorage key used to store the fragment.
+     */
+    public static final String FRAGMENT_KEY_NAME = "fragment";
+
+    /**
+     * Restores the URL fragment after a post-login redirect.
+     * <p>
+     * If a fragment is found in the query parameters (as {@code ?fragment=...}), it is decoded
+     * and used to redirect the user to the appropriate location in WebProtege. If not found, it checks
+     * local storage for a previously saved fragment and uses that instead.
+     */
+    public static void handlePostLoginFragment() {
+        // Check if fragment was passed as a query parameter (e.g., ?fragment=encoded_fragment)
+        String fragmentParam = Window.Location.getParameter(FRAGMENT_KEY_NAME);
+        if (isNonEmpty(fragmentParam)) {
+            String decodedFragment = URL.decodeQueryString(fragmentParam);
+            redirectToFragment(decodedFragment);
+            return;
+        }
+
+        // Fallback: check if a fragment is stored in localStorage
+        Storage localStorage = Storage.getLocalStorageIfSupported();
+        if (localStorage != null) {
+            String savedHash = localStorage.getItem(FRAGMENT_KEY_NAME);
+            if (isNonEmpty(savedHash)) {
+                logger.info("Applying locally stored fragment and redirecting: " + savedHash);
+                localStorage.removeItem(FRAGMENT_KEY_NAME);
+                redirectToFragment(stripLeadingHash(savedHash));
+            }
+        }
+    }
+
+    /**
+     * Returns {@code true} if the string is not {@code null} and contains non-whitespace characters.
+     *
+     * @param s the string to test
+     * @return {@code true} if the string is non-null and not empty after trimming
+     */
+    private static boolean isNonEmpty(String s) {
+        return s != null && !s.trim().isEmpty();
+    }
+
+    /**
+     * Redirects the browser to the current path with the specified fragment appended.
+     *
+     * @param fragment the fragment (anchor) to apply to the URL, without the leading {@code #}
+     */
+    private static void redirectToFragment(String fragment) {
+        String nextLocation = Window.Location.getPath() + "#" + fragment;
+        Window.Location.assign(nextLocation);
+    }
+
+    /**
+     * Removes a leading {@code #} character from a fragment string, if present.
+     *
+     * @param fragment the raw fragment string
+     * @return the fragment without a leading {@code #}, or the original string if none is found
+     */
+    private static String stripLeadingHash(String fragment) {
+        return fragment.startsWith("#") ? fragment.substring(1) : fragment;
+    }
+
+    /**
+     * Stores the current URL fragment (if present) in the browser's local storage.
+     * <p>
+     * This is typically called before redirecting to an external login provider like Keycloak.
+     * Since URL fragments are not preserved across full-page reloads or redirects,
+     * this allows the application to restore the client-side route after login.
+     */
+    public static void storeCurrentWindowLocationFragment() {
+        // Stores the route in local storage for later use by onModuleLoad() to restore
+        // the location.
+        String hash = Window.Location.getHash();
+        Storage localStorage = Storage.getLocalStorageIfSupported();
+        if (localStorage != null && hash != null && !hash.isEmpty()) {
+            localStorage.setItem(FRAGMENT_KEY_NAME, hash);
+        }
+    }
+}
+

--- a/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/dispatch/DispatchServiceCallback.java
+++ b/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/dispatch/DispatchServiceCallback.java
@@ -7,6 +7,7 @@ import com.google.gwt.user.client.rpc.IncompatibleRemoteServiceException;
 import com.google.gwt.user.client.rpc.InvocationException;
 import com.google.gwt.user.client.rpc.StatusCodeException;
 import com.google.web.bindery.event.shared.UmbrellaException;
+import edu.stanford.bmir.protege.web.client.app.FragmentManager;
 import edu.stanford.bmir.protege.web.shared.dispatch.ActionExecutionException;
 import edu.stanford.bmir.protege.web.shared.permissions.PermissionDeniedException;
 
@@ -149,22 +150,12 @@ public class DispatchServiceCallback<T> {
     }
 
     private static void handleExpiredSession() {
-        storeCurrentWindowLocationFragment();
+        FragmentManager.storeCurrentWindowLocationFragment();
         // Go to a protected page.  This will cause the authorization flow to be triggered by the
         // Tomcat keycloak valve
         String protocol = Window.Location.getProtocol();
         String host = Window.Location.getHost();
         Window.Location.assign(protocol + "//" + host);
-    }
-
-    private static void storeCurrentWindowLocationFragment() {
-        // Stores the route in local storage for later use by onModuleLoad() to restore
-        // the location.
-        String hash = Window.Location.getHash();
-        Storage localStorage = Storage.getLocalStorageIfSupported();
-        if (localStorage != null && hash != null && !hash.isEmpty()) {
-            localStorage.setItem("post-login-hash", hash);
-        }
     }
 
     private void _handleUmbrellaException(UmbrellaException e) {

--- a/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/hierarchy/EntityHierarchyContextMenuPresenter.java
+++ b/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/hierarchy/EntityHierarchyContextMenuPresenter.java
@@ -4,6 +4,7 @@ import com.google.auto.factory.AutoFactory;
 import com.google.auto.factory.Provided;
 import com.google.common.collect.ImmutableSet;
 import com.google.gwt.event.dom.client.ContextMenuEvent;
+import com.google.gwt.http.client.URL;
 import com.google.gwt.user.client.Window;
 import edu.stanford.bmir.protege.web.client.Messages;
 import edu.stanford.bmir.protege.web.client.action.UIAction;
@@ -28,6 +29,8 @@ import org.semanticweb.owlapi.model.OWLEntity;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.net.URLDecoder;
+import java.net.URLEncoder;
 import java.util.Optional;
 import java.util.function.Supplier;
 
@@ -243,7 +246,11 @@ public class EntityHierarchyContextMenuPresenter {
 
     private void showUrlForSelection() {
         String location = Window.Location.getHref();
-        inputBox.showOkDialog(messages.directLink(), true, location, input -> {});
+        int fragmentIndex = location.indexOf("#");
+        String fragment = location.substring(fragmentIndex + 1);
+        String encodedFragment = URL.encodeQueryString(fragment);
+        String rewritten = location.substring(0, fragmentIndex) + "?fragment=" + encodedFragment;
+        inputBox.showOkDialog(messages.directLink(), true, rewritten, input -> {});
     }
 
     private void handleRefresh() {


### PR DESCRIPTION
Uses a different URI for direct links to preserve place location in WebProtege when authentication is required.  Also unifies the code for working around authentication when sessions expire with this functionality.  This addresses some comments in: https://github.com/who-icatx/icatx-project/issues/202 and unifies the approach with code that deals with https://github.com/who-icatx/icatx-project/issues/208.