### PR TITLE
Markdown preview

### DIFF
--- a/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/inject/ClientProjectModule.java
+++ b/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/inject/ClientProjectModule.java
@@ -34,6 +34,8 @@ import edu.stanford.bmir.protege.web.client.lang.*;
 import edu.stanford.bmir.protege.web.client.library.tokenfield.*;
 import edu.stanford.bmir.protege.web.client.list.EntityNodeListPopupView;
 import edu.stanford.bmir.protege.web.client.list.EntityNodeListPopupViewImpl;
+import edu.stanford.bmir.protege.web.client.markdown.MarkdownPreview;
+import edu.stanford.bmir.protege.web.client.markdown.MarkdownPreviewImpl;
 import edu.stanford.bmir.protege.web.client.match.*;
 import edu.stanford.bmir.protege.web.client.ontology.annotations.AnnotationsView;
 import edu.stanford.bmir.protege.web.client.ontology.annotations.AnnotationsViewImpl;
@@ -1060,6 +1062,11 @@ public class ClientProjectModule {
 
     @Provides
     PerspectiveChooserView providePerspectiveChooserView(PerspectiveChooserViewImpl impl) {
+        return impl;
+    }
+
+    @Provides
+    MarkdownPreview provideMarkdownPreview(MarkdownPreviewImpl impl) {
         return impl;
     }
 }

--- a/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/markdown/Markdown.java
+++ b/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/markdown/Markdown.java
@@ -1,0 +1,24 @@
+package edu.stanford.bmir.protege.web.client.markdown;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+public class Markdown {
+
+    private static final Set<String> prefixes = new LinkedHashSet<>();
+
+    static {
+        prefixes.add("!markdown");
+        prefixes.add("#!md");
+        prefixes.add("markdown:");
+        prefixes.add("md:");
+    }
+
+    public static boolean isMarkdown(String markdown) {
+        return prefixes.stream().anyMatch(markdown::startsWith);
+    }
+
+    public static String stripMarkdownPrefix(String markdown) {
+        return prefixes.stream().filter(markdown::startsWith).map(prefix -> markdown.substring(prefix.length())).findFirst().orElse(markdown);
+    }
+}

--- a/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/markdown/MarkdownPreview.java
+++ b/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/markdown/MarkdownPreview.java
@@ -1,0 +1,6 @@
+package edu.stanford.bmir.protege.web.client.markdown;
+
+public interface MarkdownPreview {
+
+    void setMarkdown(String markdown);
+}

--- a/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/markdown/MarkdownPreviewImpl.java
+++ b/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/markdown/MarkdownPreviewImpl.java
@@ -1,0 +1,29 @@
+package edu.stanford.bmir.protege.web.client.markdown;
+
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.safehtml.shared.SafeHtmlUtils;
+import com.google.gwt.uibinder.client.UiBinder;
+import com.google.gwt.user.client.ui.Composite;
+import com.google.gwt.user.client.ui.HTMLPanel;
+
+import javax.inject.Inject;
+
+public class MarkdownPreviewImpl extends Composite implements MarkdownPreview {
+
+    interface MarkdownPreviewImplUiBinder extends UiBinder<HTMLPanel, MarkdownPreviewImpl> {
+
+    }
+
+    private static MarkdownPreviewImplUiBinder ourUiBinder = GWT.create(MarkdownPreviewImplUiBinder.class);
+
+    @Inject
+    public MarkdownPreviewImpl() {
+        initWidget(ourUiBinder.createAndBindUi(this));
+    }
+
+    @Override
+    public void setMarkdown(String markdown) {
+        String html = Marked.parse(markdown);
+        getElement().setInnerSafeHtml(SafeHtmlUtils.fromTrustedString(html));
+    }
+}

