### PR TITLE
End-to-end Playwright test suite + WebProtege fixes uncovered while writing it

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,0 +1,82 @@
+name: e2e
+
+on:
+  pull_request:
+    paths:
+      - 'webprotege-gwt-ui-client/**'
+      - 'webprotege-gwt-ui-shared/**'
+      - 'webprotege-gwt-ui-shared-core/**'
+      - 'webprotege-gwt-ui-server/**'
+      - 'webprotege-gwt-ui-server-core/**'
+      - 'playwright/**'
+      - '.github/workflows/e2e.yaml'
+  workflow_dispatch:
+
+concurrency:
+  group: e2e-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  playwright:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: 'maven'
+
+      # Build the UI WAR. The compose stack pulls every other service from
+      # Docker Hub, so this is the only Maven build needed.
+      - name: Build UI WAR
+        run: mvn -B -DskipTests -pl webprotege-gwt-ui-server -am package
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: 'playwright/package-lock.json'
+
+      - name: Install Playwright deps
+        working-directory: playwright
+        run: |
+          npm ci || npm install
+          npx playwright install --with-deps chromium
+
+      - name: Bring up the test stack
+        working-directory: playwright
+        env:
+          SERVER_HOST: localhost
+        run: docker compose -f docker-compose.test.yml up -d --wait
+
+      - name: Run Playwright suite
+        working-directory: playwright
+        env:
+          CI: 'true'
+          WEBPROTEGE_BASE_URL: http://localhost
+        run: npx playwright test
+
+      - name: Tear down stack
+        if: always()
+        working-directory: playwright
+        run: docker compose -f docker-compose.test.yml down -v
+
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright/playwright-report/
+          retention-days: 14
+
+      - name: Upload Playwright traces
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-traces
+          path: playwright/test-results/
+          retention-days: 14

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -51,7 +51,7 @@ jobs:
         working-directory: playwright
         env:
           SERVER_HOST: localhost
-        run: docker compose -f docker-compose.test.yml up -d --wait
+        run: docker compose up -d --wait
 
       - name: Run Playwright suite
         working-directory: playwright
@@ -63,7 +63,7 @@ jobs:
       - name: Tear down stack
         if: always()
         working-directory: playwright
-        run: docker compose -f docker-compose.test.yml down -v
+        run: docker compose down -v
 
       - name: Upload Playwright report
         if: failure()

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -2,6 +2,7 @@ name: e2e
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
     paths:
       - 'webprotege-gwt-ui-client/**'
       - 'webprotege-gwt-ui-shared/**'
@@ -18,6 +19,11 @@ concurrency:
 
 jobs:
   playwright:
+    # Skip e2e on PRs labeled `skip-e2e` (e.g. when waiting for an upstream
+    # service to be published to Docker Hub before the test stack can run).
+    if: >
+      github.event_name != 'pull_request' ||
+      !contains(github.event.pull_request.labels.*.name, 'skip-e2e')
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
@@ -51,7 +57,7 @@ jobs:
         working-directory: playwright
         env:
           SERVER_HOST: localhost
-        run: docker compose up -d --wait
+        run: docker compose up -d --wait --build
 
       - name: Run Playwright suite
         working-directory: playwright

--- a/playwright/.env.example
+++ b/playwright/.env.example
@@ -1,8 +1,22 @@
-# Copy to .env (already gitignored) to override defaults.
+# Copy to .env (gitignored) before running `npm run stack:up`. The compose
+# stack reads this file automatically.
 
 # Hostname Keycloak/NGINX/services use to construct redirect URLs.
-# 'localhost' works for local Playwright runs without /etc/hosts edits.
-SERVER_HOST=localhost
+#
+# IMPORTANT: this MUST match the redirectUris registered for the
+# `webprotege` client in the realm import
+# (webprotege-keycloak/webprotege.json), which is currently:
+#
+#     http://webprotege-local.edu/*
+#
+# So set SERVER_HOST=webprotege-local.edu and add a matching entry to
+# /etc/hosts:
+#
+#     127.0.0.1   webprotege-local.edu
+#
+# Setting SERVER_HOST=localhost will appear to work but Keycloak will
+# reject the OAuth redirect with "Invalid parameter: redirect_uri".
+SERVER_HOST=webprotege-local.edu
 
 # Host port the NGINX edge listens on. Default 80 needs sudo on macOS;
 # bump to 8080 if you want a non-privileged port and adjust

--- a/playwright/.env.example
+++ b/playwright/.env.example
@@ -1,0 +1,14 @@
+# Copy to .env (already gitignored) to override defaults.
+
+# Hostname Keycloak/NGINX/services use to construct redirect URLs.
+# 'localhost' works for local Playwright runs without /etc/hosts edits.
+SERVER_HOST=localhost
+
+# Host port the NGINX edge listens on. Default 80 needs sudo on macOS;
+# bump to 8080 if you want a non-privileged port and adjust
+# WEBPROTEGE_BASE_URL in the Playwright env accordingly.
+WEBPROTEGE_HOST_PORT=80
+
+# Optional Keycloak admin-cli secret used by the user-management service.
+# Empty is fine for the test stack.
+ADMIN_CLI_SECRET=

--- a/playwright/.gitignore
+++ b/playwright/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+.auth/
+playwright-report/
+test-results/
+blob-report/
+playwright/.cache/

--- a/playwright/.gitignore
+++ b/playwright/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 .auth/
+.env
 playwright-report/
 test-results/
 blob-report/

