### PR TITLE
Support EntityStatus on the client side

### DIFF
--- a/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/entity/EntityNodeUpdater.java
+++ b/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/entity/EntityNodeUpdater.java
@@ -1,5 +1,6 @@
 package edu.stanford.bmir.protege.web.client.entity;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.gwt.core.client.GWT;
 import edu.stanford.bmir.protege.web.shared.entity.EntityNode;
 import edu.stanford.bmir.protege.web.shared.entity.EntityNodeIndex;
@@ -76,7 +77,8 @@ public class EntityNodeUpdater {
                     node.isDeprecated(),
                     node.getWatches(),
                     node.getOpenCommentCount(),
-                    node.getTags());
+                    node.getTags(),
+                    node.getStatuses());
             nodeIndex.updateNode(updatedNode);
         });
     }
@@ -114,7 +116,8 @@ public class EntityNodeUpdater {
                 node.isDeprecated(),
                 updatedWatches,
                 node.getOpenCommentCount(),
-                node.getTags());
+                node.getTags(),
+                node.getStatuses());
         nodeIndex.updateNode(updatedNode);
     }
 
@@ -131,7 +134,8 @@ public class EntityNodeUpdater {
                         node.isDeprecated(),
                         node.getWatches(),
                         event.getOpenCommentCountForEntity(),
-                        node.getTags());
+                        node.getTags(),
+                        node.getStatuses());
                 nodeIndex.updateNode(updatedNode);
             });
         });
@@ -150,7 +154,8 @@ public class EntityNodeUpdater {
                         node.isDeprecated(),
                         node.getWatches(),
                         event.getOpenCommentsCountForEntity(),
-                        node.getTags());
+                        node.getTags(),
+                        node.getStatuses());
                 nodeIndex.updateNode(updatedNode);
             });
         });
@@ -168,7 +173,8 @@ public class EntityNodeUpdater {
                     event.isDeprecated(),
                     node.getWatches(),
                     node.getOpenCommentCount(),
-                    node.getTags());
+                    node.getTags(),
+                    node.getStatuses());
             nodeIndex.updateNode(updatedNode);
         });
     }
@@ -185,7 +191,8 @@ public class EntityNodeUpdater {
                     node.isDeprecated(),
                     node.getWatches(),
                     node.getOpenCommentCount(),
-                    event.getTags());
+                    event.getTags(),
+                    node.getStatuses());
             nodeIndex.updateNode(updatedNode);
         });
     }

--- a/webprotege-gwt-ui-server-core/src/test/java/edu/stanford/bmir/protege/web/shared/entity/EntityNode_Serialization_TestCase.java
+++ b/webprotege-gwt-ui-server-core/src/test/java/edu/stanford/bmir/protege/web/shared/entity/EntityNode_Serialization_TestCase.java
@@ -13,6 +13,7 @@ import edu.stanford.bmir.protege.web.shared.watches.WatchType;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.Collections;
 
 import static edu.stanford.bmir.protege.web.MockingUtils.*;
 
@@ -36,7 +37,7 @@ public class EntityNode_Serialization_TestCase {
                                                "The Tag Label",
                                                "The tag description",
                                                Color.getWhite(),
-                                               Color.getWhite(), ImmutableList.of())));
+                                               Color.getWhite(), ImmutableList.of())), ImmutableSet.of());
         JsonSerializationTestUtil.testSerialization(entityNode, EntityNode.class);
     }
 }

