### PR TITLE
Pin @JsonProperty on FRAGILE Action/Result classes (#272)

### DIFF
--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/change/GetProjectChangesAction.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/change/GetProjectChangesAction.java
@@ -1,5 +1,7 @@
 package edu.stanford.bmir.protege.web.shared.change;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
@@ -42,22 +44,26 @@ public class GetProjectChangesAction implements ProjectAction<GetProjectChangesR
         this.pageRequest = checkNotNull(pageRequest);
     }
 
-    public static GetProjectChangesAction create(@Nonnull ProjectId projectId,
-                                                 @Nonnull Optional<OWLEntity> subject,
-                                                 @Nonnull PageRequest pageRequest) {
+    @JsonCreator
+    public static GetProjectChangesAction create(@JsonProperty("projectId") @Nonnull ProjectId projectId,
+                                                 @JsonProperty("subject") @Nonnull Optional<OWLEntity> subject,
+                                                 @JsonProperty("pageRequest") @Nonnull PageRequest pageRequest) {
         return new GetProjectChangesAction(projectId, subject, pageRequest);
     }
 
+    @JsonProperty("projectId")
     @Nonnull
     public ProjectId getProjectId() {
         return projectId;
     }
 
+    @JsonProperty("subject")
     @Nonnull
     public Optional<OWLEntity> getSubject() {
         return Optional.ofNullable(subject);
     }
 
+    @JsonProperty("pageRequest")
     @Nonnull
     public PageRequest getPageRequest() {
         return pageRequest;

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/entity/LookupEntitiesAction.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/entity/LookupEntitiesAction.java
@@ -1,5 +1,7 @@
 package edu.stanford.bmir.protege.web.shared.entity;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.common.base.MoreObjects;
 import edu.stanford.bmir.protege.web.shared.dispatch.ProjectAction;
@@ -37,7 +39,9 @@ public class LookupEntitiesAction implements ProjectAction<LookupEntitiesResult>
         this.entityLookupRequest = checkNotNull(entityLookupRequest);
     }
 
-    public static LookupEntitiesAction create(ProjectId projectId, EntityLookupRequest entityLookupRequest) {
+    @JsonCreator
+    public static LookupEntitiesAction create(@JsonProperty("projectId") ProjectId projectId,
+                                              @JsonProperty("entityLookupRequest") EntityLookupRequest entityLookupRequest) {
         return new LookupEntitiesAction(projectId, entityLookupRequest);
     }
 
@@ -45,6 +49,7 @@ public class LookupEntitiesAction implements ProjectAction<LookupEntitiesResult>
      * Gets the {@link ProjectId} that identifies the project in which the lookup will be performed.
      * @return The {@link ProjectId}.  Not {@code null}.
      */
+    @JsonProperty("projectId")
     @Nonnull
     @Override
     public ProjectId getProjectId() {
@@ -55,6 +60,7 @@ public class LookupEntitiesAction implements ProjectAction<LookupEntitiesResult>
      * Gets the {@link EntityLookupRequest} that describes the lookup to be performed.
      * @return The {@link EntityLookupRequest}. Not {@code null}.
      */
+    @JsonProperty("entityLookupRequest")
     public EntityLookupRequest getEntityLookupRequest() {
         return entityLookupRequest;
     }

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/hierarchy/GetHierarchyRootsAction.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/hierarchy/GetHierarchyRootsAction.java
@@ -1,5 +1,7 @@
 package edu.stanford.bmir.protege.web.shared.hierarchy;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.common.base.Objects;
 import edu.stanford.bmir.protege.web.client.hierarchy.HierarchyDescriptor;
@@ -31,16 +33,20 @@ public class GetHierarchyRootsAction implements ProjectAction<GetHierarchyRootsR
     private GetHierarchyRootsAction() {
     }
 
-    public static GetHierarchyRootsAction create(@Nonnull ProjectId projectId, @Nonnull HierarchyDescriptor hierarchyDescriptor) {
+    @JsonCreator
+    public static GetHierarchyRootsAction create(@JsonProperty("projectId") @Nonnull ProjectId projectId,
+                                                 @JsonProperty("hierarchyDescriptor") @Nonnull HierarchyDescriptor hierarchyDescriptor) {
         return new GetHierarchyRootsAction(projectId, hierarchyDescriptor);
     }
 
+    @JsonProperty("projectId")
     @Nonnull
     @Override
     public ProjectId getProjectId() {
         return projectId;
     }
 
+    @JsonProperty("hierarchyDescriptor")
     @Nonnull
     public HierarchyDescriptor getHierarchyDescriptor() {
         return hierarchyDescriptor;

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/issues/GetEntityDiscussionThreadsAction.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/issues/GetEntityDiscussionThreadsAction.java
@@ -1,5 +1,7 @@
 package edu.stanford.bmir.protege.web.shared.issues;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.common.base.Objects;
 import edu.stanford.bmir.protege.web.shared.annotations.GwtSerializationConstructor;
@@ -29,8 +31,9 @@ public class GetEntityDiscussionThreadsAction implements ProjectAction<GetEntity
         this.entity = checkNotNull(entity);
     }
 
-    public static GetEntityDiscussionThreadsAction create(@Nonnull ProjectId projectId,
-                                                          @Nonnull OWLEntity entity) {
+    @JsonCreator
+    public static GetEntityDiscussionThreadsAction create(@JsonProperty("projectId") @Nonnull ProjectId projectId,
+                                                          @JsonProperty("entity") @Nonnull OWLEntity entity) {
         return new GetEntityDiscussionThreadsAction(projectId, entity);
     }
 
@@ -38,11 +41,13 @@ public class GetEntityDiscussionThreadsAction implements ProjectAction<GetEntity
     private GetEntityDiscussionThreadsAction() {
     }
 
+    @JsonProperty("projectId")
     @Nonnull
     public ProjectId getProjectId() {
         return projectId;
     }
 
+    @JsonProperty("entity")
     @Nonnull
     public OWLEntity getEntity() {
         return entity;

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/issues/SetDiscussionThreadStatusResult.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/issues/SetDiscussionThreadStatusResult.java
@@ -1,5 +1,7 @@
 package edu.stanford.bmir.protege.web.shared.issues;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import edu.stanford.bmir.protege.web.shared.annotations.GwtSerializationConstructor;
 import edu.stanford.bmir.protege.web.shared.dispatch.Result;
@@ -25,8 +27,9 @@ public class SetDiscussionThreadStatusResult implements Result {
 
     private EventList<ProjectEvent<?>> eventList;
 
-    public SetDiscussionThreadStatusResult(@Nonnull ThreadId threadId,
-                                           @Nonnull Status result) {
+    @JsonCreator
+    public SetDiscussionThreadStatusResult(@JsonProperty("threadId") @Nonnull ThreadId threadId,
+                                           @JsonProperty("result") @Nonnull Status result) {
         this.threadId = checkNotNull(threadId);
         this.result = checkNotNull(result);
         this.eventList = checkNotNull(eventList);
@@ -36,11 +39,13 @@ public class SetDiscussionThreadStatusResult implements Result {
     private SetDiscussionThreadStatusResult() {
     }
 
+    @JsonProperty("threadId")
     @Nonnull
     public ThreadId getThreadId() {
         return threadId;
     }
 
+    @JsonProperty("result")
     @Nonnull
     public Status getResult() {
         return result;

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/lang/GetProjectLangTagsAction.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/lang/GetProjectLangTagsAction.java
@@ -1,5 +1,7 @@
 package edu.stanford.bmir.protege.web.shared.lang;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.common.base.MoreObjects;
 import edu.stanford.bmir.protege.web.shared.annotations.GwtSerializationConstructor;
@@ -28,10 +30,12 @@ public class GetProjectLangTagsAction implements ProjectAction<GetProjectLangTag
     private GetProjectLangTagsAction() {
     }
 
-    public static GetProjectLangTagsAction create(@Nonnull ProjectId projectId) {
+    @JsonCreator
+    public static GetProjectLangTagsAction create(@JsonProperty("projectId") @Nonnull ProjectId projectId) {
         return new GetProjectLangTagsAction(projectId);
     }
 
+    @JsonProperty("projectId")
     @Nonnull
     @Override
     public ProjectId getProjectId() {

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/lang/GetProjectLangTagsResult.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/lang/GetProjectLangTagsResult.java
@@ -1,5 +1,7 @@
 package edu.stanford.bmir.protege.web.shared.lang;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.auto.value.AutoValue;
 import com.google.common.annotations.GwtCompatible;
@@ -35,16 +37,19 @@ public class GetProjectLangTagsResult implements Result {
     private GetProjectLangTagsResult() {
     }
 
-    public static GetProjectLangTagsResult create(@Nonnull ProjectId projectId,
-                                                  @Nonnull ImmutableSet<LangTag> langTags) {
+    @JsonCreator
+    public static GetProjectLangTagsResult create(@JsonProperty("projectId") @Nonnull ProjectId projectId,
+                                                  @JsonProperty("langTags") @Nonnull ImmutableSet<LangTag> langTags) {
         return new GetProjectLangTagsResult(projectId, langTags);
     }
 
+    @JsonProperty("projectId")
     @Nonnull
     public ProjectId getProjectId() {
         return projectId;
     }
 
+    @JsonProperty("langTags")
     @Nonnull
     public ImmutableSet<LangTag> getLangTags() {
         return langTags;

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/mail/GetEmailAddressAction.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/mail/GetEmailAddressAction.java
@@ -1,5 +1,7 @@
 package edu.stanford.bmir.protege.web.shared.mail;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import edu.stanford.bmir.protege.web.shared.dispatch.Action;
 import edu.stanford.bmir.protege.web.shared.user.UserId;
@@ -35,7 +37,8 @@ public class GetEmailAddressAction implements Action<GetEmailAddressResult> {
         }
     }
 
-    public static GetEmailAddressAction create(UserId userId) {
+    @JsonCreator
+    public static GetEmailAddressAction create(@JsonProperty("userId") UserId userId) {
         return new GetEmailAddressAction(userId);
     }
 
@@ -43,6 +46,7 @@ public class GetEmailAddressAction implements Action<GetEmailAddressResult> {
      * Gets the {@link UserId} of the user whose email address is to be retrieved.
      * @return The {@link UserId}.  Not {@code null}.
      */
+    @JsonProperty("userId")
     public UserId getUserId() {
         return userId;
     }

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/mail/SetEmailAddressAction.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/mail/SetEmailAddressAction.java
@@ -1,5 +1,7 @@
 package edu.stanford.bmir.protege.web.shared.mail;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import edu.stanford.bmir.protege.web.shared.dispatch.Action;
 import edu.stanford.bmir.protege.web.shared.user.UserId;
@@ -32,7 +34,9 @@ public class SetEmailAddressAction implements Action<SetEmailAddressResult> {
      * @throws NullPointerException if {@code userId} or {@code emailAddress} is {@code null}.
      * @throws IllegalArgumentException if the value of {@link UserId} is the user id of the guest user.
      */
-    public SetEmailAddressAction(UserId userId, String emailAddress) {
+    @JsonCreator
+    public SetEmailAddressAction(@JsonProperty("userId") UserId userId,
+                                 @JsonProperty("emailAddress") String emailAddress) {
         this.userId = checkNotNull(userId);
         if(userId.isGuest()) {
             throw new IllegalArgumentException("userId cannot be guest");
@@ -44,6 +48,7 @@ public class SetEmailAddressAction implements Action<SetEmailAddressResult> {
      * Gets the {@link UserId} of the user whose email address should be set.
      * @return The {@link UserId}.  Not {@code null}.
      */
+    @JsonProperty("userId")
     public UserId getUserId() {
         return userId;
     }
@@ -52,6 +57,7 @@ public class SetEmailAddressAction implements Action<SetEmailAddressResult> {
      * Gets the email address to set.
      * @return A string representing the email address. Not {@code null}.
      */
+    @JsonProperty("emailAddress")
     public String getEmailAddress() {
         return emailAddress;
     }

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/mail/SetEmailAddressResult.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/mail/SetEmailAddressResult.java
@@ -1,5 +1,7 @@
 package edu.stanford.bmir.protege.web.shared.mail;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.common.base.Objects;
 import edu.stanford.bmir.protege.web.shared.dispatch.Result;
@@ -39,10 +41,12 @@ public class SetEmailAddressResult implements Result {
     private SetEmailAddressResult() {
     }
 
-    public SetEmailAddressResult(Result result) {
+    @JsonCreator
+    public SetEmailAddressResult(@JsonProperty("result") Result result) {
         this.result = checkNotNull(result);
     }
 
+    @JsonProperty("result")
     public Result getResult() {
         return result;
     }

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/permissions/GetProjectPermissionsAction.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/permissions/GetProjectPermissionsAction.java
@@ -1,5 +1,7 @@
 package edu.stanford.bmir.protege.web.shared.permissions;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.common.base.Objects;
 import edu.stanford.bmir.protege.web.shared.HasUserId;
@@ -35,16 +37,20 @@ public class GetProjectPermissionsAction implements Action<GetProjectPermissions
         this.userId = checkNotNull(userId);
     }
 
-    public static GetProjectPermissionsAction create(@Nonnull ProjectId projectId, @Nonnull UserId userId) {
+    @JsonCreator
+    public static GetProjectPermissionsAction create(@JsonProperty("projectId") @Nonnull ProjectId projectId,
+                                                     @JsonProperty("userId") @Nonnull UserId userId) {
         return new GetProjectPermissionsAction(projectId, userId);
     }
 
+    @JsonProperty("projectId")
     @Nonnull
     @Override
     public ProjectId getProjectId() {
         return projectId;
     }
 
+    @JsonProperty("userId")
     @Nonnull
     @Override
     public UserId getUserId() {

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/permissions/GetProjectPermissionsResult.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/permissions/GetProjectPermissionsResult.java
@@ -1,5 +1,7 @@
 package edu.stanford.bmir.protege.web.shared.permissions;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableSet;
@@ -28,10 +30,12 @@ public class GetProjectPermissionsResult implements Result {
         this.allowedActions = ImmutableSet.copyOf(allowedActions);
     }
 
-    public static GetProjectPermissionsResult create(Set<Capability> allowedActions) {
+    @JsonCreator
+    public static GetProjectPermissionsResult create(@JsonProperty("allowedActions") Set<Capability> allowedActions) {
         return new GetProjectPermissionsResult(allowedActions);
     }
 
+    @JsonProperty("allowedActions")
     public Set<Capability> getAllowedActions() {
         return allowedActions;
     }

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/perspective/GetPerspectiveLayoutAction.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/perspective/GetPerspectiveLayoutAction.java
@@ -1,5 +1,7 @@
 package edu.stanford.bmir.protege.web.shared.perspective;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.common.base.Objects;
 import edu.stanford.bmir.protege.web.shared.dispatch.ProjectAction;
@@ -35,19 +37,25 @@ public class GetPerspectiveLayoutAction implements ProjectAction<GetPerspectiveL
         this.perspectiveId = checkNotNull(perspectiveId);
     }
 
-    public static GetPerspectiveLayoutAction create(ProjectId projectId, UserId userId, PerspectiveId perspectiveId) {
+    @JsonCreator
+    public static GetPerspectiveLayoutAction create(@JsonProperty("projectId") ProjectId projectId,
+                                                    @JsonProperty("userId") UserId userId,
+                                                    @JsonProperty("perspectiveId") PerspectiveId perspectiveId) {
         return new GetPerspectiveLayoutAction(projectId, userId, perspectiveId);
     }
 
+    @JsonProperty("projectId")
     @Nonnull
     public ProjectId getProjectId() {
         return projectId;
     }
 
+    @JsonProperty("userId")
     public UserId getUserId() {
         return userId;
     }
 
+    @JsonProperty("perspectiveId")
     public PerspectiveId getPerspectiveId() {
         return perspectiveId;
     }

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/perspective/ResetPerspectiveLayoutResult.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/perspective/ResetPerspectiveLayoutResult.java
@@ -1,5 +1,7 @@
 package edu.stanford.bmir.protege.web.shared.perspective;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import edu.stanford.bmir.protege.web.shared.annotations.GwtSerializationConstructor;
 import edu.stanford.bmir.protege.web.shared.dispatch.Result;
@@ -28,10 +30,12 @@ public class ResetPerspectiveLayoutResult implements Result {
         this.resetLayout = checkNotNull(resetLayout);
     }
 
-    public static ResetPerspectiveLayoutResult create(@Nonnull PerspectiveLayout resetLayout) {
+    @JsonCreator
+    public static ResetPerspectiveLayoutResult create(@JsonProperty("resetLayout") @Nonnull PerspectiveLayout resetLayout) {
         return new ResetPerspectiveLayoutResult(resetLayout);
     }
 
+    @JsonProperty("resetLayout")
     @Nonnull
     public PerspectiveLayout getResetLayout() {
         return resetLayout;

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/perspective/SetPerspectiveLayoutAction.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/perspective/SetPerspectiveLayoutAction.java
@@ -1,5 +1,7 @@
 package edu.stanford.bmir.protege.web.shared.perspective;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.common.base.Objects;
 import com.google.gwt.user.client.rpc.IsSerializable;
@@ -46,23 +48,31 @@ public class SetPerspectiveLayoutAction implements ProjectAction<SetPerspectiveL
     public static SetPerspectiveLayoutAction create(ProjectId projectId, UserId userId, PerspectiveLayout layout) {
         return new SetPerspectiveLayoutAction(ChangeRequestId.get("123"), projectId, userId, layout);
     }
-    public static SetPerspectiveLayoutAction create(ChangeRequestId changeRequestId, ProjectId projectId, UserId userId, PerspectiveLayout layout) {
+    @JsonCreator
+    public static SetPerspectiveLayoutAction create(@JsonProperty("changeRequestId") ChangeRequestId changeRequestId,
+                                                    @JsonProperty("projectId") ProjectId projectId,
+                                                    @JsonProperty("userId") UserId userId,
+                                                    @JsonProperty("layout") PerspectiveLayout layout) {
         return new SetPerspectiveLayoutAction(changeRequestId, projectId, userId, layout);
     }
 
+    @JsonProperty("projectId")
     @Nonnull
     public ProjectId getProjectId() {
         return projectId;
     }
 
+    @JsonProperty("userId")
     public UserId getUserId() {
         return userId;
     }
 
+    @JsonProperty("layout")
     public PerspectiveLayout getLayout() {
         return layout;
     }
 
+    @JsonProperty("changeRequestId")
     public ChangeRequestId getChangeRequestId() {
         return changeRequestId;
     }

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/project/CreateNewProjectResult.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/project/CreateNewProjectResult.java
@@ -1,5 +1,7 @@
 package edu.stanford.bmir.protege.web.shared.project;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.common.base.Objects;
 import edu.stanford.bmir.protege.web.shared.dispatch.Result;
@@ -23,10 +25,12 @@ public class CreateNewProjectResult implements Result {
     private CreateNewProjectResult() {
     }
 
-    public CreateNewProjectResult(ProjectDetails projectDetails) {
+    @JsonCreator
+    public CreateNewProjectResult(@JsonProperty("projectDetails") ProjectDetails projectDetails) {
         this.projectDetails = checkNotNull(projectDetails);
     }
 
+    @JsonProperty("projectDetails")
     public ProjectDetails getProjectDetails() {
         return projectDetails;
     }

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/project/GetProjectDetailsAction.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/project/GetProjectDetailsAction.java
@@ -1,5 +1,7 @@
 package edu.stanford.bmir.protege.web.shared.project;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.common.base.Objects;
 import edu.stanford.bmir.protege.web.shared.dispatch.Action;
@@ -22,10 +24,12 @@ public class GetProjectDetailsAction implements Action<GetProjectDetailsResult>,
     private GetProjectDetailsAction() {
     }
 
-    public GetProjectDetailsAction(ProjectId projectId) {
+    @JsonCreator
+    public GetProjectDetailsAction(@JsonProperty("projectId") ProjectId projectId) {
         this.projectId = checkNotNull(projectId);
     }
 
+    @JsonProperty("projectId")
     @Nonnull
     @Override
     public ProjectId getProjectId() {

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/project/GetProjectInfoAction.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/project/GetProjectInfoAction.java
@@ -1,5 +1,7 @@
 package edu.stanford.bmir.protege.web.shared.project;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import edu.stanford.bmir.protege.web.shared.annotations.GwtSerializationConstructor;
 import edu.stanford.bmir.protege.web.shared.dispatch.ProjectAction;
@@ -27,10 +29,12 @@ public class GetProjectInfoAction implements ProjectAction<GetProjectInfoResult>
         this.projectId = checkNotNull(projectId);
     }
 
-    public static GetProjectInfoAction create(@Nonnull ProjectId projectId) {
+    @JsonCreator
+    public static GetProjectInfoAction create(@JsonProperty("projectId") @Nonnull ProjectId projectId) {
         return new GetProjectInfoAction(projectId);
     }
 
+    @JsonProperty("projectId")
     @Nonnull
     @Override
     public ProjectId getProjectId() {

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/project/SetProjectPrefixDeclarationsResult.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/project/SetProjectPrefixDeclarationsResult.java
@@ -1,5 +1,7 @@
 package edu.stanford.bmir.protege.web.shared.project;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.common.base.Objects;
 import edu.stanford.bmir.protege.web.shared.annotations.GwtSerializationConstructor;
@@ -34,11 +36,13 @@ public class SetProjectPrefixDeclarationsResult implements Result {
     private SetProjectPrefixDeclarationsResult() {
     }
 
-    public static SetProjectPrefixDeclarationsResult create(@Nonnull ProjectId projectId,
-                                                            @Nonnull List<PrefixDeclaration> prefixDeclarations) {
+    @JsonCreator
+    public static SetProjectPrefixDeclarationsResult create(@JsonProperty("projectId") @Nonnull ProjectId projectId,
+                                                            @JsonProperty("prefixDeclarations") @Nonnull List<PrefixDeclaration> prefixDeclarations) {
         return new SetProjectPrefixDeclarationsResult(projectId, prefixDeclarations);
     }
 
+    @JsonProperty("projectId")
     @Nonnull
     public ProjectId getProjectId() {
         return projectId;
@@ -48,6 +52,7 @@ public class SetProjectPrefixDeclarationsResult implements Result {
      * Gets the prefix declarations that were set
      * @return A list of prefix declarations.
      */
+    @JsonProperty("prefixDeclarations")
     @Nonnull
     public List<PrefixDeclaration> getPrefixDeclarations() {
         return new ArrayList<>(prefixDeclarations);

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/revision/GetHeadRevisionNumberAction.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/revision/GetHeadRevisionNumberAction.java
@@ -1,5 +1,7 @@
 package edu.stanford.bmir.protege.web.shared.revision;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.common.base.Objects;
 import edu.stanford.bmir.protege.web.shared.dispatch.ProjectAction;
@@ -27,10 +29,12 @@ public class GetHeadRevisionNumberAction implements ProjectAction<GetHeadRevisio
         this.projectId = checkNotNull(projectId);
     }
 
-    public static GetHeadRevisionNumberAction create(ProjectId projectId) {
+    @JsonCreator
+    public static GetHeadRevisionNumberAction create(@JsonProperty("projectId") ProjectId projectId) {
         return new GetHeadRevisionNumberAction(projectId);
     }
 
+    @JsonProperty("projectId")
     @Nonnull
     @Override
     public ProjectId getProjectId() {

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/revision/GetRevisionSummariesResult.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/revision/GetRevisionSummariesResult.java
@@ -1,5 +1,7 @@
 package edu.stanford.bmir.protege.web.shared.revision;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableList;
@@ -28,10 +30,12 @@ public class GetRevisionSummariesResult implements Result {
         this.revisionSummaries = checkNotNull(revisionSummaries);
     }
 
-    public static GetRevisionSummariesResult create(ImmutableList<RevisionSummary> revisionSummaries) {
+    @JsonCreator
+    public static GetRevisionSummariesResult create(@JsonProperty("revisionSummaries") ImmutableList<RevisionSummary> revisionSummaries) {
         return new GetRevisionSummariesResult(revisionSummaries);
     }
 
+    @JsonProperty("revisionSummaries")
     public ImmutableList<RevisionSummary> getRevisionSummaries() {
         return revisionSummaries;
     }

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/sharing/GetProjectSharingSettingsAction.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/sharing/GetProjectSharingSettingsAction.java
@@ -1,5 +1,7 @@
 package edu.stanford.bmir.protege.web.shared.sharing;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.common.base.Objects;
 import edu.stanford.bmir.protege.web.shared.dispatch.ProjectAction;
@@ -27,10 +29,12 @@ public class GetProjectSharingSettingsAction implements ProjectAction<GetProject
         this.projectId = checkNotNull(projectId);
     }
 
-    public static GetProjectSharingSettingsAction create(ProjectId projectId) {
+    @JsonCreator
+    public static GetProjectSharingSettingsAction create(@JsonProperty("projectId") ProjectId projectId) {
         return new GetProjectSharingSettingsAction(projectId);
     }
 
+    @JsonProperty("projectId")
     @Nonnull
     @Override
     public ProjectId getProjectId() {

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/sharing/SetProjectSharingSettingsAction.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/sharing/SetProjectSharingSettingsAction.java
@@ -1,5 +1,7 @@
 package edu.stanford.bmir.protege.web.shared.sharing;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.common.base.Objects;
 import edu.stanford.bmir.protege.web.shared.dispatch.ProjectAction;
@@ -34,7 +36,10 @@ public class SetProjectSharingSettingsAction implements ProjectAction<SetProject
         this.changeRequestId = changeRequestId;
     }
 
-    public static SetProjectSharingSettingsAction create(ProjectSharingSettings projectSharingSettings,  ChangeRequestId changeRequestId, ProjectId projectId) {
+    @JsonCreator
+    public static SetProjectSharingSettingsAction create(@JsonProperty("settings") ProjectSharingSettings projectSharingSettings,
+                                                         @JsonProperty("changeRequestId") ChangeRequestId changeRequestId,
+                                                         @JsonProperty("projectId") ProjectId projectId) {
         return new SetProjectSharingSettingsAction(projectSharingSettings, changeRequestId, projectId);
     }
 
@@ -44,10 +49,12 @@ public class SetProjectSharingSettingsAction implements ProjectAction<SetProject
         return settings.getProjectId();
     }
 
+    @JsonProperty("settings")
     public ProjectSharingSettings getSettings() {
         return settings;
     }
 
+    @JsonProperty("changeRequestId")
     public ChangeRequestId getChangeRequestId() {
         return changeRequestId;
     }

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/tag/GetEntityTagsResult.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/tag/GetEntityTagsResult.java
@@ -1,5 +1,7 @@
 package edu.stanford.bmir.protege.web.shared.tag;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.common.base.Objects;
 import edu.stanford.bmir.protege.web.shared.annotations.GwtSerializationConstructor;
@@ -34,14 +36,16 @@ public class GetEntityTagsResult implements Result {
     private GetEntityTagsResult() {
     }
 
-    public static GetEntityTagsResult create(@Nonnull Collection<Tag> entityTags,
-                                             @Nonnull Collection<Tag> projectTags) {
+    @JsonCreator
+    public static GetEntityTagsResult create(@JsonProperty("entityTags") @Nonnull Collection<Tag> entityTags,
+                                             @JsonProperty("projectTags") @Nonnull Collection<Tag> projectTags) {
         return new GetEntityTagsResult(entityTags, projectTags);
     }
 
     /**
      * Gets the tags for the requested entity and project.
      */
+    @JsonProperty("entityTags")
     @Nonnull
     public List<Tag> getEntityTags() {
         return new ArrayList<>(entityTags);
@@ -51,6 +55,7 @@ public class GetEntityTagsResult implements Result {
      * Gets the tags for the requested project.  These represent the available
      * entity tags.
      */
+    @JsonProperty("projectTags")
     @Nonnull
     public List<Tag> getProjectTags() {
         return new ArrayList<>(projectTags);

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/tag/GetProjectTagsAction.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/tag/GetProjectTagsAction.java
@@ -1,5 +1,7 @@
 package edu.stanford.bmir.protege.web.shared.tag;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import edu.stanford.bmir.protege.web.shared.annotations.GwtSerializationConstructor;
 import edu.stanford.bmir.protege.web.shared.dispatch.ProjectAction;
@@ -28,10 +30,12 @@ public class GetProjectTagsAction implements ProjectAction<GetProjectTagsResult>
     private GetProjectTagsAction() {
     }
 
-    public static GetProjectTagsAction create(@Nonnull ProjectId projectId) {
+    @JsonCreator
+    public static GetProjectTagsAction create(@JsonProperty("projectId") @Nonnull ProjectId projectId) {
         return new GetProjectTagsAction(projectId);
     }
 
+    @JsonProperty("projectId")
     @Nonnull
     @Override
     public ProjectId getProjectId() {

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/tag/GetProjectTagsResult.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/tag/GetProjectTagsResult.java
@@ -1,5 +1,7 @@
 package edu.stanford.bmir.protege.web.shared.tag;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.common.base.Objects;
 import edu.stanford.bmir.protege.web.shared.annotations.GwtSerializationConstructor;
@@ -32,15 +34,19 @@ public class GetProjectTagsResult implements Result {
     private GetProjectTagsResult() {
     }
 
-    public static GetProjectTagsResult create(@Nonnull Collection<Tag> tags, @Nonnull Map<TagId, Integer> tagUsage) {
+    @JsonCreator
+    public static GetProjectTagsResult create(@JsonProperty("tags") @Nonnull Collection<Tag> tags,
+                                              @JsonProperty("tagUsage") @Nonnull Map<TagId, Integer> tagUsage) {
         return new GetProjectTagsResult(tags, tagUsage);
     }
 
+    @JsonProperty("tags")
     @Nonnull
     public List<Tag> getTags() {
         return new ArrayList<>(tags);
     }
 
+    @JsonProperty("tagUsage")
     @Nonnull
     public Map<TagId, Integer> getTagUsage() {
         return new HashMap<>(tagUsage);


### PR DESCRIPTION
## Summary
- For every class flagged `FRAGILE` by the wire-DTO conformance audit, add `@JsonCreator` on the existing static `create(...)` factory (or public constructor where no factory exists) and `@JsonProperty("<name>")` on each parameter and getter — pinning both directions of the wire contract.
- Covers all 26 client files listed in #272; the chosen JSON names match what Jackson was already inferring from getter discovery, so no `MATCH` row should regress to `NAME_MISMATCH`.
- Companion to backend [`webprotege-backend-api#52`](https://github.com/protegeproject/webprotege-backend-api/issues/52) / [PR #60](https://github.com/protegeproject/webprotege-backend-api/pull/60).

## Test plan
- [x] `mvn -q -DskipTests -pl webprotege-gwt-ui-shared -am compile` passes.
- [x] After merging together with the backend PR, re-run `tools/audit_json_conformance.py` and confirm `FRAGILE=0`.
- [x] Verify no `MATCH` pair regresses to `NAME_MISMATCH`.