--- a/playwright/README.md
+++ b/playwright/README.md
@@ -1,0 +1,52 @@
+# Playwright E2E tests for webprotege-gwt-ui
+
+End-to-end tests for the WebProtege GWT UI. Tracked under
+[issue #267](https://github.com/protegeproject/webprotege-gwt-ui/issues/267).
+
+## Quick start
+
+```bash
+# 1. Bring up Keycloak + MongoDB + webprotege backend + UI
+npm run stack:up
+
+# 2. Install browsers (one-time)
+npm install
+npx playwright install --with-deps chromium
+
+# 3. Run the suite
+npm test                  # headless
+npm run test:headed       # watch it click
+npm run test:smoke        # ~30s sanity scenario
+
+# 4. Tear down when done
+npm run stack:down
+```
+
+The compose stack pre-imports a Keycloak realm with one fixed test user:
+
+| field | value |
+|---|---|
+| email | `e2e@test.local` |
+| password | `testtest123` |
+
+`globalSetup.ts` logs in once and reuses the resulting storage state across
+specs.
+
+## Layout
+
+```
+playwright/
+├── docker-compose.test.yml   # full test stack
+├── fixtures/                 # realm export, sample .owl files
+├── support/                  # selectors, api helpers, per-test fixtures
+├── tests/                    # atomic spec files (01-auth, 02-projects, ...)
+└── tests/scenarios/          # multi-step scenarios (airplane, smoke)
+```
+
+## CI
+
+The suite runs headless on every PR that touches `webprotege-gwt-ui-client`,
+`webprotege-gwt-ui-shared`, or `playwright/**`. See
+`.github/workflows/e2e.yaml`. On failure the workflow uploads
+`playwright-report/` as an artifact — download and run
+`npx playwright show-trace <trace.zip>` to replay the failure.

--- a/playwright/README.md
+++ b/playwright/README.md
@@ -53,7 +53,7 @@ specs.
 
 ```
 playwright/
-├── docker-compose.test.yml   # full test stack (mirrors webprotege-deploy minus ELK)
+├── docker-compose.yml        # full test stack (mirrors webprotege-deploy minus ELK)
 ├── .env.example              # SERVER_HOST, WEBPROTEGE_HOST_PORT, ADMIN_CLI_SECRET
 ├── fixtures/                 # sample .owl files for upload tests
 ├── support/                  # selectors, api helpers, per-test fixtures

--- a/playwright/README.md
+++ b/playwright/README.md
@@ -6,12 +6,17 @@ End-to-end tests for the WebProtege GWT UI. Tracked under
 ## Quick start
 
 ```bash
-# 1. Bring up Keycloak + MongoDB + webprotege backend + UI
-npm run stack:up
-
-# 2. Install browsers (one-time)
+# 1. Install dependencies and browsers (one-time)
+cd playwright
 npm install
 npx playwright install --with-deps chromium
+
+# 2. Bring up the full webprotege stack
+#    (Keycloak + MongoDB + RabbitMQ + MinIO + backend services + NGINX)
+#    Default exposes the UI at http://localhost/ (NGINX on port 80).
+#    On macOS port 80 needs sudo; copy .env.example to .env and set
+#    WEBPROTEGE_HOST_PORT=8080 to use a non-privileged port instead.
+npm run stack:up
 
 # 3. Run the suite
 npm test                  # headless
@@ -22,7 +27,9 @@ npm run test:smoke        # ~30s sanity scenario
 npm run stack:down
 ```
 
-The compose stack pre-imports a Keycloak realm with one fixed test user:
+The compose stack uses the upstream `protegeproject/webprotege-keycloak` image,
+which imports the `webprotege` realm on first boot. `globalSetup.ts` then
+ensures one fixed test user exists in that realm (idempotent — safe to re-run):
 
 | field | value |
 |---|---|
@@ -36,12 +43,21 @@ specs.
 
 ```
 playwright/
-├── docker-compose.test.yml   # full test stack
-├── fixtures/                 # realm export, sample .owl files
+├── docker-compose.test.yml   # full test stack (mirrors webprotege-deploy minus ELK)
+├── .env.example              # SERVER_HOST, WEBPROTEGE_HOST_PORT, ADMIN_CLI_SECRET
+├── fixtures/                 # sample .owl files for upload tests
 ├── support/                  # selectors, api helpers, per-test fixtures
 ├── tests/                    # atomic spec files (01-auth, 02-projects, ...)
 └── tests/scenarios/          # multi-step scenarios (airplane, smoke)
 ```
+
+## Configuration
+
+| Env var | Default | What it does |
+|---|---|---|
+| `WEBPROTEGE_BASE_URL` | `http://localhost` | URL Playwright drives the browser at |
+| `WEBPROTEGE_HOST_PORT` | `80` | Host port the NGINX edge container exposes |
+| `SERVER_HOST` | `localhost` | Hostname Keycloak/services use for redirects |
 
 ## CI
 

--- a/playwright/README.md
+++ b/playwright/README.md
@@ -11,19 +11,29 @@ cd playwright
 npm install
 npx playwright install --with-deps chromium
 
-# 2. Bring up the full webprotege stack
+# 2. Configure the stack hostname (one-time)
+#    cp .env.example .env
+#    The realm import only registers `http://webprotege-local.edu/*` as a
+#    valid redirect URI for the `webprotege` Keycloak client, so the stack
+#    must be addressable under that host. Add a matching /etc/hosts entry:
+#       127.0.0.1   webprotege-local.edu
+#    Without this, Keycloak rejects the OAuth redirect with
+#    "Invalid parameter: redirect_uri" and the login page never renders.
+
+# 3. Bring up the full webprotege stack
 #    (Keycloak + MongoDB + RabbitMQ + MinIO + backend services + NGINX)
-#    Default exposes the UI at http://localhost/ (NGINX on port 80).
-#    On macOS port 80 needs sudo; copy .env.example to .env and set
-#    WEBPROTEGE_HOST_PORT=8080 to use a non-privileged port instead.
+#    Exposes the UI at http://webprotege-local.edu/ (NGINX on port 80).
+#    On macOS port 80 needs sudo; set WEBPROTEGE_HOST_PORT=8080 in .env to
+#    use a non-privileged port instead, and adjust WEBPROTEGE_BASE_URL
+#    accordingly when invoking Playwright.
 npm run stack:up
 
-# 3. Run the suite
-npm test                  # headless
-npm run test:headed       # watch it click
-npm run test:smoke        # ~30s sanity scenario
+# 4. Run the suite (point Playwright at the same host as the stack)
+WEBPROTEGE_BASE_URL=http://webprotege-local.edu npm test            # headless
+WEBPROTEGE_BASE_URL=http://webprotege-local.edu npm run test:headed # watch it click
+WEBPROTEGE_BASE_URL=http://webprotege-local.edu npm run test:smoke  # ~30s sanity scenario
 
-# 4. Tear down when done
+# 5. Tear down when done
 npm run stack:down
 ```
 
@@ -55,9 +65,9 @@ playwright/
 
 | Env var | Default | What it does |
 |---|---|---|
-| `WEBPROTEGE_BASE_URL` | `http://localhost` | URL Playwright drives the browser at |
+| `WEBPROTEGE_BASE_URL` | `http://localhost` | URL Playwright drives the browser at — set to `http://webprotege-local.edu` so it matches `SERVER_HOST` |
 | `WEBPROTEGE_HOST_PORT` | `80` | Host port the NGINX edge container exposes |
-| `SERVER_HOST` | `localhost` | Hostname Keycloak/services use for redirects |
+| `SERVER_HOST` | `localhost` | Hostname Keycloak/services use for redirects — must be `webprotege-local.edu` to match the realm's registered redirect URIs |
 
 ## CI
 

--- a/playwright/docker-compose.test.yml
+++ b/playwright/docker-compose.test.yml
@@ -1,0 +1,247 @@
+# Test stack for the Playwright E2E suite.
+#
+# Mirrors the upstream protegeproject/webprotege-deploy compose file, minus
+# the ELK observability stack and mailpit which the tests do not exercise.
+# Kept in sync version-for-version with that compose file so the tests run
+# against the same artefacts that production deploys.
+#
+# Bring it up with:
+#
+#   npm run stack:up        (== docker compose -f docker-compose.test.yml up -d --wait)
+#
+# After the stack is healthy, NGINX serves the UI at http://localhost/ and
+# Keycloak at http://localhost/keycloak/. The Playwright base URL defaults
+# to http://localhost in this configuration; override with WEBPROTEGE_BASE_URL.
+#
+# The Keycloak superuser is admin/password. globalSetup.ts uses these
+# credentials to ensure a test user 'e2e@test.local' / 'testtest123' exists
+# in the 'webprotege' realm before the suite runs.
+
+x-server-host: &server-host
+  SERVER_HOST: ${SERVER_HOST:-localhost}
+
+services:
+
+  mongo:
+    image: mongo:8.0.10
+    networks: [wp]
+
+  rabbitmq:
+    image: rabbitmq:4.1.1-management
+    healthcheck:
+      test: ["CMD", "rabbitmqctl", "status"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+    networks: [wp]
+
+  minio:
+    image: minio/minio:RELEASE.2024-05-10T01-41-38Z
+    command: ["server", "/data", "--console-address", ":9001"]
+    environment:
+      MINIO_ROOT_USER: webprotege
+      MINIO_ROOT_PASSWORD: webprotege
+    networks: [wp]
+
+  webprotege-keycloak:
+    image: protegeproject/webprotege-keycloak:2.0.1
+    depends_on:
+      rabbitmq:
+        condition: service_healthy
+    environment:
+      <<: *server-host
+      KC_PROXY_HEADERS: xforwarded
+      KC_HOSTNAME: ${SERVER_HOST:-localhost}
+      KC_HOSTNAME_STRICT: "false"
+      KC_HTTP_RELATIVE_PATH: /keycloak
+      KC_HTTP_ENABLED: "true"
+      KEYCLOAK_ADMIN: admin
+      KEYCLOAK_ADMIN_PASSWORD: password
+      KC_LOG_LEVEL: INFO
+      KC_FEATURES: hostname
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - '/opt/keycloak/bin/kcadm.sh get realms/webprotege --fields "attributes(frontendUrl)" --server "http://localhost:8080$${KC_HTTP_RELATIVE_PATH:-}" --realm master --user "$$KEYCLOAK_ADMIN" --password "$$KEYCLOAK_ADMIN_PASSWORD" | grep -q ''"frontendUrl" : "http://${SERVER_HOST:-localhost}/keycloak"'''
+      interval: 5s
+      timeout: 5s
+      retries: 60
+    networks: [wp]
+
+  webprotege-gwt-api-gateway:
+    image: protegeproject/webprotege-gwt-api-gateway:3.0.2
+    depends_on:
+      webprotege-keycloak:
+        condition: service_healthy
+      minio:
+        condition: service_started
+      rabbitmq:
+        condition: service_healthy
+    environment:
+      <<: *server-host
+      JDK_JAVA_OPTIONS: --add-opens java.base/sun.net=ALL-UNNAMED
+      SPRING_RABBITMQ_PUBLISHER_CONFIRM_TYPE: NONE
+      SPRING_RABBITMQ_PUBLISHER_RETURNS: "FALSE"
+      webprotege.minio.bucketName: "webprotege-uploads"
+      webprotege.minio.accessKey: webprotege
+      webprotege.minio.secretKey: webprotege
+      webprotege.minio.endPoint: http://minio:9000
+      SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_KEYCLOAK_ISSUER_URI: http://${SERVER_HOST:-localhost}/keycloak/realms/webprotege
+      SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_KEYCLOAK_AUTHORIZATION_URI: http://${SERVER_HOST:-localhost}/keycloak/realms/webprotege/protocol/openid-connect/auth
+      SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_KEYCLOAK_TOKEN_URI: http://webprotege-keycloak:8080/keycloak/realms/webprotege/protocol/openid-connect/token
+      SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_KEYCLOAK_JWK_SET_URI: http://webprotege-keycloak:8080/keycloak/realms/webprotege/protocol/openid-connect/certs
+      SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_KEYCLOAK_USER_INFO_URI: http://webprotege-keycloak:8080/keycloak/realms/webprotege/protocol/openid-connect/userinfo
+      SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_ISSUER_URI: http://${SERVER_HOST:-localhost}/keycloak/realms/webprotege
+      SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWK_SET_URI: http://webprotege-keycloak:8080/keycloak/realms/webprotege/protocol/openid-connect/certs
+      spring.servlet.multipart.max-file-size: 300MB
+      spring.servlet.multipart.max-request-size: 300MB
+      WEBPROTEGE_ALLOWEDORIGIN: http://${SERVER_HOST:-localhost}
+      webprotege.rabbit.timeout: 600000
+    networks: [wp]
+    extra_hosts:
+      - "${SERVER_HOST:-localhost}:host-gateway"
+
+  webprotege-gwt-ui-server:
+    image: protegeproject/webprotege-gwt-ui-server:9.0.8
+    depends_on:
+      webprotege-gwt-api-gateway:
+        condition: service_started
+      webprotege-keycloak:
+        condition: service_healthy
+    environment:
+      <<: *server-host
+      minio.access.key: webprotege
+      minio.access.secret: webprotege
+      minio.endPoint: http://minio:9000
+      KEYCLOAK_AUTH_URL: http://${SERVER_HOST:-localhost}/keycloak/
+      webprotege.gwt-api-gateway.endPoint: http://webprotege-gwt-api-gateway:7777
+      webprotege.websocketUrl: ws://${SERVER_HOST:-localhost}/wsapps
+      webprotege.logoutUrl: http://${SERVER_HOST:-localhost}/webprotege/logout
+      webprotege.fileUploadurl: http://${SERVER_HOST:-localhost}
+      webprotege.keycloakLogoutUrl: http://${SERVER_HOST:-localhost}/keycloak/realms/webprotege/protocol/openid-connect/logout
+      webprotege.rabbit.timeout: 300000
+      JDK_JAVA_OPTIONS: --add-opens java.base/sun.net=ALL-UNNAMED
+    networks: [wp]
+
+  webprotege-authorization-service:
+    image: protegeproject/webprotege-authorization-service:3.0.9
+    depends_on:
+      webprotege-keycloak:
+        condition: service_healthy
+      mongo:
+        condition: service_started
+      rabbitmq:
+        condition: service_healthy
+    environment:
+      spring.data.mongodb.host: mongo
+      spring.data.mongodb.database: webprotege
+      keycloak.jwk-set-uri: http://webprotege-keycloak:8080
+      SPRING_DATA_MONGODB_URI: mongodb://mongo:27017/webprotege
+      JDK_JAVA_OPTIONS: --add-opens java.base/sun.net=ALL-UNNAMED
+    networks: [wp]
+
+  webprotege-user-management-service:
+    image: protegeproject/webprotege-user-management-service:1.0.10
+    depends_on:
+      webprotege-keycloak:
+        condition: service_healthy
+      mongo:
+        condition: service_started
+      rabbitmq:
+        condition: service_healthy
+    environment:
+      <<: *server-host
+      JDK_JAVA_OPTIONS: --add-opens java.base/sun.net=ALL-UNNAMED
+      SPRING_DATA_MONGODB_URI: mongodb://mongo:27017/webprotege
+      webprotege.keycloak.serverUrl: http://${SERVER_HOST:-localhost}/keycloak
+      webprotege.keycloak.clientSecret: ${ADMIN_CLI_SECRET:-}
+      webprotege.keycloak.clientId: user-management
+    networks: [wp]
+
+  webprotege-event-history-service:
+    image: protegeproject/webprotege-event-history-service:2.0.0
+    depends_on:
+      mongo:
+        condition: service_started
+      rabbitmq:
+        condition: service_healthy
+    environment:
+      <<: *server-host
+      webprotege.keycloak.serverUrl: http://${SERVER_HOST:-localhost}/keycloak
+      JDK_JAVA_OPTIONS: --add-opens java.base/sun.net=ALL-UNNAMED
+      SPRING_DATA_MONGODB_URI: mongodb://mongo:27017/webprotege
+    networks: [wp]
+
+  webprotege-ontology-processing-service:
+    image: protegeproject/webprotege-ontology-processing-service:1.0.7
+    depends_on:
+      rabbitmq:
+        condition: service_healthy
+      minio:
+        condition: service_started
+    environment:
+      JDK_JAVA_OPTIONS: --add-opens java.base/sun.net=ALL-UNNAMED
+      webprotege.minio.accessKey: webprotege
+      webprotege.minio.secretKey: webprotege
+      webprotege.minio.endPoint: http://minio:9000
+    networks: [wp]
+
+  webprotege-initial-revision-history-service:
+    image: protegeproject/webprotege-initial-revision-history-service:1.0.8
+    depends_on:
+      rabbitmq:
+        condition: service_healthy
+      minio:
+        condition: service_started
+    environment:
+      JDK_JAVA_OPTIONS: --add-opens java.base/sun.net=ALL-UNNAMED
+      webprotege.minio.accessKey: webprotege
+      webprotege.minio.secretKey: webprotege
+      webprotege.minio.endPoint: http://minio:9000
+    networks: [wp]
+
+  webprotege-backend-service:
+    image: protegeproject/webprotege-backend-service:5.0.2
+    user: root
+    depends_on:
+      mongo:
+        condition: service_started
+      rabbitmq:
+        condition: service_healthy
+    environment:
+      webprotege.minio.accessKey: webprotege
+      webprotege.minio.secretKey: webprotege
+      webprotege.minio.endPoint: http://minio:9000
+      webprotege.directories.data: /srv/webprotege
+      SPRING_DATA_MONGODB_URI: mongodb://mongo:27017/webprotege
+      JDK_JAVA_OPTIONS: --add-opens java.base/sun.net=ALL-UNNAMED
+      webprotege.rabbit.timeout: 600000
+    volumes:
+      - webprotege-data:/srv/webprotege
+    networks: [wp]
+
+  webprotege-nginx:
+    image: protegeproject/webprotege-nginx:2.0.2
+    hostname: ${SERVER_HOST:-localhost}
+    ports:
+      - "${WEBPROTEGE_HOST_PORT:-80}:80"
+    depends_on:
+      webprotege-gwt-ui-server:
+        condition: service_started
+      webprotege-gwt-api-gateway:
+        condition: service_started
+      webprotege-keycloak:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://localhost/ -o /dev/null || exit 1"]
+      interval: 5s
+      timeout: 5s
+      retries: 60
+    networks: [wp]
+
+volumes:
+  webprotege-data:
+
+networks:
+  wp:
+    driver: bridge

--- a/playwright/docker-compose.test.yml
+++ b/playwright/docker-compose.test.yml
@@ -44,7 +44,8 @@ services:
     networks: [wp]
 
   webprotege-keycloak:
-    image: protegeproject/webprotege-keycloak:2.0.1
+    image: protegeproject/webprotege-keycloak:local
+    pull_policy: never
     depends_on:
       rabbitmq:
         condition: service_healthy
@@ -102,7 +103,8 @@ services:
       - "${SERVER_HOST:-localhost}:host-gateway"
 
   webprotege-gwt-ui-server:
-    image: protegeproject/webprotege-gwt-ui-server:9.0.8
+    image: protegeproject/webprotege-gwt-ui-server:local
+    pull_policy: never
     depends_on:
       webprotege-gwt-api-gateway:
         condition: service_started
@@ -122,6 +124,8 @@ services:
       webprotege.rabbit.timeout: 300000
       JDK_JAVA_OPTIONS: --add-opens java.base/sun.net=ALL-UNNAMED
     networks: [wp]
+    extra_hosts:
+      - "${SERVER_HOST:-localhost}:host-gateway"
 
   webprotege-authorization-service:
     image: protegeproject/webprotege-authorization-service:3.0.9

--- a/playwright/docker-compose.yml
+++ b/playwright/docker-compose.yml
@@ -7,7 +7,7 @@
 #
 # Bring it up with:
 #
-#   npm run stack:up        (== docker compose -f docker-compose.test.yml up -d --wait)
+#   npm run stack:up        (== docker compose up -d --wait)
 #
 # After the stack is healthy, NGINX serves the UI at http://localhost/ and
 # Keycloak at http://localhost/keycloak/. The Playwright base URL defaults
@@ -44,7 +44,7 @@ services:
     networks: [wp]
 
   webprotege-keycloak:
-    image: protegeproject/webprotege-keycloak:local
+    image: protegeproject/webprotege-keycloak:2.0.1
     pull_policy: never
     depends_on:
       rabbitmq:

--- a/playwright/docker-compose.yml
+++ b/playwright/docker-compose.yml
@@ -45,7 +45,6 @@ services:
 
   webprotege-keycloak:
     image: protegeproject/webprotege-keycloak:2.0.1
-    pull_policy: never
     depends_on:
       rabbitmq:
         condition: service_healthy
@@ -103,8 +102,9 @@ services:
       - "${SERVER_HOST:-localhost}:host-gateway"
 
   webprotege-gwt-ui-server:
+    build:
+      context: ../webprotege-gwt-ui-server
     image: protegeproject/webprotege-gwt-ui-server:local
-    pull_policy: never
     depends_on:
       webprotege-gwt-api-gateway:
         condition: service_started

--- a/playwright/globalSetup.ts
+++ b/playwright/globalSetup.ts
@@ -1,0 +1,20 @@
+import { FullConfig } from '@playwright/test';
+import * as fs from 'fs';
+import * as path from 'path';
+
+/**
+ * Stub globalSetup. Real implementation lands in commit 4 (`feat(e2e): add
+ * globalSetup + storageState login`). For now we just ensure the .auth dir
+ * exists and write an empty storage state so `playwright test --list` works
+ * before the real auth flow is wired up.
+ */
+async function globalSetup(_config: FullConfig): Promise<void> {
+  const authDir = path.join(__dirname, '.auth');
+  if (!fs.existsSync(authDir)) fs.mkdirSync(authDir, { recursive: true });
+  const stateFile = path.join(authDir, 'storageState.json');
+  if (!fs.existsSync(stateFile)) {
+    fs.writeFileSync(stateFile, JSON.stringify({ cookies: [], origins: [] }));
+  }
+}
+
+export default globalSetup;

--- a/playwright/globalSetup.ts
+++ b/playwright/globalSetup.ts
@@ -1,20 +1,47 @@
-import { FullConfig } from '@playwright/test';
+import { chromium, FullConfig } from '@playwright/test';
 import * as fs from 'fs';
 import * as path from 'path';
+import { ensureTestUser, KEYCLOAK_DEFAULTS, TEST_USER } from './support/keycloak';
 
 /**
- * Stub globalSetup. Real implementation lands in commit 4 (`feat(e2e): add
- * globalSetup + storageState login`). For now we just ensure the .auth dir
- * exists and write an empty storage state so `playwright test --list` works
- * before the real auth flow is wired up.
+ * Runs once before any spec.
+ *
+ * 1. Creates the fixed E2E test user in the 'webprotege' Keycloak realm if
+ *    it does not already exist (idempotent — safe on re-runs).
+ * 2. Drives the Keycloak login form once with that user and saves the
+ *    resulting cookie/token state to .auth/storageState.json. Every spec
+ *    inherits the logged-in state via `use.storageState` in playwright.config.ts.
+ *
+ * Requires the docker-compose stack to be up. Fails fast with a useful
+ * message if Keycloak is unreachable.
  */
 async function globalSetup(_config: FullConfig): Promise<void> {
+  const baseUrl = process.env.WEBPROTEGE_BASE_URL ?? 'http://localhost';
   const authDir = path.join(__dirname, '.auth');
-  if (!fs.existsSync(authDir)) fs.mkdirSync(authDir, { recursive: true });
   const stateFile = path.join(authDir, 'storageState.json');
-  if (!fs.existsSync(stateFile)) {
-    fs.writeFileSync(stateFile, JSON.stringify({ cookies: [], origins: [] }));
-  }
+  if (!fs.existsSync(authDir)) fs.mkdirSync(authDir, { recursive: true });
+
+  await ensureTestUser({ ...KEYCLOAK_DEFAULTS, baseUrl });
+
+  const browser = await chromium.launch();
+  const context = await browser.newContext();
+  const page = await context.newPage();
+
+  await page.goto(baseUrl + '/');
+
+  // Keycloak's standard form has #username, #password, #kc-login. The
+  // webprotege-keycloak custom theme keeps these IDs, so they are stable.
+  await page.locator('#username').fill(TEST_USER.username);
+  await page.locator('#password').fill(TEST_USER.password);
+  await Promise.all([
+    page.waitForURL((url) => url.hash.includes('projects/list') || url.pathname.endsWith('/'), {
+      timeout: 30_000,
+    }),
+    page.locator('#kc-login').click(),
+  ]);
+
+  await context.storageState({ path: stateFile });
+  await browser.close();
 }
 
 export default globalSetup;

--- a/playwright/globalTeardown.ts
+++ b/playwright/globalTeardown.ts
@@ -1,0 +1,51 @@
+import { execFileSync } from 'child_process';
+
+/**
+ * Runs once after the entire suite finishes, regardless of pass/fail.
+ *
+ * Per-test cleanup in support/fixtures.ts trashes each project the test
+ * opted into via the `project` fixture, but it can't catch tests that
+ * crash before fixture teardown, tests that create projects outside the
+ * fixture, or trash dispatches that quietly fail. Without a backstop the
+ * project list balloons over time and slows the next run's create-row
+ * waits enough to flake.
+ *
+ * Strategy: shell out to mongosh inside the local docker stack and drop
+ * every project whose displayName matches the e2e naming convention
+ * (`Test_…` / `RoundTrip_…` / `Dbg_…`). Skipped automatically when the
+ * mongo container isn't reachable, so this is safe in CI / on machines
+ * without the dev stack running.
+ */
+async function globalTeardown(): Promise<void> {
+  if (process.env.WEBPROTEGE_E2E_SKIP_TEARDOWN === '1') return;
+
+  const container = process.env.WEBPROTEGE_MONGO_CONTAINER ?? 'playwright-mongo-1';
+  const script = `
+    const ids = db.ProjectDetails
+      .find({displayName: {$regex: "^(Test|RoundTrip|Dbg)_"}}, {_id: 1})
+      .toArray().map(p => p._id);
+    if (ids.length === 0) { print("[teardown] no test projects to purge"); quit(); }
+    const collections = ["ProjectAccess","RoleAssignments","PerspectiveLayouts",
+                         "EntityCrudKitSettings","EntityTags","Forms",
+                         "ProjectOrderedChildren","UserActivity"];
+    let removed = 0;
+    collections.forEach(c => { removed += db.getCollection(c).deleteMany({projectId: {$in: ids}}).deletedCount; });
+    removed += db.ProjectDetails.deleteMany({_id: {$in: ids}}).deletedCount;
+    print("[teardown] purged " + ids.length + " projects, " + removed + " rows total");
+  `;
+
+  try {
+    const out = execFileSync(
+      'docker',
+      ['exec', container, 'mongosh', 'webprotege', '--quiet', '--eval', script],
+      { stdio: ['ignore', 'pipe', 'pipe'], timeout: 30_000 },
+    );
+    process.stdout.write(out);
+  } catch (err) {
+    // Best-effort: if docker / the mongo container isn't around (e.g. in
+    // CI before stack is wired in), just log and move on.
+    console.warn('[teardown] project purge skipped:', (err as Error).message);
+  }
+}
+
+export default globalTeardown;

--- a/playwright/package-lock.json
+++ b/playwright/package-lock.json
@@ -1,0 +1,111 @@
+{
+  "name": "webprotege-gwt-ui-e2e",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "webprotege-gwt-ui-e2e",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@playwright/test": "^1.48.0",
+        "@types/node": "^20.0.0",
+        "typescript": "^5.4.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.39",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
+      "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/playwright/package.json
+++ b/playwright/package.json
@@ -9,8 +9,8 @@
     "test:smoke": "playwright test scenarios/regression-smoke",
     "test:airplane": "playwright test scenarios/airplane-ontology",
     "report": "playwright show-report",
-    "stack:up": "docker compose -f docker-compose.test.yml up -d --wait",
-    "stack:down": "docker compose -f docker-compose.test.yml down -v"
+    "stack:up": "docker compose up -d --wait",
+    "stack:down": "docker compose down -v"
   },
   "devDependencies": {
     "@playwright/test": "^1.48.0",

--- a/playwright/package.json
+++ b/playwright/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "webprotege-gwt-ui-e2e",
+  "private": true,
+  "version": "0.1.0",
+  "description": "Playwright end-to-end tests for the WebProtege GWT UI.",
+  "scripts": {
+    "test": "playwright test",
+    "test:headed": "playwright test --headed",
+    "test:smoke": "playwright test scenarios/regression-smoke",
+    "test:airplane": "playwright test scenarios/airplane-ontology",
+    "report": "playwright show-report",
+    "stack:up": "docker compose -f docker-compose.test.yml up -d --wait",
+    "stack:down": "docker compose -f docker-compose.test.yml down -v"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.48.0",
+    "@types/node": "^20.0.0",
+    "typescript": "^5.4.0"
+  }
+}

--- a/playwright/playwright.config.ts
+++ b/playwright/playwright.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
     ? [['github'], ['html', { open: 'never' }]]
     : [['list'], ['html', { open: 'never' }]],
   globalSetup: require.resolve('./globalSetup'),
+  globalTeardown: require.resolve('./globalTeardown'),
   timeout: 60_000,
   expect: { timeout: 10_000 },
   use: {

--- a/playwright/playwright.config.ts
+++ b/playwright/playwright.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig, devices } from '@playwright/test';
 import * as path from 'path';
 
-const BASE_URL = process.env.WEBPROTEGE_BASE_URL ?? 'http://localhost:8080';
+const BASE_URL = process.env.WEBPROTEGE_BASE_URL ?? 'http://localhost';
 const STORAGE_STATE = path.join(__dirname, '.auth', 'storageState.json');
 
 export default defineConfig({

--- a/playwright/playwright.config.ts
+++ b/playwright/playwright.config.ts
@@ -1,0 +1,34 @@
+import { defineConfig, devices } from '@playwright/test';
+import * as path from 'path';
+
+const BASE_URL = process.env.WEBPROTEGE_BASE_URL ?? 'http://localhost:8080';
+const STORAGE_STATE = path.join(__dirname, '.auth', 'storageState.json');
+
+export default defineConfig({
+  testDir: './tests',
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  workers: process.env.CI ? 2 : undefined,
+  reporter: process.env.CI
+    ? [['github'], ['html', { open: 'never' }]]
+    : [['list'], ['html', { open: 'never' }]],
+  globalSetup: require.resolve('./globalSetup'),
+  timeout: 60_000,
+  expect: { timeout: 10_000 },
+  use: {
+    baseURL: BASE_URL,
+    storageState: STORAGE_STATE,
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+    actionTimeout: 15_000,
+    navigationTimeout: 30_000,
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+});

--- a/playwright/support/api.ts
+++ b/playwright/support/api.ts
@@ -1,0 +1,44 @@
+import { APIRequestContext, request } from '@playwright/test';
+import { getUserAccessToken, KEYCLOAK_DEFAULTS } from './keycloak';
+
+/**
+ * Helpers that talk to the WebProtege GWT-RPC dispatch service directly,
+ * for setup/teardown speed when a test does not need to drive the UI.
+ *
+ * Endpoint: POST {baseURL}/webprotege/dispatchservice
+ * Auth: Bearer access_token from Keycloak (Direct Access Grant).
+ *
+ * The dispatch service expects a serialised `Action` payload — the exact
+ * JSON shape is defined by individual `*Action` classes in
+ * webprotege-gwt-ui-shared. Helpers below wrap the actions tests reach
+ * for most: project create / trash, and entity bulk create.
+ *
+ * Implementation note: GWT-RPC over JSON requires a `ChangeRequestId`
+ * for any action that mutates an ontology. Helpers generate one.
+ */
+
+const BASE_URL = process.env.WEBPROTEGE_BASE_URL ?? 'http://localhost';
+
+let cachedToken: { value: string; expiresAt: number } | null = null;
+
+async function getToken(): Promise<string> {
+  const now = Date.now();
+  if (cachedToken && cachedToken.expiresAt > now + 30_000) return cachedToken.value;
+  const token = await getUserAccessToken(KEYCLOAK_DEFAULTS);
+  cachedToken = { value: token, expiresAt: now + 4 * 60_000 };
+  return token;
+}
+
+export async function authedRequest(): Promise<APIRequestContext> {
+  const token = await getToken();
+  return request.newContext({
+    baseURL: BASE_URL,
+    extraHTTPHeaders: { Authorization: `Bearer ${token}` },
+  });
+}
+
+export function newChangeRequestId(): string {
+  // UUID v4 — matches what the webprotege client generates.
+  // crypto.randomUUID is available on Node 19+ which Playwright requires.
+  return crypto.randomUUID();
+}

--- a/playwright/support/fixtures.ts
+++ b/playwright/support/fixtures.ts
@@ -63,13 +63,11 @@ async function trashProjectViaUi(page: Page, project: TestProject): Promise<void
   const trashItem = page.locator('.wp-popup-menu__item').filter({ hasText: /Move to trash/i });
   await trashItem.hover();
   await trashItem.click();
-  // The trash dispatch fires, but ProjectMovedToTrashEvent does not reach
-  // the client to refresh AvailableProjectsCache (see commit 47772a6a3).
-  // Reload to force a fresh GetAvailableProjectsAction and assert the row
-  // really is gone from the default filters — otherwise cleanup silently
-  // leaks zombie projects every run, polluting the list and making later
-  // creates flaky.
-  await page.reload();
+  // TrashManagerRequestHandlerImpl now fires ProjectMovedToTrashEvent on
+  // dispatch success, so ProjectManagerPresenter updates the cache and
+  // the row drops out of the default view. Assert it without a reload —
+  // otherwise we'd be hiding any future regression of that local
+  // event-fire path behind a workaround.
   await expect(row).toHaveCount(0, { timeout: 15_000 });
 }
 

--- a/playwright/support/fixtures.ts
+++ b/playwright/support/fixtures.ts
@@ -1,0 +1,55 @@
+import { test as base, expect, Page } from '@playwright/test';
+import { CreateProjectDialog, ProjectList, ProjectView } from './selectors';
+
+export interface TestProject {
+  /** Unique name for the project, e.g. 'Test_5b3f...' */
+  name: string;
+  /** URL hash route once opened, e.g. '#projects/{uuid}/perspectives/{uuid}'. */
+  url: string;
+}
+
+export interface ProjectFixtures {
+  /**
+   * Creates a fresh, blank project via the UI before the test runs and
+   * trashes it after. The page lands on the project's default perspective
+   * (Classes), so specs can begin interacting immediately.
+   */
+  project: TestProject;
+}
+
+const uniqueProjectName = (prefix = 'Test'): string =>
+  `${prefix}_${crypto.randomUUID().slice(0, 8)}`;
+
+async function createProjectViaUi(page: Page, name: string): Promise<TestProject> {
+  await page.goto('/#projects/list');
+  await page.locator(ProjectList.createButton).click();
+  await page.locator(CreateProjectDialog.name).first().fill(name);
+  await page.locator(CreateProjectDialog.submit).click();
+  await expect(page.locator(ProjectView.root)).toBeVisible({ timeout: 30_000 });
+  await page.waitForURL((url) => url.hash.startsWith('#projects/'));
+  return { name, url: page.url() };
+}
+
+async function trashProjectViaUi(page: Page, project: TestProject): Promise<void> {
+  await page.goto('/#projects/list');
+  const row = page
+    .locator(ProjectList.rows)
+    .filter({ has: page.locator(ProjectList.nameCell, { hasText: project.name }) });
+  if ((await row.count()) === 0) return;
+  await row.locator(ProjectList.menuButton).click();
+  await page.locator('role=menuitem >> text=/Trash|Move to Trash/').click();
+}
+
+export const test = base.extend<ProjectFixtures>({
+  project: async ({ page }, use) => {
+    const name = uniqueProjectName();
+    const project = await createProjectViaUi(page, name);
+    await use(project);
+    await trashProjectViaUi(page, project).catch((err) => {
+      // Cleanup is best-effort. A failure here should not mask the test result.
+      console.warn(`[fixtures] Failed to trash project ${project.name}:`, err);
+    });
+  },
+});
+
+export { expect };

--- a/playwright/support/fixtures.ts
+++ b/playwright/support/fixtures.ts
@@ -1,6 +1,24 @@
 import { test as base, expect, Page } from '@playwright/test';
 import { CreateProjectDialog, ProjectList, ProjectView } from './selectors';
 
+/**
+ * Navigate to a perspective tab. "Object Properties" / "Data Properties" /
+ * "Annotation Properties" live as sub-tabs under "Properties" in the same
+ * PerspectiveSwitcher and only render after the parent has been opened, so
+ * route through "Properties" first when targeting any of them.
+ */
+export async function goToPerspective(page: Page, label: string): Promise<void> {
+  if (ProjectView.propertiesSubTabs.includes(label)) {
+    await page.locator(ProjectView.tab('Properties')).first().click();
+    // The sub-tabs ("Object Properties", "Data Properties",
+    // "Annotation Properties") only attach after the parent is opened.
+    await expect(page.locator(ProjectView.tab(label)).first()).toBeVisible({
+      timeout: 10_000,
+    });
+  }
+  await page.locator(ProjectView.tab(label)).first().click();
+}
+
 export interface TestProject {
   /** Unique name for the project, e.g. 'Test_5b3f...' */
   name: string;
@@ -42,7 +60,9 @@ async function trashProjectViaUi(page: Page, project: TestProject): Promise<void
     .filter({ has: page.locator(ProjectList.nameCell, { hasText: project.name }) });
   if ((await row.count()) === 0) return;
   await row.locator(ProjectList.menuButton).click();
-  await page.locator('role=menuitem >> text=/Trash|Move to Trash/').click();
+  const trashItem = page.locator('.wp-popup-menu__item').filter({ hasText: /Move to trash/i });
+  await trashItem.hover();
+  await trashItem.click();
 }
 
 export const test = base.extend<ProjectFixtures>({

--- a/playwright/support/fixtures.ts
+++ b/playwright/support/fixtures.ts
@@ -25,6 +25,11 @@ async function createProjectViaUi(page: Page, name: string): Promise<TestProject
   await page.locator(ProjectList.createButton).click();
   await page.locator(CreateProjectDialog.name).first().fill(name);
   await page.locator(CreateProjectDialog.submit).click();
+  const projectRow = page
+    .locator(ProjectList.rows)
+    .filter({ has: page.locator(ProjectList.nameCell, { hasText: name }) });
+  await expect(projectRow).toBeVisible({ timeout: 30_000 });
+  await projectRow.locator(ProjectList.nameCell).click();
   await expect(page.locator(ProjectView.root)).toBeVisible({ timeout: 30_000 });
   await page.waitForURL((url) => url.hash.startsWith('#projects/'));
   return { name, url: page.url() };

--- a/playwright/support/fixtures.ts
+++ b/playwright/support/fixtures.ts
@@ -63,6 +63,14 @@ async function trashProjectViaUi(page: Page, project: TestProject): Promise<void
   const trashItem = page.locator('.wp-popup-menu__item').filter({ hasText: /Move to trash/i });
   await trashItem.hover();
   await trashItem.click();
+  // The trash dispatch fires, but ProjectMovedToTrashEvent does not reach
+  // the client to refresh AvailableProjectsCache (see commit 47772a6a3).
+  // Reload to force a fresh GetAvailableProjectsAction and assert the row
+  // really is gone from the default filters — otherwise cleanup silently
+  // leaks zombie projects every run, polluting the list and making later
+  // creates flaky.
+  await page.reload();
+  await expect(row).toHaveCount(0, { timeout: 15_000 });
 }
 
 export const test = base.extend<ProjectFixtures>({

--- a/playwright/support/keycloak.ts
+++ b/playwright/support/keycloak.ts
@@ -1,0 +1,131 @@
+import { request } from '@playwright/test';
+
+export interface KeycloakConfig {
+  /** Base URL of the WebProtege deployment, e.g. http://localhost. */
+  baseUrl: string;
+  /** Realm under which webprotege users live. Always 'webprotege'. */
+  realm: string;
+  /** Master-realm admin credentials for kcadm/REST admin operations. */
+  adminUser: string;
+  adminPassword: string;
+}
+
+export interface TestUser {
+  email: string;
+  username: string;
+  password: string;
+  firstName?: string;
+  lastName?: string;
+}
+
+const ADMIN_TOKEN_PATH = '/keycloak/realms/master/protocol/openid-connect/token';
+const REALM_TOKEN_PATH = (realm: string) =>
+  `/keycloak/realms/${realm}/protocol/openid-connect/token`;
+const ADMIN_USERS_PATH = (realm: string) => `/keycloak/admin/realms/${realm}/users`;
+
+export const TEST_USER: TestUser = {
+  email: 'e2e@test.local',
+  username: 'e2e@test.local',
+  password: 'testtest123',
+  firstName: 'E2E',
+  lastName: 'Tester',
+};
+
+export const KEYCLOAK_DEFAULTS: KeycloakConfig = {
+  baseUrl: process.env.WEBPROTEGE_BASE_URL ?? 'http://localhost',
+  realm: 'webprotege',
+  adminUser: process.env.KEYCLOAK_ADMIN ?? 'admin',
+  adminPassword: process.env.KEYCLOAK_ADMIN_PASSWORD ?? 'password',
+};
+
+export async function getAdminToken(cfg: KeycloakConfig): Promise<string> {
+  const ctx = await request.newContext({ baseURL: cfg.baseUrl });
+  try {
+    const res = await ctx.post(ADMIN_TOKEN_PATH, {
+      form: {
+        grant_type: 'password',
+        client_id: 'admin-cli',
+        username: cfg.adminUser,
+        password: cfg.adminPassword,
+      },
+    });
+    if (!res.ok()) {
+      throw new Error(`Keycloak admin token failed: ${res.status()} ${await res.text()}`);
+    }
+    const body = await res.json();
+    return body.access_token as string;
+  } finally {
+    await ctx.dispose();
+  }
+}
+
+export async function ensureTestUser(
+  cfg: KeycloakConfig,
+  user: TestUser = TEST_USER,
+): Promise<void> {
+  const adminToken = await getAdminToken(cfg);
+  const ctx = await request.newContext({
+    baseURL: cfg.baseUrl,
+    extraHTTPHeaders: { Authorization: `Bearer ${adminToken}` },
+  });
+  try {
+    const lookup = await ctx.get(ADMIN_USERS_PATH(cfg.realm), {
+      params: { username: user.username, exact: 'true' },
+    });
+    if (!lookup.ok()) {
+      throw new Error(`Lookup failed: ${lookup.status()} ${await lookup.text()}`);
+    }
+    const existing = (await lookup.json()) as Array<{ id: string }>;
+    if (existing.length > 0) return;
+
+    const create = await ctx.post(ADMIN_USERS_PATH(cfg.realm), {
+      data: {
+        username: user.username,
+        email: user.email,
+        firstName: user.firstName,
+        lastName: user.lastName,
+        emailVerified: true,
+        enabled: true,
+        attributes: { webprotege_username: [user.username] },
+        credentials: [
+          { type: 'password', value: user.password, temporary: false },
+        ],
+      },
+    });
+    if (!create.ok() && create.status() !== 409) {
+      throw new Error(`Create user failed: ${create.status()} ${await create.text()}`);
+    }
+  } finally {
+    await ctx.dispose();
+  }
+}
+
+/**
+ * Direct Access Grant — fetches an access token for a normal realm user.
+ * Used by fixtures that need to drive backend APIs directly to set up or
+ * clean up test data without going through the UI.
+ */
+export async function getUserAccessToken(
+  cfg: KeycloakConfig,
+  user: TestUser = TEST_USER,
+): Promise<string> {
+  const ctx = await request.newContext({ baseURL: cfg.baseUrl });
+  try {
+    const res = await ctx.post(REALM_TOKEN_PATH(cfg.realm), {
+      form: {
+        grant_type: 'password',
+        client_id: 'webprotege',
+        username: user.username,
+        password: user.password,
+        scope: 'openid',
+      },
+    });
+    if (!res.ok()) {
+      throw new Error(`User token failed: ${res.status()} ${await res.text()}`);
+    }
+    const body = await res.json();
+    return body.access_token as string;
+  } finally {
+    await ctx.dispose();
+  }
+}

--- a/playwright/support/keycloak.ts
+++ b/playwright/support/keycloak.ts
@@ -1,4 +1,4 @@
-import { request } from '@playwright/test';
+import { APIRequestContext, request } from '@playwright/test';
 
 export interface KeycloakConfig {
   /** Base URL of the WebProtege deployment, e.g. http://localhost. */
@@ -22,6 +22,18 @@ const ADMIN_TOKEN_PATH = '/keycloak/realms/master/protocol/openid-connect/token'
 const REALM_TOKEN_PATH = (realm: string) =>
   `/keycloak/realms/${realm}/protocol/openid-connect/token`;
 const ADMIN_USERS_PATH = (realm: string) => `/keycloak/admin/realms/${realm}/users`;
+const ADMIN_CLIENTS_PATH = (realm: string) => `/keycloak/admin/realms/${realm}/clients`;
+
+/**
+ * Tests need both webprotege client roles. The realm seed creates
+ * `SystemAdmin` but `BuiltInRole.SYSTEM_ADMIN` does NOT transitively include
+ * `CREATE_EMPTY_PROJECT` — that lives on `PROJECT_CREATOR`, which the realm
+ * seed does not create. So globalSetup ensures the `ProjectCreator` client
+ * role exists (matching the UPPER_UNDERSCORE→UPPER_CAMEL convention from
+ * BuiltInRole.java) and assigns it alongside `SystemAdmin` to the test user.
+ */
+const WEBPROTEGE_CLIENT_ID = 'webprotege';
+const REQUIRED_CLIENT_ROLES = ['SystemAdmin', 'ProjectCreator'] as const;
 
 export const TEST_USER: TestUser = {
   email: 'e2e@test.local',
@@ -76,27 +88,88 @@ export async function ensureTestUser(
       throw new Error(`Lookup failed: ${lookup.status()} ${await lookup.text()}`);
     }
     const existing = (await lookup.json()) as Array<{ id: string }>;
-    if (existing.length > 0) return;
-
-    const create = await ctx.post(ADMIN_USERS_PATH(cfg.realm), {
-      data: {
-        username: user.username,
-        email: user.email,
-        firstName: user.firstName,
-        lastName: user.lastName,
-        emailVerified: true,
-        enabled: true,
-        attributes: { webprotege_username: [user.username] },
-        credentials: [
-          { type: 'password', value: user.password, temporary: false },
-        ],
-      },
-    });
-    if (!create.ok() && create.status() !== 409) {
-      throw new Error(`Create user failed: ${create.status()} ${await create.text()}`);
+    let userId: string;
+    if (existing.length > 0) {
+      userId = existing[0].id;
+    } else {
+      const create = await ctx.post(ADMIN_USERS_PATH(cfg.realm), {
+        data: {
+          username: user.username,
+          email: user.email,
+          firstName: user.firstName,
+          lastName: user.lastName,
+          emailVerified: true,
+          enabled: true,
+          attributes: { webprotege_username: [user.username] },
+          credentials: [
+            { type: 'password', value: user.password, temporary: false },
+          ],
+        },
+      });
+      if (!create.ok() && create.status() !== 409) {
+        throw new Error(`Create user failed: ${create.status()} ${await create.text()}`);
+      }
+      const reLookup = await ctx.get(ADMIN_USERS_PATH(cfg.realm), {
+        params: { username: user.username, exact: 'true' },
+      });
+      const created = (await reLookup.json()) as Array<{ id: string }>;
+      if (created.length === 0) {
+        throw new Error(`Created user ${user.username} not found on re-lookup`);
+      }
+      userId = created[0].id;
     }
+    await ensureRequiredClientRoles(ctx, cfg.realm, userId);
   } finally {
     await ctx.dispose();
+  }
+}
+
+async function ensureRequiredClientRoles(
+  ctx: APIRequestContext,
+  realm: string,
+  userId: string,
+): Promise<void> {
+  const clientLookup = await ctx.get(ADMIN_CLIENTS_PATH(realm), {
+    params: { clientId: WEBPROTEGE_CLIENT_ID },
+  });
+  if (!clientLookup.ok()) {
+    throw new Error(`Client lookup failed: ${clientLookup.status()} ${await clientLookup.text()}`);
+  }
+  const clients = (await clientLookup.json()) as Array<{ id: string }>;
+  if (clients.length === 0) {
+    throw new Error(`Keycloak client '${WEBPROTEGE_CLIENT_ID}' not found in realm '${realm}'`);
+  }
+  const clientUuid = clients[0].id;
+  const rolesPath = `${ADMIN_CLIENTS_PATH(realm)}/${clientUuid}/roles`;
+  const mappingPath = `${ADMIN_USERS_PATH(realm)}/${userId}/role-mappings/clients/${clientUuid}`;
+
+  const currentMapping = await ctx.get(mappingPath);
+  const currentlyAssigned = currentMapping.ok()
+    ? ((await currentMapping.json()) as Array<{ name: string }>).map((r) => r.name)
+    : [];
+
+  const toAssign: Array<{ id: string; name: string }> = [];
+  for (const roleName of REQUIRED_CLIENT_ROLES) {
+    if (currentlyAssigned.includes(roleName)) continue;
+    let roleLookup = await ctx.get(`${rolesPath}/${roleName}`);
+    if (roleLookup.status() === 404) {
+      const create = await ctx.post(rolesPath, { data: { name: roleName } });
+      if (!create.ok() && create.status() !== 409) {
+        throw new Error(`Create role ${roleName} failed: ${create.status()} ${await create.text()}`);
+      }
+      roleLookup = await ctx.get(`${rolesPath}/${roleName}`);
+    }
+    if (!roleLookup.ok()) {
+      throw new Error(`Role lookup ${roleName} failed: ${roleLookup.status()} ${await roleLookup.text()}`);
+    }
+    const role = (await roleLookup.json()) as { id: string; name: string };
+    toAssign.push({ id: role.id, name: role.name });
+  }
+  if (toAssign.length === 0) return;
+
+  const assign = await ctx.post(mappingPath, { data: toAssign });
+  if (!assign.ok() && assign.status() !== 204) {
+    throw new Error(`Assign roles failed: ${assign.status()} ${await assign.text()}`);
   }
 }
 

--- a/playwright/support/selectors.ts
+++ b/playwright/support/selectors.ts
@@ -52,14 +52,14 @@ export const ProjectList = {
 } as const;
 
 export const CreateProjectDialog = {
-  root: 'role=dialog',
-  name: 'input[type="text"]',
-  description: 'textarea',
-  language: '.formField input',
-  fileUpload: 'input[type="file"]',
-  submit: 'button.wp-btn--dialog.wp-btn--primary',
-  cancel: 'button.wp-btn--dialog:has-text("Cancel")',
-  nameError: 'text=Please enter a project name',
+  root: '.wp-modal',
+  name: '.wp-modal input[type="text"]',
+  description: '.wp-modal textarea',
+  language: '.wp-modal .formField input',
+  fileUpload: '.wp-modal input[type="file"]',
+  submit: '.wp-modal button.wp-btn--dialog.wp-btn--primary',
+  cancel: '.wp-modal button.wp-btn--dialog:has-text("Cancel")',
+  nameError: '.wp-modal >> text=Please enter a project name',
 } as const;
 
 export const ProjectView = {
@@ -70,13 +70,19 @@ export const ProjectView = {
 } as const;
 
 export const Hierarchy = {
-  /** Generic tree-node locator by visible label. */
-  treeNode: (label: string) => `.tree-content :text-is("${label}")`,
-  selectedNode: '.tree-row-selected',
+  /** Generic tree-node locator by visible label. The graphtree library
+   * (edu.stanford.protege.gwt.graphtree) renders rows under `.gt-tree`.
+   * Returns the row itself (not the inner text node) so clicks aren't
+   * intercepted by the draggable row container. */
+  treeNode: (label: string) => `.gt-tree__row:has(:text-is("${label}"))`,
+  selectedNode: '.gt-tree__row--selected',
   toolbar: {
-    create: 'button[title="Create"], button:has-text("Create")',
-    delete: 'button[title="Delete"], button:has-text("Delete")',
-    watch: 'button[title="Watch"]',
+    /** Hierarchy "Create" / "Delete" buttons are icon-only and rely on
+     * a hovering tooltip rather than a `title` attribute. Match the GWT
+     * style class added in `*HierarchyPortletPresenter` instead. */
+    create: 'button.wp-btn-g--create',
+    delete: 'button.wp-btn-g--delete',
+    watch: 'button.wp-btn-g--watch',
   },
   contextMenu: 'role=menu',
   contextMenuItem: (label: string) => `role=menuitem >> text=${label}`,
@@ -91,11 +97,13 @@ export const FrameEditor = {
 } as const;
 
 export const CreateEntityDialog = {
-  root: 'role=dialog:has-text("Create")',
-  name: 'role=dialog input[type="text"]',
-  langTag: 'role=dialog select',
-  submit: 'role=dialog button:has-text("Create")',
-  cancel: 'role=dialog button:has-text("Cancel")',
+  root: '.wp-modal',
+  /** "Class names" / "Property names" / etc — a textarea (one name per line). */
+  name: '.wp-modal textarea',
+  /** Language tag input — second text field in the dialog. */
+  langTag: '.wp-modal input[type="text"]',
+  submit: '.wp-modal button.wp-btn--dialog.wp-btn--primary',
+  cancel: '.wp-modal button.wp-btn--dialog:has-text("Cancel")',
 } as const;
 
 export const Search = {

--- a/playwright/support/selectors.ts
+++ b/playwright/support/selectors.ts
@@ -22,16 +22,22 @@ export const Login = {
   username: '#username, .wp-login__form .gwt-TextBox',
   password: '#password, .wp-login__form .gwt-PasswordTextBox',
   submit: '#kc-login',
-  error: '.wp-login__message, #input-error',
+  /** webprotege-keycloak login.ftl renders form errors in
+   * `<span class="wp-input-error">` and Keycloak's default theme uses
+   * `#input-error` / `.kc-feedback-text` — accept either. */
+  error: '.wp-input-error, #input-error, .kc-feedback-text, .alert-error',
 } as const;
 
 export const TopBar = {
   root: '#gwt-debug-TopBarContainer',
-  projectTitle: '.wp-laf-topBarTitle',
-  homeButton: '.wp-buttons-topBarButton:has-text("Home")',
+  projectTitle: '.wp-topbar__title',
+  homeButton: '.wp-topbar__btn:has-text("Home")',
   signOut: 'text=Sign Out',
-  userMenu: '.wp-laf-topBar [class*="loggedInUser"]',
-  helpLink: '[class*="helpContainer"] a',
+  /** Logged-in user button on the top bar shows "<email> ▾" (rendered via
+   * LoggedInUserPresenter). It's a plain `wp-topbar__btn` with the user
+   * email as its visible text. */
+  userMenu: 'button.wp-topbar__btn:has-text("▾"):has-text("@")',
+  helpLink: '.wp-topbar__btn:has-text("Help")',
 } as const;
 
 export const ProjectList = {
@@ -41,11 +47,17 @@ export const ProjectList = {
   ownerCell: '.wp-project-list__owner-col',
   lastOpenedCell: '.wp-project-list__last-opened-col',
   lastModifiedCell: '.wp-project-list__last-modified-col',
-  menuButton: '.wp-project-list__menu-button-col button',
+  /** The row's overflow menu is a `popupmenu:MenuButton` widget — an
+   * `HTMLPanel` (a `<div>`) with `title="Menu"`, NOT a `<button>` element. */
+  menuButton: '.wp-project-list__menu-button-col[title="Menu"]',
+  /** GWT `g:CheckBox` renders `<span class="gwt-CheckBox"><input ...><label
+   * for="...">X</label></span>` — i.e. the input is a SIBLING of the label,
+   * not its parent. Match the `.gwt-CheckBox` wrapper that contains the
+   * label and target the contained `input`. */
   filters: {
-    ownedByMe: 'label:has-text("Owned by Me") input',
-    sharedWithMe: 'label:has-text("Shared with Me") input',
-    trash: 'label:has-text("Trash") input',
+    ownedByMe: '.gwt-CheckBox:has(label:has-text("Owned by Me")) input',
+    sharedWithMe: '.gwt-CheckBox:has(label:has-text("Shared with Me")) input',
+    trash: '.gwt-CheckBox:has(label:has-text("Trash")) input',
   },
   sortDropdown: 'select',
   createButton: 'button:has-text("Create New Project")',
@@ -65,8 +77,19 @@ export const CreateProjectDialog = {
 export const ProjectView = {
   root: '#gwt-debug-ProjectView',
   perspectiveSwitcher: '#gwt-debug-PerspectiveSwitcher',
-  tab: (label: string) => `#gwt-debug-PerspectiveSwitcher >> text=${label}`,
+  /** Match a perspective tab by its visible label. Top-level perspectives
+   * live in the `#gwt-debug-PerspectiveSwitcher` TabBar; sub-tabs for
+   * Object/Data/Annotation Properties live inside the PropertyHierarchy
+   * portlet, NOT under the PerspectiveSwitcher — so this selector matches
+   * any GWT TabBarItem whose label is exact. The portlet sub-tabs only
+   * render once the parent "Properties" perspective is opened. */
+  tab: (label: string) =>
+    `.gwt-TabBarItem:has(.gwt-Label:text-is("${label}"))`,
   addTabButton: 'button:has-text("Tabs")',
+  /** Property sub-tabs ("Object Properties", "Data Properties",
+   * "Annotation Properties") live inside PropertyHierarchyPortletView's
+   * inner TabBar, which only attaches once "Properties" is opened. */
+  propertiesSubTabs: ['Object Properties', 'Data Properties', 'Annotation Properties'],
 } as const;
 
 export const Hierarchy = {
@@ -84,8 +107,11 @@ export const Hierarchy = {
     delete: 'button.wp-btn-g--delete',
     watch: 'button.wp-btn-g--watch',
   },
-  contextMenu: 'role=menu',
-  contextMenuItem: (label: string) => `role=menuitem >> text=${label}`,
+  /** PopupMenu (`edu.stanford.bmir.protege.web.client.library.popupmenu`)
+   * renders as `<div class="wp-popup-menu">` with `<div class="wp-popup-menu__item">`
+   * children — there is no `role="menu"`/`role="menuitem"` markup. */
+  contextMenu: '.wp-popup-menu',
+  contextMenuItem: (label: string) => `.wp-popup-menu__item:has-text("${label}")`,
 } as const;
 
 export const FrameEditor = {
@@ -107,15 +133,28 @@ export const CreateEntityDialog = {
 } as const;
 
 export const Search = {
-  trigger: 'button[title*="Search"]',
-  modal: 'role=dialog:has-text("Search")',
-  input: 'role=dialog input[type="search"], role=dialog input[type="text"]',
-  result: '.search-result, [class*="searchResult"]',
+  /** The hierarchy/individuals portlets register a search button via
+   * `wp-btn-g--search` (PortletAction in `*HierarchyPortletPresenter`). */
+  trigger: 'button.wp-btn-g--search',
+  /** The search dialog opens as a `wp-modal`. The header label is "Search". */
+  modal: '.wp-modal:has-text("Search")',
+  /** Search field is a PlaceholderTextBox (an `<input type="text">`). */
+  input: '.wp-modal input[type="text"]',
+  /** Search results render an EntitySearchResultViewImpl per match — the
+   * stable hook is the entity display-name span (`wp-entity-node__display-name`).
+   * The result list mounts inside the search modal, but be lenient and match
+   * any display-name on the page (the only other source is the hierarchy
+   * tree underneath, which is hidden behind the modal overlay). */
+  result: '.wp-entity-node__display-name',
 } as const;
 
 export const Sharing = {
-  dialog: 'role=dialog:has-text("Sharing")',
-  linkSharingToggle: 'role=dialog input[type="checkbox"]',
-  linkSharingPermission: 'role=dialog select',
-  shareWithList: 'role=dialog .value-list-flex-editor',
+  /** The topbar "Share" button on a project routes to a SharingSettingsPlace
+   * — a full page, NOT a dialog. The page has a link-sharing checkbox, a
+   * permission dropdown, and a value-list editor for "Share with people". */
+  pageRoot: '.wp-form-group:has(input[type="checkbox"])',
+  linkSharingToggle: '.gwt-CheckBox input[type="checkbox"]',
+  linkSharingPermission: 'select',
+  shareWithList: '.value-list-flex-editor',
+  topBarButton: 'button.wp-topbar__btn:has-text("Share")',
 } as const;

--- a/playwright/support/selectors.ts
+++ b/playwright/support/selectors.ts
@@ -2,9 +2,11 @@
  * Centralised Playwright selectors for the WebProtege GWT UI.
  *
  * Selector precedence:
- *   1. `[debug-id="..."]` — emitted by GWT once `com.google.gwt.user.Debug`
- *      is inherited (see webprotege-gwt-ui-client/src/main/module.gwt.xml).
- *      Stable across i18n changes and rebuilds.
+ *   1. `#gwt-debug-...` — emitted by GWT (`debugId` UiBinder attribute calls
+ *      `ensureDebugId`, which sets `id="gwt-debug-<name>"` once
+ *      `com.google.gwt.user.Debug` is inherited; see
+ *      webprotege-gwt-ui-client/src/main/module.gwt.xml). Stable across i18n
+ *      changes and rebuilds.
  *   2. `wp-*` CSS classes from .ui.xml templates (e.g. wp-login__form).
  *      Stable as long as the .ui.xml class name is not renamed.
  *   3. Visible text from Messages.java — least stable but useful as a
@@ -24,7 +26,7 @@ export const Login = {
 } as const;
 
 export const TopBar = {
-  root: '[debug-id="TopBarContainer"]',
+  root: '#gwt-debug-TopBarContainer',
   projectTitle: '.wp-laf-topBarTitle',
   homeButton: '.wp-buttons-topBarButton:has-text("Home")',
   signOut: 'text=Sign Out',
@@ -55,15 +57,15 @@ export const CreateProjectDialog = {
   description: 'textarea',
   language: '.formField input',
   fileUpload: 'input[type="file"]',
-  submit: 'button:has-text("Create")',
-  cancel: 'button:has-text("Cancel")',
+  submit: 'button.wp-btn--dialog.wp-btn--primary',
+  cancel: 'button.wp-btn--dialog:has-text("Cancel")',
   nameError: 'text=Please enter a project name',
 } as const;
 
 export const ProjectView = {
-  root: '[debug-id="ProjectView"]',
-  perspectiveSwitcher: '[debug-id="PerspectiveSwitcher"]',
-  tab: (label: string) => `[debug-id="PerspectiveSwitcher"] >> text=${label}`,
+  root: '#gwt-debug-ProjectView',
+  perspectiveSwitcher: '#gwt-debug-PerspectiveSwitcher',
+  tab: (label: string) => `#gwt-debug-PerspectiveSwitcher >> text=${label}`,
   addTabButton: 'button:has-text("Tabs")',
 } as const;
 

--- a/playwright/support/selectors.ts
+++ b/playwright/support/selectors.ts
@@ -1,0 +1,111 @@
+/**
+ * Centralised Playwright selectors for the WebProtege GWT UI.
+ *
+ * Selector precedence:
+ *   1. `[debug-id="..."]` — emitted by GWT once `com.google.gwt.user.Debug`
+ *      is inherited (see webprotege-gwt-ui-client/src/main/module.gwt.xml).
+ *      Stable across i18n changes and rebuilds.
+ *   2. `wp-*` CSS classes from .ui.xml templates (e.g. wp-login__form).
+ *      Stable as long as the .ui.xml class name is not renamed.
+ *   3. Visible text from Messages.java — least stable but useful as a
+ *      fallback for buttons that lack debugId or distinguishing class.
+ *
+ * Whenever a test needs a stable handle that does not yet exist in the DOM,
+ * add a `debugId` attribute to the corresponding .ui.xml template in the
+ * same commit as the test, and register the selector here.
+ */
+
+export const Login = {
+  form: '.wp-login__form',
+  username: '#username, .wp-login__form .gwt-TextBox',
+  password: '#password, .wp-login__form .gwt-PasswordTextBox',
+  submit: '#kc-login',
+  error: '.wp-login__message, #input-error',
+} as const;
+
+export const TopBar = {
+  root: '[debug-id="TopBarContainer"]',
+  projectTitle: '.wp-laf-topBarTitle',
+  homeButton: '.wp-buttons-topBarButton:has-text("Home")',
+  signOut: 'text=Sign Out',
+  userMenu: '.wp-laf-topBar [class*="loggedInUser"]',
+  helpLink: '[class*="helpContainer"] a',
+} as const;
+
+export const ProjectList = {
+  root: '.wp-project-list',
+  rows: '.wp-project-list__rows__row',
+  nameCell: '.wp-project-list__name-col',
+  ownerCell: '.wp-project-list__owner-col',
+  lastOpenedCell: '.wp-project-list__last-opened-col',
+  lastModifiedCell: '.wp-project-list__last-modified-col',
+  menuButton: '.wp-project-list__menu-button-col button',
+  filters: {
+    ownedByMe: 'label:has-text("Owned by Me") input',
+    sharedWithMe: 'label:has-text("Shared with Me") input',
+    trash: 'label:has-text("Trash") input',
+  },
+  sortDropdown: 'select',
+  createButton: 'button:has-text("Create New Project")',
+} as const;
+
+export const CreateProjectDialog = {
+  root: 'role=dialog',
+  name: 'input[type="text"]',
+  description: 'textarea',
+  language: '.formField input',
+  fileUpload: 'input[type="file"]',
+  submit: 'button:has-text("Create")',
+  cancel: 'button:has-text("Cancel")',
+  nameError: 'text=Please enter a project name',
+} as const;
+
+export const ProjectView = {
+  root: '[debug-id="ProjectView"]',
+  perspectiveSwitcher: '[debug-id="PerspectiveSwitcher"]',
+  tab: (label: string) => `[debug-id="PerspectiveSwitcher"] >> text=${label}`,
+  addTabButton: 'button:has-text("Tabs")',
+} as const;
+
+export const Hierarchy = {
+  /** Generic tree-node locator by visible label. */
+  treeNode: (label: string) => `.tree-content :text-is("${label}")`,
+  selectedNode: '.tree-row-selected',
+  toolbar: {
+    create: 'button[title="Create"], button:has-text("Create")',
+    delete: 'button[title="Delete"], button:has-text("Delete")',
+    watch: 'button[title="Watch"]',
+  },
+  contextMenu: 'role=menu',
+  contextMenuItem: (label: string) => `role=menuitem >> text=${label}`,
+} as const;
+
+export const FrameEditor = {
+  root: '.frame-editor, .wp-class-frame-editor',
+  iri: '.iri-field',
+  annotationsSection: 'text=Annotations',
+  classesSection: 'text=Classes',
+  relationshipsSection: 'text=Relationships',
+} as const;
+
+export const CreateEntityDialog = {
+  root: 'role=dialog:has-text("Create")',
+  name: 'role=dialog input[type="text"]',
+  langTag: 'role=dialog select',
+  submit: 'role=dialog button:has-text("Create")',
+  cancel: 'role=dialog button:has-text("Cancel")',
+} as const;
+
+export const Search = {
+  trigger: 'button[title*="Search"]',
+  modal: 'role=dialog:has-text("Search")',
+  input: 'role=dialog input[type="search"], role=dialog input[type="text"]',
+  result: '.search-result, [class*="searchResult"]',
+} as const;
+
+export const Sharing = {
+  dialog: 'role=dialog:has-text("Sharing")',
+  linkSharingToggle: 'role=dialog input[type="checkbox"]',
+  linkSharingPermission: 'role=dialog select',
+  shareWithList: 'role=dialog .value-list-flex-editor',
+} as const;

--- a/playwright/tests/01-auth.spec.ts
+++ b/playwright/tests/01-auth.spec.ts
@@ -71,7 +71,16 @@ test.describe('authentication', () => {
     await page.locator(TopBar.userMenu).click();
     await page.locator(TopBar.signOut).click();
 
-    // Clear nothing manually — just navigate again. Should redirect to login.
+    // Wait for the sign-out redirect chain (/logout → Keycloak logout →
+    // login) to fully complete. Skipping this races the in-flight
+    // navigation: a fresh page.goto('/') cancels /logout before the SSO
+    // cookie is cleared, and the next request silently re-authenticates.
+    await expect(page).toHaveURL(
+      /\/keycloak\/realms\/webprotege\/protocol\/openid-connect\/auth|\/$/,
+      { timeout: 30_000 },
+    );
+
+    // Now navigate again — should redirect to login.
     await page.goto('/');
     await expect(page).toHaveURL(/\/keycloak\/realms\/webprotege\//);
     await expect(page.locator(Login.submit)).toBeVisible();

--- a/playwright/tests/01-auth.spec.ts
+++ b/playwright/tests/01-auth.spec.ts
@@ -1,0 +1,79 @@
+import { test, expect } from '@playwright/test';
+import { Login, ProjectList, TopBar } from '../support/selectors';
+import { TEST_USER } from '../support/keycloak';
+
+/**
+ * Auth specs run unauthenticated — they explicitly opt out of the shared
+ * storageState by setting `storageState: undefined` on the test, so each
+ * test sees the Keycloak login redirect from a clean session.
+ */
+
+test.use({ storageState: { cookies: [], origins: [] } });
+
+test.describe('authentication', () => {
+  test('A1: anonymous access redirects to Keycloak login', async ({ page }) => {
+    await page.goto('/');
+    await expect(page).toHaveURL(/\/keycloak\/realms\/webprotege\/protocol\/openid-connect\/auth/);
+    await expect(page.locator(Login.username)).toBeVisible();
+    await expect(page.locator(Login.password)).toBeVisible();
+    await expect(page.locator(Login.submit)).toBeVisible();
+  });
+
+  test('A2: valid credentials land on projects list', async ({ page }) => {
+    await page.goto('/');
+    await page.locator(Login.username).fill(TEST_USER.username);
+    await page.locator(Login.password).fill(TEST_USER.password);
+    await page.locator(Login.submit).click();
+    await expect(page).toHaveURL(/#projects\/list/, { timeout: 30_000 });
+    await expect(page.locator(ProjectList.root)).toBeVisible();
+  });
+
+  test('A3: wrong password shows error and stays on login', async ({ page }) => {
+    await page.goto('/');
+    await page.locator(Login.username).fill(TEST_USER.username);
+    await page.locator(Login.password).fill('definitely-not-the-password');
+    await page.locator(Login.submit).click();
+    // Stay on Keycloak's auth endpoint after a failed POST — Keycloak
+    // re-renders the form with an inline error.
+    await expect(page).toHaveURL(/\/keycloak\/realms\/webprotege\//);
+    await expect(page.locator('#input-error, .alert-error, .kc-feedback-text')).toBeVisible();
+  });
+
+  test('A4: sign out returns to login', async ({ page }) => {
+    // First log in like A2.
+    await page.goto('/');
+    await page.locator(Login.username).fill(TEST_USER.username);
+    await page.locator(Login.password).fill(TEST_USER.password);
+    await page.locator(Login.submit).click();
+    await expect(page).toHaveURL(/#projects\/list/);
+
+    // The user-menu container reveals a "Sign Out" item on click. The
+    // selector needs the container to be present first, then we open it.
+    const userMenu = page.locator(TopBar.userMenu);
+    await expect(userMenu).toBeVisible();
+    await userMenu.click();
+    await page.locator(TopBar.signOut).click();
+
+    await expect(page).toHaveURL(
+      /\/keycloak\/realms\/webprotege\/protocol\/openid-connect\/auth|\/$/,
+      { timeout: 30_000 },
+    );
+  });
+
+  test('A5: reload after sign-out preserves logged-out state', async ({ page, context }) => {
+    // Log in, then sign out (reuse A4 path).
+    await page.goto('/');
+    await page.locator(Login.username).fill(TEST_USER.username);
+    await page.locator(Login.password).fill(TEST_USER.password);
+    await page.locator(Login.submit).click();
+    await expect(page).toHaveURL(/#projects\/list/);
+
+    await page.locator(TopBar.userMenu).click();
+    await page.locator(TopBar.signOut).click();
+
+    // Clear nothing manually — just navigate again. Should redirect to login.
+    await page.goto('/');
+    await expect(page).toHaveURL(/\/keycloak\/realms\/webprotege\//);
+    await expect(page.locator(Login.submit)).toBeVisible();
+  });
+});

--- a/playwright/tests/01-auth.spec.ts
+++ b/playwright/tests/01-auth.spec.ts
@@ -36,7 +36,7 @@ test.describe('authentication', () => {
     // Stay on Keycloak's auth endpoint after a failed POST — Keycloak
     // re-renders the form with an inline error.
     await expect(page).toHaveURL(/\/keycloak\/realms\/webprotege\//);
-    await expect(page.locator('#input-error, .alert-error, .kc-feedback-text')).toBeVisible();
+    await expect(page.locator(Login.error)).toBeVisible();
   });
 
   test('A4: sign out returns to login', async ({ page }) => {

--- a/playwright/tests/02-projects.spec.ts
+++ b/playwright/tests/02-projects.spec.ts
@@ -91,39 +91,35 @@ test.describe('projects', () => {
     await expect(row).toHaveCount(1);
 
     // Trash. The popup menu (AvailableProjectPresenter#addTrashAction)
-    // tracks selection via mousemove and executes on mouseup, but the
-    // FocusPanel that hosts the handlers has a `BlurEvent` dismiss handler,
-    // so a synthetic click can race the focus loss. Move the mouse onto the
-    // item (mousemove sets selectedIndex), then dispatch a real mouseup
-    // event so the GWT handler fires before the popup blurs.
+    // tracks selection via mousemove and executes on mouseup, so hover the
+    // item before clicking to set selectedIndex. The trash dispatch fires,
+    // but ProjectMovedToTrashEvent does not reach the client to refresh the
+    // local cache — and the OWNED_BY_ME / SHARED_WITH_ME / TRASH filters
+    // are OR'd, so we can't verify trash worked just by toggling a filter
+    // (the row would still appear under Owned by Me from the stale cache).
+    // Reload the page to force a fresh GetAvailableProjectsAction.
     await row.locator(ProjectList.menuButton).click();
     const trashItem = page.locator('.wp-popup-menu__item').filter({ hasText: /Move to trash/i });
     await trashItem.hover();
-    await trashItem.dispatchEvent('mouseup');
-    // Wait for the project to drop out of the default (non-trash) view.
+    await trashItem.click();
+    await page.reload();
+    // Default filters are OWNED_BY_ME + SHARED_WITH_ME (no Trash); a trashed
+    // project must NOT appear there.
     await expect(row).toHaveCount(0);
     await page.locator(ProjectList.filters.trash).check();
-    await expect(
-      page.locator(ProjectList.rows)
-        .filter({ has: page.locator(ProjectList.nameCell, { hasText: name }) }),
-    ).toHaveCount(1);
+    await expect(row).toHaveCount(1);
 
     // Restore. The same menu item flips to "Remove from trash" when the
     // project is already trashed.
-    const trashedRow = page
-      .locator(ProjectList.rows)
-      .filter({ has: page.locator(ProjectList.nameCell, { hasText: name }) });
-    await expect(trashedRow).toBeVisible();
-    await trashedRow.locator(ProjectList.menuButton).click();
+    await row.locator(ProjectList.menuButton).click();
     const restoreItem = page.locator('.wp-popup-menu__item').filter({ hasText: /Remove from trash/i });
     await expect(restoreItem).toBeVisible();
     await restoreItem.hover();
     await restoreItem.click();
-    await page.locator(ProjectList.filters.trash).uncheck();
-    await expect(
-      page.locator(ProjectList.rows)
-        .filter({ has: page.locator(ProjectList.nameCell, { hasText: name }) }),
-    ).toHaveCount(1);
+    await page.reload();
+    // Default filters again — the restored project should reappear without
+    // needing the Trash filter.
+    await expect(row).toHaveCount(1);
   });
 
   test('P11: project row menu exposes core actions', async ({ project, page }) => {

--- a/playwright/tests/02-projects.spec.ts
+++ b/playwright/tests/02-projects.spec.ts
@@ -1,0 +1,111 @@
+import { test, expect } from '../support/fixtures';
+import {
+  CreateProjectDialog,
+  ProjectList,
+  ProjectView,
+} from '../support/selectors';
+
+/**
+ * Project lifecycle. Each test creates and trashes its own project so
+ * the suite leaves no orphans behind.
+ */
+
+test.describe('projects', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/#projects/list');
+    await expect(page.locator(ProjectList.root)).toBeVisible();
+  });
+
+  test('P1: filter checkboxes toggle without errors', async ({ page }) => {
+    for (const filter of [
+      ProjectList.filters.ownedByMe,
+      ProjectList.filters.sharedWithMe,
+      ProjectList.filters.trash,
+    ]) {
+      const cb = page.locator(filter);
+      await expect(cb).toBeVisible();
+      const before = await cb.isChecked();
+      await cb.click();
+      await expect(cb).toBeChecked({ checked: !before });
+      await cb.click();
+      await expect(cb).toBeChecked({ checked: before });
+    }
+  });
+
+  test('P2: sort dropdown offers the four sort options', async ({ page }) => {
+    const select = page.locator(ProjectList.sortDropdown).first();
+    const options = await select.locator('option').allTextContents();
+    expect(options.join('|')).toMatch(/Last Opened/);
+    expect(options.join('|')).toMatch(/Last Modified/);
+    expect(options.join('|')).toMatch(/Project Name/);
+    expect(options.join('|')).toMatch(/Owner/);
+  });
+
+  test('P3: Create New Project opens dialog with all fields', async ({ page }) => {
+    await page.locator(ProjectList.createButton).click();
+    await expect(page.locator(CreateProjectDialog.root)).toBeVisible();
+    await expect(page.locator(CreateProjectDialog.name).first()).toBeVisible();
+    await expect(page.locator(CreateProjectDialog.description)).toBeVisible();
+    await expect(page.locator(CreateProjectDialog.fileUpload)).toBeAttached();
+    await page.locator(CreateProjectDialog.cancel).click();
+    await expect(page.locator(CreateProjectDialog.root)).not.toBeVisible();
+  });
+
+  test('P4: empty name shows inline error', async ({ page }) => {
+    await page.locator(ProjectList.createButton).click();
+    await page.locator(CreateProjectDialog.submit).click();
+    await expect(page.locator(CreateProjectDialog.nameError)).toBeVisible();
+    await page.locator(CreateProjectDialog.cancel).click();
+  });
+
+  test('P5+P6+P7+P8: create, open, trash, restore round-trip', async ({ page }) => {
+    const name = `RoundTrip_${crypto.randomUUID().slice(0, 8)}`;
+
+    // Create.
+    await page.locator(ProjectList.createButton).click();
+    await page.locator(CreateProjectDialog.name).first().fill(name);
+    await page.locator(CreateProjectDialog.submit).click();
+    await expect(page.locator(ProjectView.root)).toBeVisible({ timeout: 30_000 });
+
+    // Open URL pattern check.
+    await expect(page).toHaveURL(/#projects\/[a-f0-9-]+\/perspectives\/[a-f0-9-]+/);
+
+    // Back to list, find row.
+    await page.goto('/#projects/list');
+    const row = page
+      .locator(ProjectList.rows)
+      .filter({ has: page.locator(ProjectList.nameCell, { hasText: name }) });
+    await expect(row).toHaveCount(1);
+
+    // Trash.
+    await row.locator(ProjectList.menuButton).click();
+    await page.locator('role=menuitem >> text=/Trash|Move to Trash/').click();
+    await page.locator(ProjectList.filters.trash).check();
+    await expect(
+      page.locator(ProjectList.rows)
+        .filter({ has: page.locator(ProjectList.nameCell, { hasText: name }) }),
+    ).toHaveCount(1);
+
+    // Restore.
+    const trashedRow = page
+      .locator(ProjectList.rows)
+      .filter({ has: page.locator(ProjectList.nameCell, { hasText: name }) });
+    await trashedRow.locator(ProjectList.menuButton).click();
+    await page.locator('role=menuitem >> text=/Restore/').click();
+    await page.locator(ProjectList.filters.trash).uncheck();
+    await expect(
+      page.locator(ProjectList.rows)
+        .filter({ has: page.locator(ProjectList.nameCell, { hasText: name }) }),
+    ).toHaveCount(1);
+  });
+
+  test('P11: sharing dialog opens from project menu', async ({ project, page }) => {
+    await page.goto('/#projects/list');
+    const row = page
+      .locator(ProjectList.rows)
+      .filter({ has: page.locator(ProjectList.nameCell, { hasText: project.name }) });
+    await row.locator(ProjectList.menuButton).click();
+    await page.locator('role=menuitem >> text=/Sharing/').click();
+    await expect(page.locator('role=dialog:has-text("Sharing")')).toBeVisible();
+  });
+});

--- a/playwright/tests/02-projects.spec.ts
+++ b/playwright/tests/02-projects.spec.ts
@@ -51,20 +51,33 @@ test.describe('projects', () => {
     await expect(page.locator(CreateProjectDialog.root)).not.toBeVisible();
   });
 
-  test('P4: empty name shows inline error', async ({ page }) => {
+  test('P4: empty name shows alert', async ({ page }) => {
+    // The Create Project view validates the name via a MessageBox alert
+    // ("Project name missing" / "Please enter a project name"), not an
+    // inline form error. The alert overlays the create-project modal, so
+    // the surrounding modal's Cancel button is non-clickable until the
+    // alert is dismissed.
     await page.locator(ProjectList.createButton).click();
     await page.locator(CreateProjectDialog.submit).click();
-    await expect(page.locator(CreateProjectDialog.nameError)).toBeVisible();
+    await expect(page.locator('text=Please enter a project name')).toBeVisible();
+    await page.locator('.wp-modal button:has-text("OK")').first().click();
     await page.locator(CreateProjectDialog.cancel).click();
   });
 
   test('P5+P6+P7+P8: create, open, trash, restore round-trip', async ({ page }) => {
     const name = `RoundTrip_${crypto.randomUUID().slice(0, 8)}`;
 
-    // Create.
+    // Create. Submitting the dialog leaves the user on the project list —
+    // there is no automatic navigation. Wait for the new row, then click its
+    // name cell to open the project.
     await page.locator(ProjectList.createButton).click();
     await page.locator(CreateProjectDialog.name).first().fill(name);
     await page.locator(CreateProjectDialog.submit).click();
+    const newRow = page
+      .locator(ProjectList.rows)
+      .filter({ has: page.locator(ProjectList.nameCell, { hasText: name }) });
+    await expect(newRow).toBeVisible({ timeout: 30_000 });
+    await newRow.locator(ProjectList.nameCell).click();
     await expect(page.locator(ProjectView.root)).toBeVisible({ timeout: 30_000 });
 
     // Open URL pattern check.
@@ -77,21 +90,35 @@ test.describe('projects', () => {
       .filter({ has: page.locator(ProjectList.nameCell, { hasText: name }) });
     await expect(row).toHaveCount(1);
 
-    // Trash.
+    // Trash. The popup menu (AvailableProjectPresenter#addTrashAction)
+    // tracks selection via mousemove and executes on mouseup, but the
+    // FocusPanel that hosts the handlers has a `BlurEvent` dismiss handler,
+    // so a synthetic click can race the focus loss. Move the mouse onto the
+    // item (mousemove sets selectedIndex), then dispatch a real mouseup
+    // event so the GWT handler fires before the popup blurs.
     await row.locator(ProjectList.menuButton).click();
-    await page.locator('role=menuitem >> text=/Trash|Move to Trash/').click();
+    const trashItem = page.locator('.wp-popup-menu__item').filter({ hasText: /Move to trash/i });
+    await trashItem.hover();
+    await trashItem.dispatchEvent('mouseup');
+    // Wait for the project to drop out of the default (non-trash) view.
+    await expect(row).toHaveCount(0);
     await page.locator(ProjectList.filters.trash).check();
     await expect(
       page.locator(ProjectList.rows)
         .filter({ has: page.locator(ProjectList.nameCell, { hasText: name }) }),
     ).toHaveCount(1);
 
-    // Restore.
+    // Restore. The same menu item flips to "Remove from trash" when the
+    // project is already trashed.
     const trashedRow = page
       .locator(ProjectList.rows)
       .filter({ has: page.locator(ProjectList.nameCell, { hasText: name }) });
+    await expect(trashedRow).toBeVisible();
     await trashedRow.locator(ProjectList.menuButton).click();
-    await page.locator('role=menuitem >> text=/Restore/').click();
+    const restoreItem = page.locator('.wp-popup-menu__item').filter({ hasText: /Remove from trash/i });
+    await expect(restoreItem).toBeVisible();
+    await restoreItem.hover();
+    await restoreItem.click();
     await page.locator(ProjectList.filters.trash).uncheck();
     await expect(
       page.locator(ProjectList.rows)
@@ -99,13 +126,18 @@ test.describe('projects', () => {
     ).toHaveCount(1);
   });
 
-  test('P11: sharing dialog opens from project menu', async ({ project, page }) => {
+  test('P11: project row menu exposes core actions', async ({ project, page }) => {
+    // The project list row menu (AvailableProjectPresenter) exposes Open,
+    // Open in new window, Download and Move to trash. Sharing lives on the
+    // project's topbar, not in this menu.
     await page.goto('/#projects/list');
     const row = page
       .locator(ProjectList.rows)
       .filter({ has: page.locator(ProjectList.nameCell, { hasText: project.name }) });
     await row.locator(ProjectList.menuButton).click();
-    await page.locator('role=menuitem >> text=/Sharing/').click();
-    await expect(page.locator('role=dialog:has-text("Sharing")')).toBeVisible();
+    // Use exact-text match — "Open" alone would also match "Open in new window".
+    for (const label of [/^Open$/, /^Download$/, /^Move to trash$/]) {
+      await expect(page.locator('.wp-popup-menu__item').filter({ hasText: label })).toBeVisible();
+    }
   });
 });

--- a/playwright/tests/02-projects.spec.ts
+++ b/playwright/tests/02-projects.spec.ts
@@ -92,19 +92,18 @@ test.describe('projects', () => {
 
     // Trash. The popup menu (AvailableProjectPresenter#addTrashAction)
     // tracks selection via mousemove and executes on mouseup, so hover the
-    // item before clicking to set selectedIndex. The trash dispatch fires,
-    // but ProjectMovedToTrashEvent does not reach the client to refresh the
-    // local cache — and the OWNED_BY_ME / SHARED_WITH_ME / TRASH filters
-    // are OR'd, so we can't verify trash worked just by toggling a filter
-    // (the row would still appear under Owned by Me from the stale cache).
-    // Reload the page to force a fresh GetAvailableProjectsAction.
+    // item before clicking to set selectedIndex.
+    // TrashManagerRequestHandlerImpl now fires ProjectMovedToTrashEvent
+    // on dispatch success (matching how CreateNewProjectPresenter fires
+    // ProjectCreatedEvent), so ProjectManagerPresenter updates the cache
+    // and the row drops out of the default view without a reload — same
+    // as a real user would see.
     await row.locator(ProjectList.menuButton).click();
     const trashItem = page.locator('.wp-popup-menu__item').filter({ hasText: /Move to trash/i });
     await trashItem.hover();
     await trashItem.click();
-    await page.reload();
     // Default filters are OWNED_BY_ME + SHARED_WITH_ME (no Trash); a trashed
-    // project must NOT appear there.
+    // project must NOT appear there once the cache has been updated.
     await expect(row).toHaveCount(0);
     await page.locator(ProjectList.filters.trash).check();
     await expect(row).toHaveCount(1);
@@ -116,9 +115,13 @@ test.describe('projects', () => {
     await expect(restoreItem).toBeVisible();
     await restoreItem.hover();
     await restoreItem.click();
-    await page.reload();
-    // Default filters again — the restored project should reappear without
-    // needing the Trash filter.
+    // ProjectMovedFromTrashEvent fires on dispatch success → the cache
+    // entry flips back to inTrash=false. With OWNED_BY_ME + SHARED_WITH_ME
+    // + TRASH all checked the row stays visible (now matching
+    // OWNED_BY_ME instead of TRASH — filters are OR'd), so to prove the
+    // restore actually took effect, drop the Trash filter and confirm the
+    // row is still listed under the defaults.
+    await page.locator(ProjectList.filters.trash).uncheck();
     await expect(row).toHaveCount(1);
   });
 

--- a/playwright/tests/03-classes.spec.ts
+++ b/playwright/tests/03-classes.spec.ts
@@ -1,0 +1,83 @@
+import { test, expect } from '../support/fixtures';
+import {
+  CreateEntityDialog,
+  FrameEditor,
+  Hierarchy,
+  ProjectView,
+} from '../support/selectors';
+
+/**
+ * Class hierarchy CRUD. Each test starts with a freshly-created project
+ * (via the `project` fixture) sitting on the default Classes perspective.
+ */
+
+async function createClassUnder(
+  page: import('@playwright/test').Page,
+  parentLabel: string,
+  newLabel: string,
+): Promise<void> {
+  await page.locator(Hierarchy.treeNode(parentLabel)).first().click();
+  await page.locator(Hierarchy.toolbar.create).first().click();
+  await expect(page.locator(CreateEntityDialog.root)).toBeVisible();
+  await page.locator(CreateEntityDialog.name).fill(newLabel);
+  await page.locator(CreateEntityDialog.submit).click();
+  await expect(page.locator(Hierarchy.treeNode(newLabel))).toBeVisible({
+    timeout: 15_000,
+  });
+}
+
+test.describe('class hierarchy', () => {
+  test('C1+C2: Classes is default; owl:Thing root with frame editor', async ({
+    page,
+    project,
+  }) => {
+    await expect(page.locator(ProjectView.root)).toBeVisible();
+    await expect(page.locator(Hierarchy.treeNode('owl:Thing'))).toBeVisible();
+    await page.locator(Hierarchy.treeNode('owl:Thing')).click();
+    await expect(page.locator(FrameEditor.annotationsSection)).toBeVisible();
+    await expect(page.locator(FrameEditor.classesSection)).toBeVisible();
+    await expect(page.locator(FrameEditor.relationshipsSection)).toBeVisible();
+  });
+
+  test('C3: create sub-class under owl:Thing', async ({ page, project }) => {
+    await createClassUnder(page, 'owl:Thing', 'Vehicle');
+  });
+
+  test('C4: empty name is rejected', async ({ page, project }) => {
+    await page.locator(Hierarchy.treeNode('owl:Thing')).first().click();
+    await page.locator(Hierarchy.toolbar.create).first().click();
+    await expect(page.locator(CreateEntityDialog.root)).toBeVisible();
+    await page.locator(CreateEntityDialog.submit).click();
+    // Dialog stays open — no class was created.
+    await expect(page.locator(CreateEntityDialog.root)).toBeVisible();
+    await page.locator(CreateEntityDialog.cancel).click();
+  });
+
+  test('C5: create child under a non-root class', async ({ page, project }) => {
+    await createClassUnder(page, 'owl:Thing', 'Vehicle');
+    await createClassUnder(page, 'Vehicle', 'Car');
+  });
+
+  test('C7: right-click context menu exposes core actions', async ({
+    page,
+    project,
+  }) => {
+    await page.locator(Hierarchy.treeNode('owl:Thing')).first().click({ button: 'right' });
+    const menu = page.locator(Hierarchy.contextMenu);
+    await expect(menu).toBeVisible();
+    for (const label of ['Create', 'Delete', 'Watch']) {
+      await expect(menu.locator(`text=${label}`).first()).toBeVisible();
+    }
+    await page.keyboard.press('Escape');
+  });
+
+  test('C8: delete a leaf class', async ({ page, project }) => {
+    await createClassUnder(page, 'owl:Thing', 'Vehicle');
+    await page.locator(Hierarchy.treeNode('Vehicle')).click();
+    await page.locator(Hierarchy.toolbar.delete).first().click();
+    // Some delete flows show a confirmation prompt; accept if present.
+    const confirm = page.locator('role=button >> text=/OK|Delete|Yes/').first();
+    if (await confirm.isVisible().catch(() => false)) await confirm.click();
+    await expect(page.locator(Hierarchy.treeNode('Vehicle'))).toHaveCount(0);
+  });
+});

--- a/playwright/tests/04-object-properties.spec.ts
+++ b/playwright/tests/04-object-properties.spec.ts
@@ -1,0 +1,62 @@
+import { test, expect } from '../support/fixtures';
+import {
+  CreateEntityDialog,
+  Hierarchy,
+  ProjectView,
+} from '../support/selectors';
+
+test.describe('object properties', () => {
+  test.beforeEach(async ({ page, project }) => {
+    await page.locator(ProjectView.tab('Object Properties')).click();
+    await expect(page.locator(Hierarchy.treeNode('owl:topObjectProperty'))).toBeVisible({
+      timeout: 15_000,
+    });
+  });
+
+  test('OP1: switch to Object Properties shows the topObjectProperty root', async ({
+    page,
+  }) => {
+    await expect(page.locator(Hierarchy.treeNode('owl:topObjectProperty'))).toBeVisible();
+  });
+
+  test('OP2: create object property hasPart', async ({ page }) => {
+    await page.locator(Hierarchy.treeNode('owl:topObjectProperty')).click();
+    await page.locator(Hierarchy.toolbar.create).first().click();
+    await expect(page.locator(CreateEntityDialog.root)).toBeVisible();
+    await page.locator(CreateEntityDialog.name).fill('hasPart');
+    await page.locator(CreateEntityDialog.submit).click();
+    await expect(page.locator(Hierarchy.treeNode('hasPart'))).toBeVisible({
+      timeout: 15_000,
+    });
+  });
+
+  test('OP3: create sub-property', async ({ page }) => {
+    await page.locator(Hierarchy.treeNode('owl:topObjectProperty')).click();
+    await page.locator(Hierarchy.toolbar.create).first().click();
+    await page.locator(CreateEntityDialog.name).fill('hasPart');
+    await page.locator(CreateEntityDialog.submit).click();
+    await expect(page.locator(Hierarchy.treeNode('hasPart'))).toBeVisible();
+
+    await page.locator(Hierarchy.treeNode('hasPart')).click();
+    await page.locator(Hierarchy.toolbar.create).first().click();
+    await page.locator(CreateEntityDialog.name).fill('hasEngine');
+    await page.locator(CreateEntityDialog.submit).click();
+    await expect(page.locator(Hierarchy.treeNode('hasEngine'))).toBeVisible({
+      timeout: 15_000,
+    });
+  });
+
+  test('OP8: delete a property', async ({ page }) => {
+    await page.locator(Hierarchy.treeNode('owl:topObjectProperty')).click();
+    await page.locator(Hierarchy.toolbar.create).first().click();
+    await page.locator(CreateEntityDialog.name).fill('temporaryProp');
+    await page.locator(CreateEntityDialog.submit).click();
+    await expect(page.locator(Hierarchy.treeNode('temporaryProp'))).toBeVisible();
+
+    await page.locator(Hierarchy.treeNode('temporaryProp')).click();
+    await page.locator(Hierarchy.toolbar.delete).first().click();
+    const confirm = page.locator('role=button >> text=/OK|Delete|Yes/').first();
+    if (await confirm.isVisible().catch(() => false)) await confirm.click();
+    await expect(page.locator(Hierarchy.treeNode('temporaryProp'))).toHaveCount(0);
+  });
+});

--- a/playwright/tests/04-object-properties.spec.ts
+++ b/playwright/tests/04-object-properties.spec.ts
@@ -1,13 +1,12 @@
-import { test, expect } from '../support/fixtures';
+import { test, expect, goToPerspective } from '../support/fixtures';
 import {
   CreateEntityDialog,
   Hierarchy,
-  ProjectView,
 } from '../support/selectors';
 
 test.describe('object properties', () => {
   test.beforeEach(async ({ page, project }) => {
-    await page.locator(ProjectView.tab('Object Properties')).click();
+    await goToPerspective(page, 'Object Properties');
     await expect(page.locator(Hierarchy.treeNode('owl:topObjectProperty'))).toBeVisible({
       timeout: 15_000,
     });

--- a/playwright/tests/05-data-properties.spec.ts
+++ b/playwright/tests/05-data-properties.spec.ts
@@ -1,0 +1,45 @@
+import { test, expect } from '../support/fixtures';
+import {
+  CreateEntityDialog,
+  Hierarchy,
+  ProjectView,
+} from '../support/selectors';
+
+test.describe('data properties', () => {
+  test.beforeEach(async ({ page, project }) => {
+    await page.locator(ProjectView.tab('Data Properties')).click();
+    await expect(page.locator(Hierarchy.treeNode('owl:topDataProperty'))).toBeVisible({
+      timeout: 15_000,
+    });
+  });
+
+  test('DP1: Data Properties perspective shows the topDataProperty root', async ({
+    page,
+  }) => {
+    await expect(page.locator(Hierarchy.treeNode('owl:topDataProperty'))).toBeVisible();
+  });
+
+  test('DP2: create data property hasWeight', async ({ page }) => {
+    await page.locator(Hierarchy.treeNode('owl:topDataProperty')).click();
+    await page.locator(Hierarchy.toolbar.create).first().click();
+    await page.locator(CreateEntityDialog.name).fill('hasWeight');
+    await page.locator(CreateEntityDialog.submit).click();
+    await expect(page.locator(Hierarchy.treeNode('hasWeight'))).toBeVisible({
+      timeout: 15_000,
+    });
+  });
+
+  test('DP6: delete a data property', async ({ page }) => {
+    await page.locator(Hierarchy.treeNode('owl:topDataProperty')).click();
+    await page.locator(Hierarchy.toolbar.create).first().click();
+    await page.locator(CreateEntityDialog.name).fill('tempDataProp');
+    await page.locator(CreateEntityDialog.submit).click();
+    await expect(page.locator(Hierarchy.treeNode('tempDataProp'))).toBeVisible();
+
+    await page.locator(Hierarchy.treeNode('tempDataProp')).click();
+    await page.locator(Hierarchy.toolbar.delete).first().click();
+    const confirm = page.locator('role=button >> text=/OK|Delete|Yes/').first();
+    if (await confirm.isVisible().catch(() => false)) await confirm.click();
+    await expect(page.locator(Hierarchy.treeNode('tempDataProp'))).toHaveCount(0);
+  });
+});

--- a/playwright/tests/05-data-properties.spec.ts
+++ b/playwright/tests/05-data-properties.spec.ts
@@ -1,13 +1,12 @@
-import { test, expect } from '../support/fixtures';
+import { test, expect, goToPerspective } from '../support/fixtures';
 import {
   CreateEntityDialog,
   Hierarchy,
-  ProjectView,
 } from '../support/selectors';
 
 test.describe('data properties', () => {
   test.beforeEach(async ({ page, project }) => {
-    await page.locator(ProjectView.tab('Data Properties')).click();
+    await goToPerspective(page, 'Data Properties');
     await expect(page.locator(Hierarchy.treeNode('owl:topDataProperty'))).toBeVisible({
       timeout: 15_000,
     });

--- a/playwright/tests/06-annotation-properties.spec.ts
+++ b/playwright/tests/06-annotation-properties.spec.ts
@@ -1,13 +1,12 @@
-import { test, expect } from '../support/fixtures';
+import { test, expect, goToPerspective } from '../support/fixtures';
 import {
   CreateEntityDialog,
   Hierarchy,
-  ProjectView,
 } from '../support/selectors';
 
 test.describe('annotation properties', () => {
   test.beforeEach(async ({ page, project }) => {
-    await page.locator(ProjectView.tab('Annotation Properties')).click();
+    await goToPerspective(page, 'Annotation Properties');
     // Standard built-in annotation properties are guaranteed to be present.
     await expect(page.locator(Hierarchy.treeNode('rdfs:label'))).toBeVisible({
       timeout: 15_000,

--- a/playwright/tests/06-annotation-properties.spec.ts
+++ b/playwright/tests/06-annotation-properties.spec.ts
@@ -1,0 +1,45 @@
+import { test, expect } from '../support/fixtures';
+import {
+  CreateEntityDialog,
+  Hierarchy,
+  ProjectView,
+} from '../support/selectors';
+
+test.describe('annotation properties', () => {
+  test.beforeEach(async ({ page, project }) => {
+    await page.locator(ProjectView.tab('Annotation Properties')).click();
+    // Standard built-in annotation properties are guaranteed to be present.
+    await expect(page.locator(Hierarchy.treeNode('rdfs:label'))).toBeVisible({
+      timeout: 15_000,
+    });
+  });
+
+  test('AP1: Annotation Properties perspective lists rdfs:label', async ({ page }) => {
+    await expect(page.locator(Hierarchy.treeNode('rdfs:label'))).toBeVisible();
+    await expect(page.locator(Hierarchy.treeNode('rdfs:comment'))).toBeVisible();
+  });
+
+  test('AP2: create custom annotation property', async ({ page }) => {
+    await page.locator(Hierarchy.treeNode('rdfs:label')).click();
+    await page.locator(Hierarchy.toolbar.create).first().click();
+    await page.locator(CreateEntityDialog.name).fill('icaoCode');
+    await page.locator(CreateEntityDialog.submit).click();
+    await expect(page.locator(Hierarchy.treeNode('icaoCode'))).toBeVisible({
+      timeout: 15_000,
+    });
+  });
+
+  test('AP4: delete a custom annotation property', async ({ page }) => {
+    await page.locator(Hierarchy.treeNode('rdfs:label')).click();
+    await page.locator(Hierarchy.toolbar.create).first().click();
+    await page.locator(CreateEntityDialog.name).fill('tempAnnotation');
+    await page.locator(CreateEntityDialog.submit).click();
+    await expect(page.locator(Hierarchy.treeNode('tempAnnotation'))).toBeVisible();
+
+    await page.locator(Hierarchy.treeNode('tempAnnotation')).click();
+    await page.locator(Hierarchy.toolbar.delete).first().click();
+    const confirm = page.locator('role=button >> text=/OK|Delete|Yes/').first();
+    if (await confirm.isVisible().catch(() => false)) await confirm.click();
+    await expect(page.locator(Hierarchy.treeNode('tempAnnotation'))).toHaveCount(0);
+  });
+});

--- a/playwright/tests/07-individuals.spec.ts
+++ b/playwright/tests/07-individuals.spec.ts
@@ -1,0 +1,44 @@
+import { test, expect } from '../support/fixtures';
+import {
+  CreateEntityDialog,
+  ProjectView,
+} from '../support/selectors';
+
+test.describe('individuals', () => {
+  test.beforeEach(async ({ page, project }) => {
+    await page.locator(ProjectView.tab('Individuals')).click();
+  });
+
+  test('I1: Individuals perspective starts empty for a fresh project', async ({
+    page,
+  }) => {
+    await expect(page.locator(ProjectView.root)).toBeVisible();
+    // The list portlet is visible even when empty; just confirm the
+    // perspective rendered something interactable.
+    await expect(page.locator('text=/Individuals/i').first()).toBeVisible();
+  });
+
+  test('I2: create individual Boeing747 (no type)', async ({ page }) => {
+    // Individuals tab uses the same Create toolbar pattern.
+    await page.locator('button[title="Create"], button:has-text("Create")').first().click();
+    await expect(page.locator(CreateEntityDialog.root)).toBeVisible();
+    await page.locator(CreateEntityDialog.name).fill('Boeing747');
+    await page.locator(CreateEntityDialog.submit).click();
+    await expect(page.locator('text=Boeing747').first()).toBeVisible({
+      timeout: 15_000,
+    });
+  });
+
+  test('I8: delete an individual', async ({ page }) => {
+    await page.locator('button[title="Create"], button:has-text("Create")').first().click();
+    await page.locator(CreateEntityDialog.name).fill('TempIndividual');
+    await page.locator(CreateEntityDialog.submit).click();
+    await expect(page.locator('text=TempIndividual').first()).toBeVisible();
+
+    await page.locator('text=TempIndividual').first().click();
+    await page.locator('button[title="Delete"], button:has-text("Delete")').first().click();
+    const confirm = page.locator('role=button >> text=/OK|Delete|Yes/').first();
+    if (await confirm.isVisible().catch(() => false)) await confirm.click();
+    await expect(page.locator('text=TempIndividual')).toHaveCount(0);
+  });
+});

--- a/playwright/tests/07-individuals.spec.ts
+++ b/playwright/tests/07-individuals.spec.ts
@@ -33,12 +33,24 @@ test.describe('individuals', () => {
     await page.locator('button.wp-btn-g--create-individual').first().click();
     await page.locator(CreateEntityDialog.name).fill('TempIndividual');
     await page.locator(CreateEntityDialog.submit).click();
-    await expect(page.locator('text=TempIndividual').first()).toBeVisible();
 
-    await page.locator('text=TempIndividual').first().click();
+    // Scope the row selector to the list cell — `text=TempIndividual` would
+    // also match the project feed link and the frame editor, masking
+    // whether the row was actually added/removed.
+    const listRow = page
+      .locator('.wp-entity-node__display-name')
+      .filter({ hasText: 'TempIndividual' });
+    await expect(listRow).toBeVisible();
+
+    await listRow.click();
     await page.locator('button.wp-btn-g--delete-individual').first().click();
-    const confirm = page.locator('role=button >> text=/OK|Delete|Yes/').first();
-    if (await confirm.isVisible().catch(() => false)) await confirm.click();
-    await expect(page.locator('text=TempIndividual')).toHaveCount(0);
+
+    // Auto-waiting click on the modal-scoped Delete — `isVisible()` does
+    // not auto-wait and was firing before the confirm modal had rendered.
+    await page
+      .locator('.wp-modal button.wp-btn--dialog:has-text("Delete")')
+      .click();
+
+    await expect(listRow).toHaveCount(0);
   });
 });

--- a/playwright/tests/07-individuals.spec.ts
+++ b/playwright/tests/07-individuals.spec.ts
@@ -20,7 +20,7 @@ test.describe('individuals', () => {
 
   test('I2: create individual Boeing747 (no type)', async ({ page }) => {
     // Individuals tab uses the same Create toolbar pattern.
-    await page.locator('button[title="Create"], button:has-text("Create")').first().click();
+    await page.locator('button.wp-btn-g--create-individual').first().click();
     await expect(page.locator(CreateEntityDialog.root)).toBeVisible();
     await page.locator(CreateEntityDialog.name).fill('Boeing747');
     await page.locator(CreateEntityDialog.submit).click();
@@ -30,13 +30,13 @@ test.describe('individuals', () => {
   });
 
   test('I8: delete an individual', async ({ page }) => {
-    await page.locator('button[title="Create"], button:has-text("Create")').first().click();
+    await page.locator('button.wp-btn-g--create-individual').first().click();
     await page.locator(CreateEntityDialog.name).fill('TempIndividual');
     await page.locator(CreateEntityDialog.submit).click();
     await expect(page.locator('text=TempIndividual').first()).toBeVisible();
 
     await page.locator('text=TempIndividual').first().click();
-    await page.locator('button[title="Delete"], button:has-text("Delete")').first().click();
+    await page.locator('button.wp-btn-g--delete-individual').first().click();
     const confirm = page.locator('role=button >> text=/OK|Delete|Yes/').first();
     if (await confirm.isVisible().catch(() => false)) await confirm.click();
     await expect(page.locator('text=TempIndividual')).toHaveCount(0);

--- a/playwright/tests/08-search.spec.ts
+++ b/playwright/tests/08-search.spec.ts
@@ -19,7 +19,10 @@ test.describe('search', () => {
     }
     await expect(page.locator(Search.modal)).toBeVisible();
 
-    await page.locator(Search.input).first().fill('Aircraft');
+    // GWT's SearchViewImpl only debounces a search on KeyUpEvent — there is no
+    // ValueChangeHandler — so locator.fill() (which dispatches a single input
+    // event) never triggers the search. Type the term key-by-key instead.
+    await page.locator(Search.input).first().pressSequentially('Aircraft');
     // The search modal renders matched entities; ensure at least one of
     // them has the seeded label as visible text. The modal stacks above
     // the hierarchy tree so any "Aircraft" rendering on screen now belongs

--- a/playwright/tests/08-search.spec.ts
+++ b/playwright/tests/08-search.spec.ts
@@ -1,0 +1,27 @@
+import { test, expect } from '../support/fixtures';
+import { CreateEntityDialog, Hierarchy, Search } from '../support/selectors';
+
+test.describe('search', () => {
+  test('S1+S2: open search modal and find a class', async ({ page, project }) => {
+    // Seed a class so search has something to find.
+    await page.locator(Hierarchy.treeNode('owl:Thing')).first().click();
+    await page.locator(Hierarchy.toolbar.create).first().click();
+    await page.locator(CreateEntityDialog.name).fill('Aircraft');
+    await page.locator(CreateEntityDialog.submit).click();
+    await expect(page.locator(Hierarchy.treeNode('Aircraft'))).toBeVisible();
+
+    // Open the search modal. The trigger varies by skin — try a few.
+    const trigger = page.locator(Search.trigger).first();
+    if (await trigger.isVisible().catch(() => false)) {
+      await trigger.click();
+    } else {
+      await page.keyboard.press('Control+Alt+f');
+    }
+    await expect(page.locator(Search.modal)).toBeVisible();
+
+    await page.locator(Search.input).first().fill('Aircraft');
+    await expect(page.locator(Search.result).first()).toBeVisible({
+      timeout: 10_000,
+    });
+  });
+});

--- a/playwright/tests/08-search.spec.ts
+++ b/playwright/tests/08-search.spec.ts
@@ -20,8 +20,12 @@ test.describe('search', () => {
     await expect(page.locator(Search.modal)).toBeVisible();
 
     await page.locator(Search.input).first().fill('Aircraft');
-    await expect(page.locator(Search.result).first()).toBeVisible({
-      timeout: 10_000,
+    // The search modal renders matched entities; ensure at least one of
+    // them has the seeded label as visible text. The modal stacks above
+    // the hierarchy tree so any "Aircraft" rendering on screen now belongs
+    // to the search result list.
+    await expect(page.locator('.wp-modal').getByText('Aircraft').first()).toBeVisible({
+      timeout: 15_000,
     });
   });
 });

--- a/playwright/tests/09-history-and-comments.spec.ts
+++ b/playwright/tests/09-history-and-comments.spec.ts
@@ -1,0 +1,32 @@
+import { test, expect } from '../support/fixtures';
+import {
+  CreateEntityDialog,
+  Hierarchy,
+  ProjectView,
+} from '../support/selectors';
+
+test.describe('history and comments', () => {
+  test('H1: History perspective lists revisions after edits', async ({
+    page,
+    project,
+  }) => {
+    // Create a class so there is at least one revision to display.
+    await page.locator(Hierarchy.treeNode('owl:Thing')).first().click();
+    await page.locator(Hierarchy.toolbar.create).first().click();
+    await page.locator(CreateEntityDialog.name).fill('HistoryProbe');
+    await page.locator(CreateEntityDialog.submit).click();
+    await expect(page.locator(Hierarchy.treeNode('HistoryProbe'))).toBeVisible();
+
+    await page.locator(ProjectView.tab('History')).click();
+    // Expect at least one revision row. The history portlet renders rows
+    // with timestamps; we look for any element containing a 4-digit year.
+    await expect(
+      page.locator(`text=/${new Date().getFullYear()}/`).first(),
+    ).toBeVisible({ timeout: 15_000 });
+  });
+
+  test('H3: Comments perspective opens', async ({ page, project }) => {
+    await page.locator(ProjectView.tab('Comments')).click();
+    await expect(page.locator(ProjectView.root)).toBeVisible();
+  });
+});

--- a/playwright/tests/09-history-and-comments.spec.ts
+++ b/playwright/tests/09-history-and-comments.spec.ts
@@ -25,8 +25,10 @@ test.describe('history and comments', () => {
     ).toBeVisible({ timeout: 15_000 });
   });
 
-  test('H3: Comments perspective opens', async ({ page, project }) => {
-    await page.locator(ProjectView.tab('Comments')).click();
+  test('H3: Discussions perspective opens', async ({ page, project }) => {
+    // The "Comments" perspective was renamed "Discussions" in the default
+    // perspective set; the underlying portlet (CommentsByEntity) is the same.
+    await page.locator(ProjectView.tab('Discussions')).click();
     await expect(page.locator(ProjectView.root)).toBeVisible();
   });
 });

--- a/playwright/tests/10-sharing.spec.ts
+++ b/playwright/tests/10-sharing.spec.ts
@@ -1,34 +1,29 @@
 import { test, expect } from '../support/fixtures';
-import { ProjectList, Sharing } from '../support/selectors';
+import { Sharing } from '../support/selectors';
+
+/**
+ * Sharing settings live on a dedicated SharingSettingsPlace, not a modal
+ * dialog. The "Share" button on the project's topbar routes there.
+ */
 
 test.describe('sharing', () => {
-  test('SH1: sharing dialog opens from project menu', async ({ page, project }) => {
-    await page.goto('/#projects/list');
-    const row = page
-      .locator(ProjectList.rows)
-      .filter({ has: page.locator(ProjectList.nameCell, { hasText: project.name }) });
-    await row.locator(ProjectList.menuButton).click();
-    await page.locator('role=menuitem >> text=/Sharing/').click();
-    await expect(page.locator(Sharing.dialog)).toBeVisible();
+  test('SH1: sharing page opens from the topbar Share button', async ({
+    page,
+    project,
+  }) => {
+    await page.locator(Sharing.topBarButton).click();
+    await expect(page).toHaveURL(/#projects\/[a-f0-9-]+\/sharing/);
+    await expect(page.locator(Sharing.linkSharingToggle).first()).toBeVisible();
   });
 
   test('SH2: link sharing toggle reveals permission dropdown', async ({
     page,
     project,
   }) => {
-    await page.goto('/#projects/list');
-    const row = page
-      .locator(ProjectList.rows)
-      .filter({ has: page.locator(ProjectList.nameCell, { hasText: project.name }) });
-    await row.locator(ProjectList.menuButton).click();
-    await page.locator('role=menuitem >> text=/Sharing/').click();
-    const dialog = page.locator(Sharing.dialog);
-    await expect(dialog).toBeVisible();
-
-    const toggle = dialog.locator(Sharing.linkSharingToggle).first();
-    if (await toggle.isVisible().catch(() => false)) {
-      await toggle.check();
-      await expect(dialog.locator(Sharing.linkSharingPermission).first()).toBeEnabled();
-    }
+    await page.locator(Sharing.topBarButton).click();
+    const toggle = page.locator(Sharing.linkSharingToggle).first();
+    await expect(toggle).toBeVisible();
+    if (!(await toggle.isChecked())) await toggle.check();
+    await expect(page.locator(Sharing.linkSharingPermission).first()).toBeVisible();
   });
 });

--- a/playwright/tests/10-sharing.spec.ts
+++ b/playwright/tests/10-sharing.spec.ts
@@ -1,0 +1,34 @@
+import { test, expect } from '../support/fixtures';
+import { ProjectList, Sharing } from '../support/selectors';
+
+test.describe('sharing', () => {
+  test('SH1: sharing dialog opens from project menu', async ({ page, project }) => {
+    await page.goto('/#projects/list');
+    const row = page
+      .locator(ProjectList.rows)
+      .filter({ has: page.locator(ProjectList.nameCell, { hasText: project.name }) });
+    await row.locator(ProjectList.menuButton).click();
+    await page.locator('role=menuitem >> text=/Sharing/').click();
+    await expect(page.locator(Sharing.dialog)).toBeVisible();
+  });
+
+  test('SH2: link sharing toggle reveals permission dropdown', async ({
+    page,
+    project,
+  }) => {
+    await page.goto('/#projects/list');
+    const row = page
+      .locator(ProjectList.rows)
+      .filter({ has: page.locator(ProjectList.nameCell, { hasText: project.name }) });
+    await row.locator(ProjectList.menuButton).click();
+    await page.locator('role=menuitem >> text=/Sharing/').click();
+    const dialog = page.locator(Sharing.dialog);
+    await expect(dialog).toBeVisible();
+
+    const toggle = dialog.locator(Sharing.linkSharingToggle).first();
+    if (await toggle.isVisible().catch(() => false)) {
+      await toggle.check();
+      await expect(dialog.locator(Sharing.linkSharingPermission).first()).toBeEnabled();
+    }
+  });
+});

--- a/playwright/tests/scenarios/airplane-ontology.spec.ts
+++ b/playwright/tests/scenarios/airplane-ontology.spec.ts
@@ -1,5 +1,5 @@
 import type { Page } from '@playwright/test';
-import { test, expect } from '../../support/fixtures';
+import { test, expect, goToPerspective } from '../../support/fixtures';
 import {
   CreateEntityDialog,
   Hierarchy,
@@ -32,7 +32,7 @@ async function createSubClass(page: Page, parent: string, child: string): Promis
 }
 
 async function createObjectProperty(page: Page, parent: string, name: string): Promise<void> {
-  await page.locator(ProjectView.tab('Object Properties')).click();
+  await goToPerspective(page, 'Object Properties');
   await page.locator(Hierarchy.treeNode(parent)).first().click();
   await page.locator(Hierarchy.toolbar.create).first().click();
   await page.locator(CreateEntityDialog.name).fill(name);
@@ -43,7 +43,7 @@ async function createObjectProperty(page: Page, parent: string, name: string): P
 }
 
 async function createDataProperty(page: Page, parent: string, name: string): Promise<void> {
-  await page.locator(ProjectView.tab('Data Properties')).click();
+  await goToPerspective(page, 'Data Properties');
   await page.locator(Hierarchy.treeNode(parent)).first().click();
   await page.locator(Hierarchy.toolbar.create).first().click();
   await page.locator(CreateEntityDialog.name).fill(name);
@@ -55,7 +55,7 @@ async function createDataProperty(page: Page, parent: string, name: string): Pro
 
 async function createIndividual(page: Page, name: string): Promise<void> {
   await page.locator(ProjectView.tab('Individuals')).click();
-  await page.locator('button[title="Create"], button:has-text("Create")').first().click();
+  await page.locator('button.wp-btn-g--create-individual').first().click();
   await page.locator(CreateEntityDialog.name).fill(name);
   await page.locator(CreateEntityDialog.submit).click();
   await expect(page.locator(`text=${name}`).first()).toBeVisible({ timeout: 15_000 });

--- a/playwright/tests/scenarios/airplane-ontology.spec.ts
+++ b/playwright/tests/scenarios/airplane-ontology.spec.ts
@@ -1,0 +1,108 @@
+import type { Page } from '@playwright/test';
+import { test, expect } from '../../support/fixtures';
+import {
+  CreateEntityDialog,
+  Hierarchy,
+  ProjectView,
+} from '../../support/selectors';
+
+/**
+ * Airplane ontology scenario — issue #267.
+ *
+ * Builds ~40 axioms in a fresh project, exercising the atomic actions
+ * tested individually in earlier specs. Runs sequentially. Long-running:
+ * budget ~90s on a developer laptop, more in CI.
+ */
+
+test.describe.configure({ mode: 'serial' });
+
+async function selectClass(page: Page, label: string): Promise<void> {
+  await page.locator(ProjectView.tab('Classes')).click();
+  await page.locator(Hierarchy.treeNode(label)).first().click();
+}
+
+async function createSubClass(page: Page, parent: string, child: string): Promise<void> {
+  await selectClass(page, parent);
+  await page.locator(Hierarchy.toolbar.create).first().click();
+  await page.locator(CreateEntityDialog.name).fill(child);
+  await page.locator(CreateEntityDialog.submit).click();
+  await expect(page.locator(Hierarchy.treeNode(child))).toBeVisible({
+    timeout: 15_000,
+  });
+}
+
+async function createObjectProperty(page: Page, parent: string, name: string): Promise<void> {
+  await page.locator(ProjectView.tab('Object Properties')).click();
+  await page.locator(Hierarchy.treeNode(parent)).first().click();
+  await page.locator(Hierarchy.toolbar.create).first().click();
+  await page.locator(CreateEntityDialog.name).fill(name);
+  await page.locator(CreateEntityDialog.submit).click();
+  await expect(page.locator(Hierarchy.treeNode(name))).toBeVisible({
+    timeout: 15_000,
+  });
+}
+
+async function createDataProperty(page: Page, parent: string, name: string): Promise<void> {
+  await page.locator(ProjectView.tab('Data Properties')).click();
+  await page.locator(Hierarchy.treeNode(parent)).first().click();
+  await page.locator(Hierarchy.toolbar.create).first().click();
+  await page.locator(CreateEntityDialog.name).fill(name);
+  await page.locator(CreateEntityDialog.submit).click();
+  await expect(page.locator(Hierarchy.treeNode(name))).toBeVisible({
+    timeout: 15_000,
+  });
+}
+
+async function createIndividual(page: Page, name: string): Promise<void> {
+  await page.locator(ProjectView.tab('Individuals')).click();
+  await page.locator('button[title="Create"], button:has-text("Create")').first().click();
+  await page.locator(CreateEntityDialog.name).fill(name);
+  await page.locator(CreateEntityDialog.submit).click();
+  await expect(page.locator(`text=${name}`).first()).toBeVisible({ timeout: 15_000 });
+}
+
+test('builds the Airplane ontology end-to-end', async ({ page, project }) => {
+  test.setTimeout(180_000);
+
+  // Sub-class hierarchy.
+  await createSubClass(page, 'owl:Thing', 'Vehicle');
+  await createSubClass(page, 'Vehicle', 'Aircraft');
+  await createSubClass(page, 'Aircraft', 'FixedWingAircraft');
+  await createSubClass(page, 'Aircraft', 'Helicopter');
+  await createSubClass(page, 'FixedWingAircraft', 'CommercialAircraft');
+  await createSubClass(page, 'FixedWingAircraft', 'MilitaryAircraft');
+  await createSubClass(page, 'owl:Thing', 'Engine');
+  await createSubClass(page, 'owl:Thing', 'Wing');
+  await createSubClass(page, 'owl:Thing', 'FuselagePart');
+
+  // Object properties.
+  await createObjectProperty(page, 'owl:topObjectProperty', 'hasPart');
+  await createObjectProperty(page, 'hasPart', 'hasEngine');
+  await createObjectProperty(page, 'hasPart', 'hasWing');
+
+  // Data properties.
+  await createDataProperty(page, 'owl:topDataProperty', 'hasWeight');
+  await createDataProperty(page, 'owl:topDataProperty', 'hasMaxAltitude');
+
+  // Individuals.
+  await createIndividual(page, 'Boeing747');
+  await createIndividual(page, 'Boeing747_Engine_1');
+  await createIndividual(page, 'Boeing747_Wing_1');
+  await createIndividual(page, 'AirbusA320');
+  await createIndividual(page, 'F16');
+  await createIndividual(page, 'ApacheHelicopter');
+
+  // Sanity: switch to History and verify several revisions exist.
+  await page.locator(ProjectView.tab('History')).click();
+  const yearStamps = page.locator(`text=/${new Date().getFullYear()}/`);
+  await expect.poll(async () => yearStamps.count(), {
+    timeout: 30_000,
+  }).toBeGreaterThan(10);
+
+  // Reload and confirm the hierarchy survives.
+  await page.reload();
+  await page.locator(ProjectView.tab('Classes')).click();
+  for (const label of ['Vehicle', 'Aircraft', 'FixedWingAircraft', 'Helicopter']) {
+    await expect(page.locator(Hierarchy.treeNode(label))).toBeVisible();
+  }
+});

--- a/playwright/tests/scenarios/airplane-ontology.spec.ts
+++ b/playwright/tests/scenarios/airplane-ontology.spec.ts
@@ -92,17 +92,32 @@ test('builds the Airplane ontology end-to-end', async ({ page, project }) => {
   await createIndividual(page, 'F16');
   await createIndividual(page, 'ApacheHelicopter');
 
-  // Sanity: switch to History and verify several revisions exist.
+  // Sanity: switch to History and verify several revisions exist. The
+  // change list groups all entries from the same day under one date
+  // heading ("... 2026"), so the year only appears once. Count the
+  // per-revision badges instead — ChangeDetailsViewImpl renders each as
+  // an InlineLabel with text "R <n>" (optionally followed by a dropdown
+  // arrow).
   await page.locator(ProjectView.tab('History')).click();
-  const yearStamps = page.locator(`text=/${new Date().getFullYear()}/`);
-  await expect.poll(async () => yearStamps.count(), {
+  const revisionBadges = page.getByText(/^R \d+/);
+  await expect.poll(async () => revisionBadges.count(), {
     timeout: 30_000,
   }).toBeGreaterThan(10);
 
-  // Reload and confirm the hierarchy survives.
+  // Reload and confirm the hierarchy survives. After a fresh load the
+  // class tree is collapsed below owl:Thing, so expand each parent on the
+  // path down to the deepest sub-class via its `.gt-tree__handle` chevron
+  // before asserting visibility.
   await page.reload();
   await page.locator(ProjectView.tab('Classes')).click();
-  for (const label of ['Vehicle', 'Aircraft', 'FixedWingAircraft', 'Helicopter']) {
+  await expect(page.locator(Hierarchy.treeNode('Vehicle'))).toBeVisible();
+  for (const parent of ['Vehicle', 'Aircraft']) {
+    await page
+      .locator(Hierarchy.treeNode(parent))
+      .locator('.gt-tree__handle')
+      .click();
+  }
+  for (const label of ['Aircraft', 'FixedWingAircraft', 'Helicopter']) {
     await expect(page.locator(Hierarchy.treeNode(label))).toBeVisible();
   }
 });

--- a/playwright/tests/scenarios/regression-smoke.spec.ts
+++ b/playwright/tests/scenarios/regression-smoke.spec.ts
@@ -1,0 +1,34 @@
+import { test, expect } from '../../support/fixtures';
+import {
+  CreateEntityDialog,
+  Hierarchy,
+  ProjectView,
+} from '../../support/selectors';
+
+/**
+ * Fast (<30s) sanity scenario. Run with `npm run test:smoke` to get a
+ * yes/no signal on whether the UI is alive across the major surfaces
+ * before investing in the full atomic suite.
+ */
+
+test('login → create project → create class → check history', async ({
+  page,
+  project,
+}) => {
+  // The `project` fixture already brought us to a freshly-created project
+  // sitting on the Classes perspective. Just create one class.
+  await page.locator(Hierarchy.treeNode('owl:Thing')).first().click();
+  await page.locator(Hierarchy.toolbar.create).first().click();
+  await expect(page.locator(CreateEntityDialog.root)).toBeVisible();
+  await page.locator(CreateEntityDialog.name).fill('SmokeProbeClass');
+  await page.locator(CreateEntityDialog.submit).click();
+  await expect(page.locator(Hierarchy.treeNode('SmokeProbeClass'))).toBeVisible();
+
+  // History perspective should now show at least the project-create and
+  // class-create revisions.
+  await page.locator(ProjectView.tab('History')).click();
+  await expect(page.locator(ProjectView.root)).toBeVisible();
+  await expect(
+    page.locator(`text=/${new Date().getFullYear()}/`).first(),
+  ).toBeVisible({ timeout: 15_000 });
+});

--- a/playwright/tsconfig.json
+++ b/playwright/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "types": ["node"]
+  },
+  "include": ["**/*.ts"],
+  "exclude": ["node_modules", "playwright-report", "test-results", ".auth"]
+}

--- a/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/entity/DefaultCreateEntitiesPresenter.java
+++ b/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/entity/DefaultCreateEntitiesPresenter.java
@@ -163,13 +163,22 @@ public class DefaultCreateEntitiesPresenter {
         ChangeRequestId changeRequestId = action.getChangeRequestId();
         dispatchServiceManager.execute(action,
                 result -> {
-                    // We need to wait for the events associated with change request so
-                    // that we can be sure the hierarchy has updated.  Note the events
-                    // get processed and dispatched before the one-shot wait for events
-                    // handler is called.
-                    awaiter.waitForEvents(changeRequestId, events -> {
+                    if (entityType.equals(EntityType.NAMED_INDIVIDUAL)) {
+                        // Individual creation does not produce events that
+                        // implement HasChangeRequestId, and the result
+                        // already carries the created entities — fire the
+                        // handler immediately so the list updates without
+                        // waiting on the awaiter fallback timer.
                         entitiesCreatedHandler.handleEntitiesCreated(result.getEntities());
-                    });
+                    } else {
+                        // Hierarchy types: wait for the EntityHierarchyChangedEvent
+                        // associated with this change request so the tree has
+                        // had a chance to mount the new node before the handler
+                        // tries to select / reveal it.
+                        awaiter.waitForEvents(changeRequestId, events -> {
+                            entitiesCreatedHandler.handleEntitiesCreated(result.getEntities());
+                        });
+                    }
                 });
 
     }

--- a/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/events/ChangeRequestEventAwaiter.java
+++ b/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/events/ChangeRequestEventAwaiter.java
@@ -2,6 +2,7 @@ package edu.stanford.bmir.protege.web.client.events;
 
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
+import com.google.gwt.user.client.Timer;
 import edu.stanford.bmir.protege.web.shared.event.WebProtegeEvent;
 import edu.stanford.bmir.protege.web.shared.inject.ProjectSingleton;
 import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
@@ -10,6 +11,7 @@ import edu.stanford.bmir.protege.web.shared.perspective.HasChangeRequestId;
 import javax.annotation.Nonnull;
 import javax.inject.Inject;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.logging.Logger;
 
@@ -48,6 +50,18 @@ public class ChangeRequestEventAwaiter {
     private static final Logger logger = Logger.getLogger(ChangeRequestEventAwaiter.class.getName());
 
     /**
+     * How long to wait for matching events before delivering an empty event
+     * list to a registered handler. Some change requests do not produce any
+     * events that implement {@link HasChangeRequestId} (e.g. individual
+     * creation fires only {@code BrowserTextChangedEvent} /
+     * {@code NamedIndividualFrameChangedEvent}, which do not carry a
+     * {@link ChangeRequestId}). Without this fallback the handler would
+     * never fire and downstream callers (e.g. the create-entity flow) would
+     * never see their result.
+     */
+    static final int FALLBACK_TIMEOUT_MS = 1500;
+
+    /**
      * Handlers waiting for events keyed by {@link ChangeRequestId}.
      */
     private final Multimap<ChangeRequestId, ChangeRequestEventsHandler> handlers = HashMultimap.create();
@@ -77,12 +91,35 @@ public class ChangeRequestEventAwaiter {
         // Retrieve and remove any buffered events for this ID
         Collection<WebProtegeEvent<?>> alreadyArrivedEvents = bufferedEvents.removeAll(changeRequestId);
         if (alreadyArrivedEvents.isEmpty()) {
-            // No buffered events: store the handler for later delivery
+            // No buffered events: store the handler for later delivery and
+            // arm a fallback timer so the handler still fires if the change
+            // request produces no HasChangeRequestId events.
             handlers.put(changeRequestId, handler);
+            scheduleFallback(() -> {
+                if (handlers.remove(changeRequestId, handler)) {
+                    handler.handle(Collections.emptyList());
+                }
+            });
         } else {
             // Deliver buffered events immediately
             handler.handle(alreadyArrivedEvents);
         }
+    }
+
+    /**
+     * Schedules {@code callback} to run after {@link #FALLBACK_TIMEOUT_MS}
+     * milliseconds. Visible for testing — JVM unit tests may override this
+     * to run synchronously or skip the schedule entirely (the production
+     * implementation uses {@link Timer} which is GWT-only).
+     */
+    protected void scheduleFallback(@Nonnull Runnable callback) {
+        Timer timer = new Timer() {
+            @Override
+            public void run() {
+                callback.run();
+            }
+        };
+        timer.schedule(FALLBACK_TIMEOUT_MS);
     }
 
     /**

--- a/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/events/ChangeRequestEventAwaiter.java
+++ b/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/events/ChangeRequestEventAwaiter.java
@@ -10,6 +10,7 @@ import edu.stanford.bmir.protege.web.shared.perspective.HasChangeRequestId;
 
 import javax.annotation.Nonnull;
 import javax.inject.Inject;
+import javax.inject.Provider;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -72,8 +73,17 @@ public class ChangeRequestEventAwaiter {
      */
     private final Multimap<ChangeRequestId, WebProtegeEvent<?>> bufferedEvents = HashMultimap.create();
 
+    /**
+     * Lazy provider for the project's {@link EventPollingManager}. Lazy
+     * because {@link EventPollingManager} already depends on this class
+     * (via constructor injection) and a direct field would create a Dagger
+     * cycle.
+     */
+    private final Provider<EventPollingManager> eventPollingManagerProvider;
+
     @Inject
-    public ChangeRequestEventAwaiter() {
+    public ChangeRequestEventAwaiter(@Nonnull Provider<EventPollingManager> eventPollingManagerProvider) {
+        this.eventPollingManagerProvider = eventPollingManagerProvider;
     }
 
     /**
@@ -100,9 +110,32 @@ public class ChangeRequestEventAwaiter {
                     handler.handle(Collections.emptyList());
                 }
             });
+            // Also trigger an immediate event poll so the matching events
+            // arrive within one extra round-trip rather than waiting for
+            // the next periodic tick (default 10s — see
+            // EventPollingPeriodProvider). Without this kick, every
+            // hierarchy create incurs the full FALLBACK_TIMEOUT_MS as
+            // dead time before the tree updates and the new node can be
+            // selected.
+            requestImmediatePoll();
         } else {
             // Deliver buffered events immediately
             handler.handle(alreadyArrivedEvents);
+        }
+    }
+
+    /**
+     * Asks the {@link EventPollingManager} to poll for events right now.
+     * Visible for testing — JVM unit tests may override this to capture
+     * the call without touching the GWT-only timer / network stack.
+     */
+    protected void requestImmediatePoll() {
+        try {
+            eventPollingManagerProvider.get().pollForProjectEvents();
+        } catch (RuntimeException e) {
+            // Polling is best-effort; the fallback timer guarantees the
+            // handler eventually fires either way.
+            logger.warning("Immediate event poll failed: " + e.getMessage());
         }
     }
 

--- a/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/hierarchy/DeleteEntitiesPresenter.java
+++ b/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/hierarchy/DeleteEntitiesPresenter.java
@@ -1,11 +1,14 @@
 package edu.stanford.bmir.protege.web.client.hierarchy;
 
+import com.google.common.collect.ImmutableSet;
 import edu.stanford.bmir.protege.web.client.Messages;
 import edu.stanford.bmir.protege.web.client.dispatch.DispatchServiceManager;
 import edu.stanford.bmir.protege.web.client.library.msgbox.MessageBox;
+import edu.stanford.bmir.protege.web.client.uuid.UuidV4Provider;
 import edu.stanford.bmir.protege.web.shared.entity.DeleteEntitiesAction;
 import edu.stanford.bmir.protege.web.shared.entity.EntityNode;
 import edu.stanford.bmir.protege.web.shared.entity.OWLEntityData;
+import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
 import edu.stanford.bmir.protege.web.shared.project.ProjectId;
 import edu.stanford.protege.gwt.graphtree.client.TreeWidget;
 import edu.stanford.protege.gwt.graphtree.shared.tree.TreeNode;
@@ -39,15 +42,20 @@ public class DeleteEntitiesPresenter {
     @Nonnull
     private final ProjectId projectId;
 
+    @Nonnull
+    private final UuidV4Provider uuidV4Provider;
+
     @Inject
     public DeleteEntitiesPresenter(@Nonnull Messages messages,
                                    @Nonnull MessageBox messageBox,
                                    @Nonnull DispatchServiceManager dispatchServiceManager,
-                                   @Nonnull ProjectId projectId) {
+                                   @Nonnull ProjectId projectId,
+                                   @Nonnull UuidV4Provider uuidV4Provider) {
         this.messages = checkNotNull(messages);
         this.messageBox = checkNotNull(messageBox);
         this.dispatchServiceManager = checkNotNull(dispatchServiceManager);
         this.projectId = checkNotNull(projectId);
+        this.uuidV4Provider = checkNotNull(uuidV4Provider);
     }
 
     /**
@@ -117,8 +125,11 @@ public class DeleteEntitiesPresenter {
     private void deleteEntity(@Nonnull Set<OWLEntityData> entities,
                               @Nonnull TreeWidget<EntityNode, OWLEntity> treeWidget) {
         treeWidget.moveSelectionDown();
-        Set<OWLEntity> entitiesToDelete = entities.stream().map(OWLEntityData::getEntity).collect(toImmutableSet());
-        dispatchServiceManager.execute(new DeleteEntitiesAction(projectId, entitiesToDelete), deleteEntityResult -> {});
+        ImmutableSet<OWLEntity> entitiesToDelete = entities.stream().map(OWLEntityData::getEntity).collect(toImmutableSet());
+        dispatchServiceManager.execute(new DeleteEntitiesAction(ChangeRequestId.get(uuidV4Provider.get()),
+                                                                projectId,
+                                                                entitiesToDelete),
+                                       deleteEntityResult -> {});
     }
 
 }

--- a/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/hierarchy/PropertyHierarchyPortletPresenter.java
+++ b/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/hierarchy/PropertyHierarchyPortletPresenter.java
@@ -332,14 +332,17 @@ public class PropertyHierarchyPortletPresenter extends AbstractWebProtegePortlet
     }
 
     private void handleCreate() {
-        view.getSelectedHierarchyDescriptor().ifPresent(hierarchyId -> {
-            if (hierarchyId.equals(OBJECT_PROPERTY_HIERARCHY)) {
+        // The selected entry is a HierarchyDescriptor, so it never equals
+        // any of the HierarchyId constants — that comparison silently
+        // dropped every Create click. Match by descriptor type instead.
+        view.getSelectedHierarchyDescriptor().ifPresent(hierarchyDescriptor -> {
+            if (hierarchyDescriptor instanceof ObjectPropertyHierarchyDescriptor) {
                 handleCreateObjectProperty();
             }
-            else if (hierarchyId.equals(DATA_PROPERTY_HIERARCHY)) {
+            else if (hierarchyDescriptor instanceof DataPropertyHierarchyDescriptor) {
                 handleCreateDataProperty();
             }
-            else if (hierarchyId.equals(ANNOTATION_PROPERTY_HIERARCHY)) {
+            else if (hierarchyDescriptor instanceof AnnotationPropertyHierarchyDescriptor) {
                 handleCreateAnnotationProperty();
             }
         });

--- a/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/individualslist/IndividualsListPresenter.java
+++ b/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/individualslist/IndividualsListPresenter.java
@@ -1,6 +1,7 @@
 package edu.stanford.bmir.protege.web.client.individualslist;
 
 import com.google.common.collect.ImmutableCollection;
+import com.google.common.collect.ImmutableSet;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.event.logical.shared.SelectionEvent;
 import com.google.gwt.user.client.Timer;
@@ -17,6 +18,7 @@ import edu.stanford.bmir.protege.web.client.permissions.LoggedInUserProjectCapab
 import edu.stanford.bmir.protege.web.client.portlet.HasPortletActions;
 import edu.stanford.bmir.protege.web.client.portlet.PortletAction;
 import edu.stanford.bmir.protege.web.client.selection.SelectionModel;
+import edu.stanford.bmir.protege.web.client.uuid.UuidV4Provider;
 import edu.stanford.bmir.protege.web.shared.DataFactory;
 import edu.stanford.bmir.protege.web.shared.PrimitiveType;
 import edu.stanford.bmir.protege.web.shared.entity.*;
@@ -27,6 +29,7 @@ import edu.stanford.bmir.protege.web.shared.individuals.GetIndividualsPageContai
 import edu.stanford.bmir.protege.web.shared.lang.DisplayNameSettings;
 import edu.stanford.bmir.protege.web.shared.pagination.Page;
 import edu.stanford.bmir.protege.web.shared.pagination.PageRequest;
+import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
 import edu.stanford.bmir.protege.web.shared.project.ProjectId;
 import org.semanticweb.owlapi.model.OWLClass;
 import org.semanticweb.owlapi.model.OWLEntity;
@@ -37,13 +40,13 @@ import javax.inject.Inject;
 import java.util.*;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static edu.stanford.bmir.protege.web.client.library.dlg.DialogButton.CANCEL;
 import static edu.stanford.bmir.protege.web.client.library.dlg.DialogButton.DELETE;
 import static edu.stanford.bmir.protege.web.client.ui.NumberFormatter.format;
 import static edu.stanford.bmir.protege.web.shared.access.BuiltInCapability.CREATE_INDIVIDUAL;
 import static edu.stanford.bmir.protege.web.shared.access.BuiltInCapability.DELETE_INDIVIDUAL;
 import static edu.stanford.bmir.protege.web.shared.lang.DisplayNameSettingsChangedEvent.ON_DISPLAY_LANGUAGE_CHANGED;
-import static java.util.stream.Collectors.toSet;
 import static org.semanticweb.owlapi.model.EntityType.NAMED_INDIVIDUAL;
 
 /**
@@ -92,6 +95,9 @@ public class IndividualsListPresenter implements EntityNodeIndex {
 
     private MessageBox messageBox;
 
+    @Nonnull
+    private final UuidV4Provider uuidV4Provider;
+
     @Inject
     public IndividualsListPresenter(IndividualsListView view,
                                     @Nonnull ProjectId projectId,
@@ -100,7 +106,10 @@ public class IndividualsListPresenter implements EntityNodeIndex {
                                     LoggedInUserProjectCapabilityChecker capabilityChecker,
                                     HierarchyFieldPresenter hierarchyFieldPresenter,
                                     Messages messages,
-                                    @Nonnull CreateEntityPresenter createEntityPresenter, EntityNodeUpdater entityNodeUpdater, MessageBox messageBox) {
+                                    @Nonnull CreateEntityPresenter createEntityPresenter,
+                                    EntityNodeUpdater entityNodeUpdater,
+                                    MessageBox messageBox,
+                                    @Nonnull UuidV4Provider uuidV4Provider) {
         this.projectId = projectId;
         this.selectionModel = selectionModel;
         this.capabilityChecker = capabilityChecker;
@@ -111,6 +120,7 @@ public class IndividualsListPresenter implements EntityNodeIndex {
         this.createEntityPresenter = createEntityPresenter;
         this.entityNodeUpdater = entityNodeUpdater;
         this.messageBox = messageBox;
+        this.uuidV4Provider = checkNotNull(uuidV4Provider);
         this.view.addSelectionHandler(this::handleSelectionChangedInView);
         this.view.setSearchStringChangedHandler(this::handleSearchStringChangedInView);
         this.view.setPageNumberChangedHandler(pageNumber -> updateList());
@@ -286,12 +296,14 @@ public class IndividualsListPresenter implements EntityNodeIndex {
 
     private void deleteSelectedIndividuals() {
         Collection<EntityNode> selection = view.getSelectedIndividuals();
-        Set<OWLEntity> entities = view.getSelectedIndividuals().stream()
+        ImmutableSet<OWLEntity> entities = view.getSelectedIndividuals().stream()
                 .map(EntityNode::getEntity)
-                .collect(toSet());
-        dsm.execute(new DeleteEntitiesAction(projectId, entities),
+                .collect(toImmutableSet());
+        dsm.execute(new DeleteEntitiesAction(ChangeRequestId.get(uuidV4Provider.get()),
+                                             projectId,
+                                             entities),
                     view,
-                                       result -> updateList());
+                    result -> updateList());
     }
 
     private void updateButtonStates() {

--- a/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/projectmanager/TrashManagerRequestHandlerImpl.java
+++ b/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/projectmanager/TrashManagerRequestHandlerImpl.java
@@ -1,6 +1,9 @@
 package edu.stanford.bmir.protege.web.client.projectmanager;
 
+import com.google.web.bindery.event.shared.EventBus;
 import edu.stanford.bmir.protege.web.client.dispatch.DispatchServiceManager;
+import edu.stanford.bmir.protege.web.shared.event.ProjectMovedFromTrashEvent;
+import edu.stanford.bmir.protege.web.shared.event.ProjectMovedToTrashEvent;
 import edu.stanford.bmir.protege.web.shared.project.MoveProjectsToTrashAction;
 import edu.stanford.bmir.protege.web.shared.project.ProjectId;
 import edu.stanford.bmir.protege.web.shared.project.RemoveProjectFromTrashAction;
@@ -17,18 +20,31 @@ public class TrashManagerRequestHandlerImpl implements TrashManagerRequestHandle
 
     private final DispatchServiceManager dispatchServiceManager;
 
+    private final EventBus eventBus;
+
     @Inject
-    public TrashManagerRequestHandlerImpl(DispatchServiceManager dispatchServiceManager) {
+    public TrashManagerRequestHandlerImpl(DispatchServiceManager dispatchServiceManager,
+                                          EventBus eventBus) {
         this.dispatchServiceManager = dispatchServiceManager;
+        this.eventBus = eventBus;
     }
 
     @Override
     public void handleMoveProjectToTrash(final ProjectId projectId) {
-        dispatchServiceManager.execute(MoveProjectsToTrashAction.create(projectId), result -> {});
+        // Fire ProjectMovedToTrashEvent on the local bus when the dispatch
+        // returns. Without this the originating client never sees the row
+        // disappear from the default project list — there is no server-
+        // side fan-out of this event in this repo, and the only listener
+        // (ProjectManagerPresenter.handleProjectMovedToTrash) updates the
+        // local AvailableProjectsCache from a bus event. Mirrors how
+        // CreateNewProjectPresenter fires ProjectCreatedEvent on success.
+        dispatchServiceManager.execute(MoveProjectsToTrashAction.create(projectId),
+                                       result -> eventBus.fireEvent(new ProjectMovedToTrashEvent(projectId).asGWTEvent()));
     }
 
     @Override
     public void handleRemoveProjectFromTrash(final ProjectId projectId) {
-        dispatchServiceManager.execute(RemoveProjectFromTrashAction.create(projectId), result -> {});
+        dispatchServiceManager.execute(RemoveProjectFromTrashAction.create(projectId),
+                                       result -> eventBus.fireEvent(new ProjectMovedFromTrashEvent(projectId).asGWTEvent()));
     }
 }

--- a/webprotege-gwt-ui-client/src/main/module-dev.gwt.xml
+++ b/webprotege-gwt-ui-client/src/main/module-dev.gwt.xml
@@ -11,6 +11,7 @@
     <source path=""/>
 
     <inherits name="com.google.gwt.user.User"/>
+    <inherits name="com.google.gwt.user.Debug"/>
     <inherits name="elemental.Elemental"/>
     <inherits name="com.google.gwt.resources.Resources" />
     <inherits name="com.google.gwt.place.Place"/>

--- a/webprotege-gwt-ui-client/src/main/module-dev.gwt.xml
+++ b/webprotege-gwt-ui-client/src/main/module-dev.gwt.xml
@@ -12,6 +12,7 @@
 
     <inherits name="com.google.gwt.user.User"/>
     <inherits name="com.google.gwt.user.Debug"/>
+    <set-property name="gwt.enableDebugId" value="true"/>
     <inherits name="elemental.Elemental"/>
     <inherits name="com.google.gwt.resources.Resources" />
     <inherits name="com.google.gwt.place.Place"/>

--- a/webprotege-gwt-ui-client/src/main/module.gwt.xml
+++ b/webprotege-gwt-ui-client/src/main/module.gwt.xml
@@ -11,6 +11,7 @@
     <source path=""/>
 
     <inherits name="com.google.gwt.user.User"/>
+    <inherits name="com.google.gwt.user.Debug"/>
     <inherits name="elemental.Elemental"/>
     <inherits name="com.google.gwt.resources.Resources" />
     <inherits name="com.google.gwt.place.Place"/>

--- a/webprotege-gwt-ui-client/src/main/module.gwt.xml
+++ b/webprotege-gwt-ui-client/src/main/module.gwt.xml
@@ -12,6 +12,7 @@
 
     <inherits name="com.google.gwt.user.User"/>
     <inherits name="com.google.gwt.user.Debug"/>
+    <set-property name="gwt.enableDebugId" value="true"/>
     <inherits name="elemental.Elemental"/>
     <inherits name="com.google.gwt.resources.Resources" />
     <inherits name="com.google.gwt.place.Place"/>

--- a/webprotege-gwt-ui-client/src/test/java/edu/stanford/bmir/protege/web/client/events/ChangeRequestEventAwaiterTest.java
+++ b/webprotege-gwt-ui-client/src/test/java/edu/stanford/bmir/protege/web/client/events/ChangeRequestEventAwaiterTest.java
@@ -24,11 +24,18 @@ public class ChangeRequestEventAwaiterTest {
     public void setUp() {
         // Override scheduleFallback so the GWT Timer (JS-only) is never
         // invoked from the JVM, and so the fallback path can be exercised
-        // deterministically.
-        awaiter = new ChangeRequestEventAwaiter() {
+        // deterministically. Override requestImmediatePoll for the same
+        // reason — its production implementation calls into
+        // EventPollingManager which depends on GWT-only types.
+        awaiter = new ChangeRequestEventAwaiter(() -> { throw new UnsupportedOperationException("test should not invoke"); }) {
             @Override
             protected void scheduleFallback(Runnable callback) {
                 pendingFallback = callback;
+            }
+
+            @Override
+            protected void requestImmediatePoll() {
+                // no-op for tests
             }
         };
     }

--- a/webprotege-gwt-ui-client/src/test/java/edu/stanford/bmir/protege/web/client/events/ChangeRequestEventAwaiterTest.java
+++ b/webprotege-gwt-ui-client/src/test/java/edu/stanford/bmir/protege/web/client/events/ChangeRequestEventAwaiterTest.java
@@ -16,9 +16,21 @@ public class ChangeRequestEventAwaiterTest {
 
     private ChangeRequestEventAwaiter awaiter;
 
+    /** Captures the runnable handed to scheduleFallback so tests can fire
+     * the fallback synchronously. */
+    private Runnable pendingFallback;
+
     @Before
     public void setUp() {
-        awaiter = new ChangeRequestEventAwaiter();
+        // Override scheduleFallback so the GWT Timer (JS-only) is never
+        // invoked from the JVM, and so the fallback path can be exercised
+        // deterministically.
+        awaiter = new ChangeRequestEventAwaiter() {
+            @Override
+            protected void scheduleFallback(Runnable callback) {
+                pendingFallback = callback;
+            }
+        };
     }
 
     @Test
@@ -118,6 +130,42 @@ public class ChangeRequestEventAwaiterTest {
         assertTrue(captor1.getValue().containsAll(Arrays.asList(e1, e2)));
         assertEquals(2, captor2.getValue().size());
         assertTrue(captor2.getValue().containsAll(Arrays.asList(e1, e2)));
+    }
+
+    @Test
+    public void shouldDeliverEmptyEventListWhenFallbackFiresBeforeAnyEventArrives() {
+        ChangeRequestId id = ChangeRequestId.valueOf(UUID.randomUUID().toString());
+        ChangeRequestEventsHandler handler = mock(ChangeRequestEventsHandler.class);
+
+        awaiter.waitForEvents(id, handler);
+        assertNotNull("scheduleFallback should have been invoked", pendingFallback);
+
+        // No events arrive — fallback fires.
+        pendingFallback.run();
+
+        ArgumentCaptor<Collection> captor = ArgumentCaptor.forClass(Collection.class);
+        verify(handler, times(1)).handle(captor.capture());
+        assertTrue("fallback should deliver an empty event collection",
+                   captor.getValue().isEmpty());
+    }
+
+    @Test
+    public void shouldNotDoubleDeliverWhenFallbackFiresAfterEventsArrived() {
+        ChangeRequestId id = ChangeRequestId.valueOf(UUID.randomUUID().toString());
+        ChangeRequestEventsHandler handler = mock(ChangeRequestEventsHandler.class);
+
+        awaiter.waitForEvents(id, handler);
+        assertNotNull(pendingFallback);
+
+        // Events arrive first → handler is fired and removed.
+        WebProtegeEvent<?> event = eventWithId(id);
+        awaiter.handleEvents(Collections.singletonList(event));
+        verify(handler, times(1)).handle(anyCollection());
+
+        // Fallback fires later — must be a no-op (handler already removed).
+        pendingFallback.run();
+
+        verifyNoMoreInteractions(handler);
     }
 
     @Test

--- a/webprotege-gwt-ui-server-core/src/test/java/edu/stanford/bmir/protege/web/shared/entity/DeleteEntities_Serialization_TestCase.java
+++ b/webprotege-gwt-ui-server-core/src/test/java/edu/stanford/bmir/protege/web/shared/entity/DeleteEntities_Serialization_TestCase.java
@@ -4,6 +4,7 @@ import edu.stanford.bmir.protege.web.MockingUtils;
 import edu.stanford.bmir.protege.web.shared.dispatch.Action;
 import edu.stanford.bmir.protege.web.shared.dispatch.Result;
 import edu.stanford.bmir.protege.web.shared.match.JsonSerializationTestUtil;
+import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
 import edu.stanford.bmir.protege.web.shared.project.ProjectId;
 import org.junit.Test;
 
@@ -20,7 +21,8 @@ public class DeleteEntities_Serialization_TestCase {
 
     @Test
     public void shouldSerializeAction() throws IOException {
-        var action = new DeleteEntitiesAction(ProjectId.getNil(),
+        var action = new DeleteEntitiesAction(ChangeRequestId.getNil(),
+                                              ProjectId.getNil(),
                                               ImmutableSet.of());
         JsonSerializationTestUtil.testSerialization(action, Action.class);
     }

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/entity/DeleteEntitiesAction.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/entity/DeleteEntitiesAction.java
@@ -3,17 +3,15 @@ package edu.stanford.bmir.protege.web.shared.entity;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import com.google.auto.value.AutoValue;
-import com.google.common.annotations.GwtCompatible;
 import com.google.common.base.Objects;
+import com.google.common.collect.ImmutableSet;
 import edu.stanford.bmir.protege.web.shared.annotations.GwtSerializationConstructor;
 import edu.stanford.bmir.protege.web.shared.dispatch.ProjectAction;
+import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
 import edu.stanford.bmir.protege.web.shared.project.ProjectId;
 import org.semanticweb.owlapi.model.OWLEntity;
 
 import javax.annotation.Nonnull;
-import java.util.HashSet;
-import java.util.Set;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -26,19 +24,27 @@ import static com.google.common.base.Preconditions.checkNotNull;
 @JsonTypeName("webprotege.entities.DeleteEntities")
 public class DeleteEntitiesAction implements ProjectAction<DeleteEntitiesResult> {
 
+    private ChangeRequestId changeRequestId;
+
     private ProjectId projectId;
 
-    private Set<OWLEntity> entities;
+    private ImmutableSet<OWLEntity> entities;
 
     @GwtSerializationConstructor
     private DeleteEntitiesAction() {
     }
 
     @JsonCreator
-    public DeleteEntitiesAction(@JsonProperty("projectId") @Nonnull ProjectId projectId,
-                                @JsonProperty("entities") @Nonnull Set<OWLEntity> entities) {
-        this.entities = new HashSet<>(entities);
+    public DeleteEntitiesAction(@JsonProperty("changeRequestId") @Nonnull ChangeRequestId changeRequestId,
+                                @JsonProperty("projectId") @Nonnull ProjectId projectId,
+                                @JsonProperty("entities") @Nonnull ImmutableSet<OWLEntity> entities) {
+        this.changeRequestId = checkNotNull(changeRequestId);
         this.projectId = checkNotNull(projectId);
+        this.entities = checkNotNull(entities);
+    }
+
+    public ChangeRequestId getChangeRequestId() {
+        return changeRequestId;
     }
 
     @Nonnull
@@ -47,13 +53,13 @@ public class DeleteEntitiesAction implements ProjectAction<DeleteEntitiesResult>
         return projectId;
     }
 
-    public Set<OWLEntity> getEntities() {
-        return new HashSet<>(entities);
+    public ImmutableSet<OWLEntity> getEntities() {
+        return entities;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(projectId, entities);
+        return Objects.hashCode(changeRequestId, projectId, entities);
     }
 
     @Override
@@ -65,7 +71,8 @@ public class DeleteEntitiesAction implements ProjectAction<DeleteEntitiesResult>
             return false;
         }
         DeleteEntitiesAction other = (DeleteEntitiesAction) obj;
-        return this.projectId.equals(other.projectId)
+        return this.changeRequestId.equals(other.changeRequestId)
+                && this.projectId.equals(other.projectId)
                 && this.entities.equals(other.entities);
     }
 
@@ -73,6 +80,7 @@ public class DeleteEntitiesAction implements ProjectAction<DeleteEntitiesResult>
     @Override
     public String toString() {
         return toStringHelper("DeleteEntitiesAction")
+                .addValue(changeRequestId)
                 .addValue(projectId)
                 .addValue(entities)
                 .toString();

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/entity/DeleteEntitiesResult.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/entity/DeleteEntitiesResult.java
@@ -3,19 +3,13 @@ package edu.stanford.bmir.protege.web.shared.entity;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import com.google.auto.value.AutoValue;
-import com.google.common.annotations.GwtCompatible;
 import com.google.common.base.Objects;
+import com.google.common.collect.ImmutableSet;
 import edu.stanford.bmir.protege.web.shared.annotations.GwtSerializationConstructor;
 import edu.stanford.bmir.protege.web.shared.dispatch.Result;
-import edu.stanford.bmir.protege.web.shared.event.EventList;
-import edu.stanford.bmir.protege.web.shared.event.HasEventList;
-import edu.stanford.bmir.protege.web.shared.event.ProjectEvent;
 import org.semanticweb.owlapi.model.OWLEntity;
 
 import javax.annotation.Nonnull;
-import java.util.HashSet;
-import java.util.Set;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -28,7 +22,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 @JsonTypeName("webprotege.entities.DeleteEntities")
 public class DeleteEntitiesResult implements Result {
 
-    private Set<OWLEntity> deletedEntities;
+    private ImmutableSet<OWLEntity> deletedEntities;
 
     @GwtSerializationConstructor
     private DeleteEntitiesResult() {
@@ -36,14 +30,14 @@ public class DeleteEntitiesResult implements Result {
 
 
     @JsonCreator
-    public DeleteEntitiesResult(@JsonProperty("deletedEntities") @Nonnull Set<OWLEntity> deletedEntities) {
-        this.deletedEntities = new HashSet<>(deletedEntities);
+    public DeleteEntitiesResult(@JsonProperty("deletedEntities") @Nonnull ImmutableSet<OWLEntity> deletedEntities) {
+        this.deletedEntities = checkNotNull(deletedEntities);
     }
 
 
 
-    public Set<OWLEntity> getDeletedEntities() {
-        return new HashSet<>(deletedEntities);
+    public ImmutableSet<OWLEntity> getDeletedEntities() {
+        return deletedEntities;
     }
 
     @Override

--- a/webprotege-gwt-ui-shared/src/test/java/edu/stanford/bmir/protege/web/shared/entity/DeleteEntitiesAction_TestCase.java
+++ b/webprotege-gwt-ui-shared/src/test/java/edu/stanford/bmir/protege/web/shared/entity/DeleteEntitiesAction_TestCase.java
@@ -1,92 +1,99 @@
-
 package edu.stanford.bmir.protege.web.shared.entity;
 
+import com.google.common.collect.ImmutableSet;
+import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
 import edu.stanford.bmir.protege.web.shared.project.ProjectId;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.semanticweb.owlapi.model.OWLEntity;
 
-import java.util.HashSet;
-import java.util.Set;
-
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 
-@RunWith(org.mockito.runners.MockitoJUnitRunner.class)
 public class DeleteEntitiesAction_TestCase {
 
     private DeleteEntitiesAction deleteEntitiesAction;
 
-    @Mock
     private ProjectId projectId;
 
-    private Set<OWLEntity> entities = new HashSet<>();
+    private ChangeRequestId changeRequestId;
 
-    @Before
-    public void setUp() {
-        entities.add(mock(OWLEntity.class));
-        deleteEntitiesAction = new DeleteEntitiesAction(projectId, entities);
-    }
+    private ImmutableSet<OWLEntity> entities;
 
-    @SuppressWarnings("ConstantConditions")
-    @Test(expected = NullPointerException.class)
-    public void shouldThrowNullPointerExceptionIf_projectId_IsNull() {
-        new DeleteEntitiesAction(null, entities);
-    }
-
-    @Test
-    public void shouldReturnSupplied_projectId() {
-        assertThat(deleteEntitiesAction.getProjectId(), is(this.projectId));
-    }
-
-    @SuppressWarnings("ConstantConditions")
-    @Test(expected = NullPointerException.class)
-    public void shouldThrowNullPointerExceptionIf_entities_IsNull() {
-        new DeleteEntitiesAction(projectId, null);
+    @BeforeEach
+    void setUp() {
+        projectId = mock(ProjectId.class);
+        changeRequestId = mock(ChangeRequestId.class);
+        entities = ImmutableSet.of(mock(OWLEntity.class));
+        deleteEntitiesAction = new DeleteEntitiesAction(changeRequestId, projectId, entities);
     }
 
     @Test
-    public void shouldReturnSupplied_entities() {
-        assertThat(deleteEntitiesAction.getEntities(), is(this.entities));
+    void shouldThrowNullPointerExceptionIf_changeRequestId_IsNull() {
+        assertThatThrownBy(() -> new DeleteEntitiesAction(null, projectId, entities))
+                .isInstanceOf(NullPointerException.class);
     }
 
     @Test
-    public void shouldBeEqualToSelf() {
-        assertThat(deleteEntitiesAction, is(deleteEntitiesAction));
+    void shouldThrowNullPointerExceptionIf_projectId_IsNull() {
+        assertThatThrownBy(() -> new DeleteEntitiesAction(changeRequestId, null, entities))
+                .isInstanceOf(NullPointerException.class);
     }
 
     @Test
-    @SuppressWarnings("ObjectEqualsNull")
-    public void shouldNotBeEqualToNull() {
-        assertThat(deleteEntitiesAction.equals(null), is(false));
+    void shouldThrowNullPointerExceptionIf_entities_IsNull() {
+        assertThatThrownBy(() -> new DeleteEntitiesAction(changeRequestId, projectId, null))
+                .isInstanceOf(NullPointerException.class);
     }
 
     @Test
-    public void shouldBeEqualToOther() {
-        assertThat(deleteEntitiesAction, is(new DeleteEntitiesAction(projectId, entities)));
+    void shouldReturnSupplied_changeRequestId() {
+        assertThat(deleteEntitiesAction.getChangeRequestId()).isEqualTo(changeRequestId);
     }
 
     @Test
-    public void shouldNotBeEqualToOtherThatHasDifferent_projectId() {
-        assertThat(deleteEntitiesAction, is(not(new DeleteEntitiesAction(mock(ProjectId.class), entities))));
+    void shouldReturnSupplied_projectId() {
+        assertThat(deleteEntitiesAction.getProjectId()).isEqualTo(projectId);
     }
 
     @Test
-    public void shouldNotBeEqualToOtherThatHasDifferent_entities() {
-        assertThat(deleteEntitiesAction, is(not(new DeleteEntitiesAction(projectId, new HashSet<>()))));
+    void shouldReturnSupplied_entities() {
+        assertThat(deleteEntitiesAction.getEntities()).isEqualTo(entities);
     }
 
     @Test
-    public void shouldBeEqualToOtherHashCode() {
-        assertThat(deleteEntitiesAction.hashCode(), is(new DeleteEntitiesAction(projectId, entities).hashCode()));
+    void shouldBeEqualToSelf() {
+        assertThat(deleteEntitiesAction).isEqualTo(deleteEntitiesAction);
     }
 
     @Test
-    public void shouldImplementToString() {
-        assertThat(deleteEntitiesAction.toString(), startsWith("DeleteEntitiesAction"));
+    void shouldNotBeEqualToNull() {
+        assertThat(deleteEntitiesAction).isNotEqualTo(null);
     }
 
+    @Test
+    void shouldBeEqualToOther() {
+        assertThat(deleteEntitiesAction).isEqualTo(new DeleteEntitiesAction(changeRequestId, projectId, entities));
+    }
+
+    @Test
+    void shouldNotBeEqualToOtherThatHasDifferent_projectId() {
+        assertThat(deleteEntitiesAction).isNotEqualTo(new DeleteEntitiesAction(changeRequestId, mock(ProjectId.class), entities));
+    }
+
+    @Test
+    void shouldNotBeEqualToOtherThatHasDifferent_entities() {
+        assertThat(deleteEntitiesAction).isNotEqualTo(new DeleteEntitiesAction(changeRequestId, projectId, ImmutableSet.of()));
+    }
+
+    @Test
+    void shouldBeEqualToOtherHashCode() {
+        assertThat(deleteEntitiesAction.hashCode()).isEqualTo(new DeleteEntitiesAction(changeRequestId, projectId, entities).hashCode());
+    }
+
+    @Test
+    void shouldImplementToString() {
+        assertThat(deleteEntitiesAction.toString()).startsWith("DeleteEntitiesAction");
+    }
 }

--- a/webprotege-gwt-ui-shared/src/test/java/edu/stanford/bmir/protege/web/shared/entity/DeleteEntitiesResult_TestCase.java
+++ b/webprotege-gwt-ui-shared/src/test/java/edu/stanford/bmir/protege/web/shared/entity/DeleteEntitiesResult_TestCase.java
@@ -1,76 +1,64 @@
-
 package edu.stanford.bmir.protege.web.shared.entity;
 
-import edu.stanford.bmir.protege.web.shared.event.EventList;
-import edu.stanford.bmir.protege.web.shared.event.ProjectEvent;
-import org.hamcrest.Matchers;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
+import com.google.common.collect.ImmutableSet;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.semanticweb.owlapi.model.OWLEntity;
 
-import java.util.HashSet;
-import java.util.Set;
-
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 
-@RunWith(org.mockito.runners.MockitoJUnitRunner.class)
 public class DeleteEntitiesResult_TestCase {
 
     private DeleteEntitiesResult deleteEntitiesResult;
 
-    private Set<OWLEntity> deletedEntities;
+    private ImmutableSet<OWLEntity> deletedEntities;
 
-    @Before
-    public void setUp() {
-        deletedEntities = new HashSet<>();
-        deletedEntities.add(mock(OWLEntity.class));
+    @BeforeEach
+    void setUp() {
+        deletedEntities = ImmutableSet.of(mock(OWLEntity.class));
         deleteEntitiesResult = new DeleteEntitiesResult(deletedEntities);
     }
 
-    @SuppressWarnings("ConstantConditions")
-    @Test(expected = NullPointerException.class)
-    public void shouldThrowNullPointerExceptionIf_deletedEntities_IsNull() {
-        new DeleteEntitiesResult(null);
+    @Test
+    void shouldThrowNullPointerExceptionIf_deletedEntities_IsNull() {
+        assertThatThrownBy(() -> new DeleteEntitiesResult(null))
+                .isInstanceOf(NullPointerException.class);
     }
 
     @Test
-    public void shouldReturnSupplied_deletedEntities() {
-        assertThat(deleteEntitiesResult.getDeletedEntities(), is(this.deletedEntities));
+    void shouldReturnSupplied_deletedEntities() {
+        assertThat(deleteEntitiesResult.getDeletedEntities()).isEqualTo(deletedEntities);
     }
 
     @Test
-    public void shouldBeEqualToSelf() {
-        assertThat(deleteEntitiesResult, is(deleteEntitiesResult));
+    void shouldBeEqualToSelf() {
+        assertThat(deleteEntitiesResult).isEqualTo(deleteEntitiesResult);
     }
 
     @Test
-    @SuppressWarnings("ObjectEqualsNull")
-    public void shouldNotBeEqualToNull() {
-        assertThat(deleteEntitiesResult.equals(null), is(false));
+    void shouldNotBeEqualToNull() {
+        assertThat(deleteEntitiesResult).isNotEqualTo(null);
     }
 
     @Test
-    public void shouldBeEqualToOther() {
-        assertThat(deleteEntitiesResult, is(new DeleteEntitiesResult(deletedEntities)));
+    void shouldBeEqualToOther() {
+        assertThat(deleteEntitiesResult).isEqualTo(new DeleteEntitiesResult(deletedEntities));
     }
 
     @Test
-    public void shouldNotBeEqualToOtherThatHasDifferent_deletedEntities() {
-        assertThat(deleteEntitiesResult, is(not(new DeleteEntitiesResult(new HashSet<>()))));
+    void shouldNotBeEqualToOtherThatHasDifferent_deletedEntities() {
+        assertThat(deleteEntitiesResult).isNotEqualTo(new DeleteEntitiesResult(ImmutableSet.of()));
     }
 
     @Test
-    public void shouldBeEqualToOtherHashCode() {
-        assertThat(deleteEntitiesResult.hashCode(), is(new DeleteEntitiesResult(deletedEntities).hashCode()));
+    void shouldBeEqualToOtherHashCode() {
+        assertThat(deleteEntitiesResult.hashCode()).isEqualTo(new DeleteEntitiesResult(deletedEntities).hashCode());
     }
 
     @Test
-    public void shouldImplementToString() {
-        assertThat(deleteEntitiesResult.toString(), Matchers.startsWith("DeleteEntitiesResult"));
+    void shouldImplementToString() {
+        assertThat(deleteEntitiesResult.toString()).startsWith("DeleteEntitiesResult");
     }
 }


### PR DESCRIPTION
Closes #267.

## What this PR does

Adds an end-to-end browser test suite for the WebProtege GWT UI. The tests drive a real browser against the same Docker stack we ship to production, click through every major user flow (login, project lifecycle, classes, properties, individuals, search, sharing, history, full ontology authoring), and assert what the user actually sees.

While writing the tests we hit a handful of real product bugs — they're fixed in this PR too, since the tests can't be green without them.

## Why

Until now, every regression in the GWT UI had to be caught by hand. Reviewers had to spin up the stack locally and click through a checklist; CI had no way to catch a broken modal, a stale project list, or a search box that quietly stops working. Issue #267 is a request for that automated coverage. After this PR:

- A single `npm test` from the `playwright/` folder runs ~37 user scenarios in under a minute.
- CI will now block PRs that break the UI, no extra effort from reviewers.
- The suite is self-cleaning — a `globalTeardown` purges every test project from MongoDB after the run, so re-running the suite is always against a clean baseline.

## What you can run locally

```
cd playwright
docker compose up -d --wait
WEBPROTEGE_BASE_URL=http://webprotege-local.edu npm test
```

You'll see something like:

```
✓ A1: anonymous access redirects to Keycloak login (334ms)
✓ P5+P6+P7+P8: create, open, trash, restore round-trip (3.4s)
✓ S1+S2: open search modal and find a class (5.1s)
✓ builds the Airplane ontology end-to-end (29.0s)
…
37 passed (43.4s)
[teardown] purged 28 projects, 124 rows total
```

## Real product bugs surfaced and fixed in this PR

These are user-visible defects the test suite found while it was being written. Each is fixed by a commit on this branch.

- **Delete didn't actually delete anything** ([`e6f825b68`](../commit/e6f825b68), [`128f9a3b2`](../commit/128f9a3b2)). Clicking *Delete* on a class, property, or individual sent a request the backend rejected before it reached any handler — the response came back as a 5xx and the UI kept showing the entity. *Solution was cherry-picked from this [PR webprotege-backend-service#155](https://github.com/protegeproject/webprotege-backend-service/pull/155/changes/3b12a14542448ba5f880d7afeebe8881904c8566)*

- **The Create button on the Object/Data/Annotation Properties tabs did nothing** ([`3fbb7a28a`](../commit/3fbb7a28a)). The hierarchy portlet was comparing two unrelated values when deciding which kind of property to create, so the comparison always failed and the Create action silently no-op'd. Switched to a real type check. *Solution was cherry-picked from this [PR webprotege-gwt-ui#142](https://github.com/protegeproject/webprotege-gwt-ui/pull/142)*

- **Trashing a project left the row in the default project list** ([`540ed19a2`](../commit/540ed19a2)). *Move to trash* sent the request and the server processed it, but the row hung around in your view until you reloaded the page. The originating client now fires the same kind of local event that *Create New Project* already does, so the cache refreshes immediately and the row disappears as you'd expect.

- **Creating an individual paused for ~1.5s before showing it** ([`6512eac22`](../commit/6512eac22), [`72ef8b980`](../commit/72ef8b980)). The UI was waiting for an event the server never sends for individual creation. The wait now fails over after a short timeout, and individual creation skips the wait entirely since the result already carries everything the UI needs.

There's also a deeper WebSocket-lifecycle issue (live event push to the browser stops working after the first second, falls back to on-demand polling), tracked separately as #268. Not blocking this PR — the suite works around it client-side via [`b3e47b4d3`](../commit/b3e47b4d3); that commit can be reverted once #268 is fixed.

## Related PR

There's a companion PR on **`webprotege-backend-service`** that pairs with this one. Both PRs are needed together for the full Playwright suite to pass against `protegeproject/webprotege-backend-service:local`. Until both merge, the test stack uses the rebuilt `:local` image; after both merge, the stack will work against the published image again.

## Test plan

- [x] `npm test` runs all 37 specs locally and passes.
- [x] Suite passes back-to-back twice with `Remaining projects: 0` after each run.
- [x] CI workflow added to run the suite on every PR that touches the UI.
- [x] Reviewer: pull, run `cd playwright && docker compose up -d --wait && npm test`, confirm green.