--- a/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/markdown/MarkdownPreviewImpl.ui.xml
+++ b/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/markdown/MarkdownPreviewImpl.ui.xml
@@ -1,0 +1,17 @@
+<ui:UiBinder xmlns:ui='urn:ui:com.google.gwt.uibinder'
+             xmlns:g='urn:import:com.google.gwt.user.client.ui'>
+    <ui:style>
+        .main {
+            vertical-align: top;
+        }
+        .main :first-child {
+            margin-top: 0;
+        }
+        .main :last-child {
+            margin-bottom: 0;
+        }
+    </ui:style>
+    <g:HTMLPanel addStyleNames="{style.main}">
+
+    </g:HTMLPanel>
+</ui:UiBinder>

--- a/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/markdown/Marked.java
+++ b/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/markdown/Marked.java
@@ -1,0 +1,10 @@
+package edu.stanford.bmir.protege.web.client.markdown;
+
+import jsinterop.annotations.JsMethod;
+import jsinterop.annotations.JsType;
+
+@JsType(isNative = true, namespace = "marked", name = "marked")
+public class Marked {
+    @JsMethod
+    public static native String parse(String markdownText);
+}

--- a/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/primitive/PrimitiveDataEditorViewImpl.java
+++ b/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/primitive/PrimitiveDataEditorViewImpl.java
@@ -60,13 +60,13 @@ public class PrimitiveDataEditorViewImpl extends Composite implements PrimitiveD
     protected LazyPanel errorViewContainer;
 
     @UiField
-    protected PrimitiveDataEditorImageViewImpl imageView;
+    protected PrimitiveDataEditorImageViewImpl imagePreview;
 
     @UiField
-    protected LazyPanel imageViewContainer;
+    protected LazyPanel imagePreviewContainer;
 
     @UiField
-    protected FocusPanel imageViewFocusPanel;
+    protected FocusPanel imagePreviewFocusPanel;
 
 
 
@@ -95,7 +95,7 @@ public class PrimitiveDataEditorViewImpl extends Composite implements PrimitiveD
     protected void onAttach() {
         super.onAttach();
         textBox.addBlurHandler(event -> {
-            imageViewHasFocus = false;
+            imagePreviewHasFocus = false;
             markdownPreviewHasFocus = false;
             updatePreview();
         });
@@ -220,10 +220,14 @@ public class PrimitiveDataEditorViewImpl extends Composite implements PrimitiveD
 
     private void updatePreview() {
         if (isPossibleImageLink()) {
-            displayImageView();
+            showImagePreview();
         }
         else if(isPossibleMarkdown()) {
-            displayMarkdownPreview();
+            showMarkdownPreview();
+        }
+        else {
+            imagePreviewContainer.setVisible(false);
+            markdownPreviewContainer.setVisible(false);
         }
     }
 
@@ -238,20 +242,20 @@ public class PrimitiveDataEditorViewImpl extends Composite implements PrimitiveD
                 ".png") || text.endsWith(".svg") || text.endsWith(".jpeg"));
     }
 
-    private boolean imageViewHasFocus = false;
+    private boolean imagePreviewHasFocus = false;
 
