### PR TITLE
fix(build): prevent stale test classes from breaking mvn test (#265)

### DIFF
--- a/webprotege-gwt-ui-server-core/pom.xml
+++ b/webprotege-gwt-ui-server-core/pom.xml
@@ -154,6 +154,32 @@
                     </annotationProcessorPaths>
                 </configuration>
             </plugin>
+            <plugin>
+                <artifactId>maven-clean-plugin</artifactId>
+                <executions>
+                    <!--
+                        Wipe target/test-classes before each test-compile so an IDE's
+                        incremental ECJ output (which can bake "Unresolved compilation
+                        problems" Errors into .class files with a newer mtime than the
+                        source) cannot survive a Maven build. See #265.
+                    -->
+                    <execution>
+                        <id>clean-test-classes</id>
+                        <phase>process-test-sources</phase>
+                        <goals>
+                            <goal>clean</goal>
+                        </goals>
+                        <configuration>
+                            <excludeDefaultDirectories>true</excludeDefaultDirectories>
+                            <filesets>
+                                <fileset>
+                                    <directory>${project.build.testOutputDirectory}</directory>
+                                </fileset>
+                            </filesets>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
## Summary

Closes #265.

- The grid serialization tests in `webprotege-gwt-ui-server-core` could fail under `mvn test` / `mvn package` with `java.lang.Error: Unresolved compilation problems:` when an IDE had previously written stale test classes that Maven then skipped recompiling.
- Fix: wipe `target/test-classes` immediately before the test-compile phase, so `javac` always rebuilds the test sources from scratch. The fix is scoped to `webprotege-gwt-ui-server-core/pom.xml` only.
- Confirmed by simulating the stale-class scenario locally — the wipe fires, `javac` recompiles, and the full 508-test server-core suite passes.

## Test plan

- [x] `mvn -pl webprotege-gwt-ui-server-core -am clean test` passes on CI.
- [x] After an IDE build, `mvn -pl webprotege-gwt-ui-server-core test` (no `clean`) still passes — the previously-failing `GridControlDescriptor_Serialization_TestCase` and `GridControlDataDto_Serialization_TestCase` no longer reproduce the error.