### PR TITLE
Make sure the form control stack is listening to page requests

### DIFF
--- a/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/form/FormControlStackRepeatingPresenter.java
+++ b/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/form/FormControlStackRepeatingPresenter.java
@@ -124,6 +124,7 @@ public class FormControlStackRepeatingPresenter implements FormControlStackPrese
         FormControlContainer container = view.addFormControlContainer();
         container.setWidget(formControl);
         container.setEnabled(enabled);
+        formControl.setRegionPageChangedHandler(regionPageChangedHandler);
         formControls.add(formControl);
         container.setRemoveHandler(() -> {
             formControls.remove(formControl);


### PR DESCRIPTION
This fixes a bug with pagination in repeating form controls.  Note that this is not a fix for the current pagination issue in ICD.