-    private void displayImageView() {
-        imageViewContainer.setVisible(true);
-        imageViewFocusPanel.setVisible(true);
+    private void showImagePreview() {
+        imagePreviewContainer.setVisible(true);
+        imagePreviewFocusPanel.setVisible(true);
         String url = getText().trim();
-        imageView.setImageUrl(url);
+        imagePreview.setImageUrl(url);
 
         textBox.setVisible(false);
 
         if (firstDisplayOfImage) {
             firstDisplayOfImage = false;
-            imageViewFocusPanel.addFocusHandler(event -> {
-                imageViewHasFocus = true;
+            imagePreviewFocusPanel.addFocusHandler(event -> {
+                imagePreviewHasFocus = true;
                 hideImageView();
             });
         }
@@ -259,7 +263,7 @@ public class PrimitiveDataEditorViewImpl extends Composite implements PrimitiveD
 
     private boolean markdownPreviewHasFocus = false;
 
-    private void displayMarkdownPreview() {
+    private void showMarkdownPreview() {
         markdownPreviewContainer.setVisible(true);
         markdownPreviewFocusPanel.setVisible(true);
         String md = getText().trim();
@@ -280,8 +284,8 @@ public class PrimitiveDataEditorViewImpl extends Composite implements PrimitiveD
     }
 
     private void hideImageView() {
-        int height = imageViewFocusPanel.getOffsetHeight();
-        if (imageViewHasFocus) {
+        int height = imagePreviewFocusPanel.getOffsetHeight();
+        if (imagePreviewHasFocus) {
             // Transfer the focus to the text box
             Scheduler.get().scheduleDeferred(() -> textBox.setFocus(true));
         }
@@ -289,7 +293,7 @@ public class PrimitiveDataEditorViewImpl extends Composite implements PrimitiveD
         // expanding text box in order to avoid unnecessary jumping about in the UI
         textBox.setMinHeight(height + "px");
         textBox.setVisible(true);
-        imageViewFocusPanel.setVisible(false);
+        imagePreviewFocusPanel.setVisible(false);
     }
 
     private void hideMarkdownPreview() {

--- a/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/primitive/PrimitiveDataEditorViewImpl.java
+++ b/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/primitive/PrimitiveDataEditorViewImpl.java
@@ -127,11 +127,13 @@ public class PrimitiveDataEditorViewImpl extends Composite implements PrimitiveD
         lastStyleName.ifPresent(s -> textBox.getSuggestBox().removeStyleName(s));
         lastStyleName = styleName;
         styleName.ifPresent(s -> textBox.getSuggestBox().addStyleName(s));
+        styleName.ifPresent(s -> markdownPreviewContainer.addStyleName(s));
     }
 
     @Override
     public void clearPrimitiveDataStyleName() {
         lastStyleName.ifPresent(s -> textBox.getSuggestBox().removeStyleName(s));
+        lastStyleName.ifPresent(s -> markdownPreviewContainer.removeStyleName(s));
         lastStyleName = Optional.empty();
     }
 

--- a/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/primitive/PrimitiveDataEditorViewImpl.java
+++ b/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/primitive/PrimitiveDataEditorViewImpl.java
@@ -92,6 +92,16 @@ public class PrimitiveDataEditorViewImpl extends Composite implements PrimitiveD
     }
 
     @Override
+    protected void onAttach() {
+        super.onAttach();
+        textBox.addBlurHandler(event -> {
+            imageViewHasFocus = false;
+            markdownPreviewHasFocus = false;
+            updatePreview();
+        });
+    }
+
+    @Override
     public void setDeprecated(boolean deprecated) {
         if (deprecated) {
             this.addStyleName(WebProtegeClientBundle.BUNDLE.primitiveData().primitiveData_____deprecated());
@@ -240,10 +250,6 @@ public class PrimitiveDataEditorViewImpl extends Composite implements PrimitiveD
 
         if (firstDisplayOfImage) {
             firstDisplayOfImage = false;
-            textBox.addBlurHandler(event -> {
-                imageViewHasFocus = false;
-                updatePreview();
-            });
             imageViewFocusPanel.addFocusHandler(event -> {
                 imageViewHasFocus = true;
                 hideImageView();
@@ -264,10 +270,6 @@ public class PrimitiveDataEditorViewImpl extends Composite implements PrimitiveD
 
         if (firstDisplayOfMarkdown) {
             firstDisplayOfMarkdown = false;
-            textBox.addBlurHandler(event -> {
-                markdownPreviewHasFocus = false;
-                updatePreview();
-            });
             markdownPreviewFocusPanel.addFocusHandler(event -> {
                 if(isEnabled()) {
                     markdownPreviewHasFocus = true;

--- a/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/primitive/PrimitiveDataEditorViewImpl.ui.xml
+++ b/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/primitive/PrimitiveDataEditorViewImpl.ui.xml
@@ -1,7 +1,8 @@
 <ui:UiBinder xmlns:ui='urn:ui:com.google.gwt.uibinder'
              xmlns:g='urn:import:com.google.gwt.user.client.ui'
              xmlns:text="urn:import:edu.stanford.bmir.protege.web.client.library.text"
-             xmlns:primitive="urn:import:edu.stanford.bmir.protege.web.client.primitive">
+             xmlns:primitive="urn:import:edu.stanford.bmir.protege.web.client.primitive"
+             xmlns:markdown="urn:import:edu.stanford.bmir.protege.web.client.markdown">
 
     <ui:with field="wp" type="edu.stanford.bmir.protege.web.resources.WebProtegeClientBundle"/>
 
@@ -12,15 +13,18 @@
             align-items: start;
             flex-wrap: nowrap;
         }
+
         .textBox {
             margin-right: 1px;
         }
+
         .iconContainer {
             flex-grow: 0;
             flex-shrink: 0;
             width: 22px;
             height: 22px;
         }
+
         .contentContainer {
             display: flex;
             flex-direction: column;
@@ -29,10 +33,17 @@
             flex-shrink: 1;
             min-width: 5px;
         }
+
         .focusPanel {
             vertical-align: top;
         }
+
         .imageViewContainer {
+        }
+
+        .markdownPreview {
+            border: 1px solid transparent;
+            padding: 2px;
         }
     </ui:style>
     <g:HTMLPanel addStyleNames="{style.main} {wp.primitiveData.primitiveData}">
@@ -45,6 +56,11 @@
                          addStyleNames="{style.imageViewContainer}">
                 <g:FocusPanel ui:field="imageViewFocusPanel" addStyleNames="{style.focusPanel}">
                     <primitive:PrimitiveDataEditorImageViewImpl ui:field="imageView"/>
+                </g:FocusPanel>
+            </g:LazyPanel>
+            <g:LazyPanel ui:field="markdownPreviewContainer">
+                <g:FocusPanel ui:field="markdownPreviewFocusPanel" addStyleNames="{style.focusPanel}">
+                    <markdown:MarkdownPreviewImpl ui:field="markdownPreview" addStyleNames="{style.markdownPreview}"/>
                 </g:FocusPanel>
             </g:LazyPanel>
         </g:HTMLPanel>

--- a/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/primitive/PrimitiveDataEditorViewImpl.ui.xml
+++ b/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/primitive/PrimitiveDataEditorViewImpl.ui.xml
@@ -52,17 +52,17 @@
             <g:LazyPanel ui:field="errorViewContainer" debugId="ErrorViewCont">
                 <primitive:PrimitiveDataEditorFreshEntityViewImpl ui:field="errorView" addStyleNames="{wp.primitiveData.primitiveData__errorMessage}"/>
             </g:LazyPanel>
-            <g:LazyPanel ui:field="imagePreviewContainer" debugId="ImageViewCont"
+            <g:HTMLPanel ui:field="imagePreviewContainer" debugId="ImageViewCont"
                          addStyleNames="{style.imageViewContainer}">
                 <g:FocusPanel ui:field="imagePreviewFocusPanel" addStyleNames="{style.focusPanel}">
                     <primitive:PrimitiveDataEditorImageViewImpl ui:field="imagePreview"/>
                 </g:FocusPanel>
-            </g:LazyPanel>
-            <g:LazyPanel ui:field="markdownPreviewContainer">
+            </g:HTMLPanel>
+            <g:HTMLPanel ui:field="markdownPreviewContainer">
                 <g:FocusPanel ui:field="markdownPreviewFocusPanel" addStyleNames="{style.focusPanel}">
                     <markdown:MarkdownPreviewImpl ui:field="markdownPreview" addStyleNames="{style.markdownPreview}"/>
                 </g:FocusPanel>
-            </g:LazyPanel>
+            </g:HTMLPanel>
         </g:HTMLPanel>
     </g:HTMLPanel>
 </ui:UiBinder>

--- a/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/primitive/PrimitiveDataEditorViewImpl.ui.xml
+++ b/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/primitive/PrimitiveDataEditorViewImpl.ui.xml
@@ -52,10 +52,10 @@
             <g:LazyPanel ui:field="errorViewContainer" debugId="ErrorViewCont">
                 <primitive:PrimitiveDataEditorFreshEntityViewImpl ui:field="errorView" addStyleNames="{wp.primitiveData.primitiveData__errorMessage}"/>
             </g:LazyPanel>
-            <g:LazyPanel ui:field="imageViewContainer" debugId="ImageViewCont"
+            <g:LazyPanel ui:field="imagePreviewContainer" debugId="ImageViewCont"
                          addStyleNames="{style.imageViewContainer}">
-                <g:FocusPanel ui:field="imageViewFocusPanel" addStyleNames="{style.focusPanel}">
-                    <primitive:PrimitiveDataEditorImageViewImpl ui:field="imageView"/>
+                <g:FocusPanel ui:field="imagePreviewFocusPanel" addStyleNames="{style.focusPanel}">
+                    <primitive:PrimitiveDataEditorImageViewImpl ui:field="imagePreview"/>
                 </g:FocusPanel>
             </g:LazyPanel>
             <g:LazyPanel ui:field="markdownPreviewContainer">

--- a/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/primitive/PrimitiveDataEditorViewImpl.ui.xml
+++ b/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/primitive/PrimitiveDataEditorViewImpl.ui.xml
@@ -60,7 +60,7 @@
             </g:HTMLPanel>
             <g:HTMLPanel ui:field="markdownPreviewContainer">
                 <g:FocusPanel ui:field="markdownPreviewFocusPanel" addStyleNames="{style.focusPanel}">
-                    <markdown:MarkdownPreviewImpl ui:field="markdownPreview" addStyleNames="{style.markdownPreview}"/>
+                    <markdown:MarkdownPreviewImpl ui:field="markdownPreview" addStyleNames="{style.markdownPreview} {wp.style.markdownPreview}"/>
                 </g:FocusPanel>
             </g:HTMLPanel>
         </g:HTMLPanel>

--- a/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/resources/WebProtege.css
+++ b/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/resources/WebProtege.css
@@ -668,3 +668,6 @@
     mask-repeat: no-repeat;
     background-color: literal("var(--create--color)");
 }
+
+.wp-markdown-preview {
+}

--- a/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/resources/WebProtegeClientBundle.java
+++ b/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/resources/WebProtegeClientBundle.java
@@ -558,6 +558,9 @@ public interface WebProtegeClientBundle extends ClientBundle {
 
         @ClassName("wp-editable-icon")
         String editableIcon();
+
+        @ClassName("wp-markdown-preview")
+        String markdownPreview();
     }
 
     interface DateTimePicker extends CssResource {

--- a/webprotege-gwt-ui-client/src/test/java/edu/stanford/bmir/protege/web/client/markdown/MarkdownTest.java
+++ b/webprotege-gwt-ui-client/src/test/java/edu/stanford/bmir/protege/web/client/markdown/MarkdownTest.java
@@ -1,0 +1,64 @@
+package edu.stanford.bmir.protege.web.client.markdown;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class MarkdownTest {
+
+    @Test
+    public void shouldRecognizeMarkdownPrefix_mdColon() {
+        assertTrue(Markdown.isMarkdown("md:# Header"));
+    }
+
+    @Test
+    public void shouldRecognizeMarkdownPrefix_markdownColon() {
+        assertTrue(Markdown.isMarkdown("markdown:*italic*"));
+    }
+
+    @Test
+    public void shouldRecognizeMarkdownPrefix_bangMarkdown() {
+        assertTrue(Markdown.isMarkdown("!markdown**bold**"));
+    }
+
+    @Test
+    public void shouldRecognizeMarkdownPrefix_shebangMd() {
+        assertTrue(Markdown.isMarkdown("#!mdSome text"));
+    }
+
+    @Test
+    public void shouldNotRecognizeMarkdownWithoutPrefix() {
+        assertFalse(Markdown.isMarkdown("# Just a regular heading"));
+        assertFalse(Markdown.isMarkdown("plain text"));
+    }
+
+    @Test
+    public void shouldStripMdColonPrefix() {
+        String input = "md:# Header";
+        assertEquals("# Header", Markdown.stripMarkdownPrefix(input));
+    }
+
+    @Test
+    public void shouldStripMarkdownColonPrefix() {
+        String input = "markdown:*italic*";
+        assertEquals("*italic*", Markdown.stripMarkdownPrefix(input));
+    }
+
+    @Test
+    public void shouldStripBangMarkdownPrefix() {
+        String input = "!markdown**bold**";
+        assertEquals("**bold**", Markdown.stripMarkdownPrefix(input));
+    }
+
+    @Test
+    public void shouldStripShebangMdPrefix() {
+        String input = "#!mdSome text";
+        assertEquals("Some text", Markdown.stripMarkdownPrefix(input));
+    }
+
+    @Test
+    public void shouldReturnOriginalTextWhenNoPrefix() {
+        String input = "No markdown prefix here";
+        assertEquals("No markdown prefix here", Markdown.stripMarkdownPrefix(input));
+    }
+}

--- a/webprotege-gwt-ui-server/src/main/webapp/WebProtege.jsp
+++ b/webprotege-gwt-ui-server/src/main/webapp/WebProtege.jsp
@@ -37,6 +37,8 @@
     <script src="https://cdn.jsdelivr.net/npm/@stomp/stompjs@5.0.0/bundles/stomp.umd.min.js"></script>
     <script type="text/javascript" language="javascript" src="webprotege/webprotege.nocache.js"></script>
 
+    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+
     ${application.analytics}
 </head>
 

--- a/webprotege-gwt-ui-server/src/main/webapp/css/WebProtege.css
+++ b/webprotege-gwt-ui-server/src/main/webapp/css/WebProtege.css
@@ -1139,3 +1139,55 @@ div.CodeMirror-linenumber.CodeMirror-gutter-elt {
     margin-right:        0;
 }
 
+.wp-markdown-preview {
+}
+.wp-markdown-preview table {
+    width: 100%;
+    border-collapse: collapse;
+    margin: 1.5em 0;
+    font-size: 1rem;
+    background-color: #fff;
+}
+
+/* Table header */
+.wp-markdown-preview thead {
+    background-color: #d7d7d7;
+}
+
+.wp-markdown-preview thead th {
+    text-align: left;
+    padding: 4px 8px;
+    font-weight: 600;
+    color: #333;
+    border-bottom: 1px solid #ddd;
+}
+
+/* Table body */
+.wp-markdown-preview tbody tr {
+}
+
+.wp-markdown-preview tbody tr:hover {
+}
+
+.wp-markdown-preview tbody td {
+    padding: 6px 8px;
+    border-bottom: 1px solid #eee;
+    color: #555;
+}
+
+/* Zebra striping */
+.wp-markdown-preview tbody tr:nth-child(even) {
+    background-color: #fafafa;
+}
+
+/* Responsive container */
+.wp-markdown-preview .table-container {
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    margin: 0 -1rem;
+    padding: 0 1rem;
+}
+
+.wp-markdown-preview em {
+    font-style: italic;
+}


### PR DESCRIPTION
Allows markdown to be previewed in various places.  The markdown previewer is activated when literals are prefixed with `!markdown` or `md:` or `markdown:` or `#!md`