--- a/webprotege-gwt-ui-server-core/src/test/java/edu/stanford/bmir/protege/web/shared/event/EventsSerializationTestCase.java
+++ b/webprotege-gwt-ui-server-core/src/test/java/edu/stanford/bmir/protege/web/shared/event/EventsSerializationTestCase.java
@@ -158,11 +158,10 @@ public class EventsSerializationTestCase {
     public void shouldSerializeEntityHierarchyChangedEvent() throws IOException {
         var changes = ImmutableList.of(
                 new AddEdge<>(new GraphEdge<>(new GraphNode<>(EntityNode.get(
-                        mockOWLClass(), "A", ImmutableList.of(), true, ImmutableSet.of(), 3, ImmutableSet.of()
-                )
+                        mockOWLClass(), "A", ImmutableList.of(), true, ImmutableSet.of(), 3, ImmutableSet.of(), Collections.emptySet())
                 ),
                                               new GraphNode<>(EntityNode.get(
-                                                      mockOWLClass(), "B", ImmutableList.of(), true, ImmutableSet.of(), 3, ImmutableSet.of()
+                                                      mockOWLClass(), "B", ImmutableList.of(), true, ImmutableSet.of(), 3, ImmutableSet.of(), Collections.emptySet()
                                               )))
         ));
         JsonSerializationTestUtil.testSerialization(

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/dispatch/RpcWhiteList.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/dispatch/RpcWhiteList.java
@@ -596,6 +596,7 @@ public class RpcWhiteList implements IsSerializable, Action, Result {
     SetProjectHierarchyDescriptorRulesAction _SetProjectHierarchyDescriptorRulesAction;
     SetProjectHierarchyDescriptorRulesResult _SetProjectHierarchyDescriptorRulesResult;
     DeprecatedEntitiesTreatment _DeprecatedEntitiesTreatment;
+    EntityStatus _EntityStatus;
 
     ApplicationSettings _ApplicationSettings;
     public RpcWhiteList() {

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/entity/EntityNode.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/entity/EntityNode.java
@@ -48,14 +48,15 @@ public abstract class EntityNode implements IsSerializable, Serializable, Compar
                                  boolean deprecated,
                                  @Nonnull Set<Watch> watches,
                                  int openCommentCount,
-                                 Collection<Tag> tags) {
+                                 Collection<Tag> tags,
+                                 ImmutableSet<EntityStatus> statuses) {
         return new AutoValue_EntityNode(entity,
                                         browserText,
                                         ImmutableSet.copyOf(tags),
                                         deprecated,
                                         ImmutableSet.copyOf(watches),
                                         openCommentCount,
-                                        shortForms);
+                                        shortForms, statuses);
     }
 
     @JsonCreator
@@ -66,7 +67,8 @@ public abstract class EntityNode implements IsSerializable, Serializable, Compar
                                  @JsonProperty("deprecated") boolean deprecated,
                                  @JsonProperty("watches") @Nonnull Set<Watch> watches,
                                  @JsonProperty("openCommentCount") int openCommentCount,
-                                 @JsonProperty("tags") Collection<Tag> tags) {
+                                 @JsonProperty("tags") Collection<Tag> tags,
+                                 @JsonProperty("statuses") Set<EntityStatus> statuses) {
         ImmutableMap<DictionaryLanguage, String> map = shortForms.stream()
                                                         .collect(toImmutableMap(ShortForm::getDictionaryLanguage,
                                                                                 ShortForm::getShortForm));
@@ -77,7 +79,8 @@ public abstract class EntityNode implements IsSerializable, Serializable, Compar
                    deprecated,
                    ImmutableSet.copyOf(watches),
                    openCommentCount,
-                   ImmutableSet.copyOf(tags));
+                   ImmutableSet.copyOf(tags),
+                ImmutableSet.copyOf(statuses));
     }
 
     /**
@@ -96,7 +99,8 @@ public abstract class EntityNode implements IsSerializable, Serializable, Compar
                    NOT_DEPRECATED,
                    NO_WATCHES,
                    NO_OPEN_COMMENTS,
-                   NO_ENTITY_TAGS);
+                   NO_ENTITY_TAGS,
+                   Collections.emptySet());
     }
 
     @Nonnull
@@ -147,6 +151,9 @@ public abstract class EntityNode implements IsSerializable, Serializable, Compar
                        .map(entry -> ShortForm.get(entry.getKey(), entry.getValue()))
                        .collect(ImmutableList.toImmutableList());
     }
+
+    @JsonProperty("statuses")
+    public abstract ImmutableSet<EntityStatus> getStatuses();
 
     @Override
     public int compareTo(EntityNode o) {

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/entity/EntityStatus.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/entity/EntityStatus.java
@@ -1,0 +1,31 @@
+package edu.stanford.bmir.protege.web.shared.entity;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+import com.google.common.annotations.GwtCompatible;
+
+import javax.annotation.Nonnull;
+import java.io.Serializable;
+
+@AutoValue
+@GwtCompatible(serializable = true)
+public abstract class EntityStatus implements Serializable, Comparable<EntityStatus> {
+
+    public static final String STATUS = "status";
+
+    @JsonCreator
+    public static EntityStatus get(@Nonnull @JsonProperty(STATUS) String status) {
+        return new AutoValue_EntityStatus(status);
+    }
+
+
+    @JsonProperty(STATUS)
+    @Nonnull
+    public abstract String getStatus();
+
+    @Override
+    public int compareTo(EntityStatus o) {
+        return this.getStatus().compareToIgnoreCase(o.getStatus());
+    }
+}


### PR DESCRIPTION
This might have been added to icatx only but it is needed in the core system because the backend-service has the entity status field in EntityNode.  Fixes https://github.com/who-icatx/icatx-project/issues/266