### PR TITLE
Reconcile MISMATCH wire DTOs (issue protegeproject/webprotege-backend-api#53) — client half

### DIFF
--- a/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/app/ApplicationSettingsPresenter.java
+++ b/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/app/ApplicationSettingsPresenter.java
@@ -11,11 +11,13 @@ import edu.stanford.bmir.protege.web.client.dispatch.ProgressDisplay;
 import edu.stanford.bmir.protege.web.client.library.msgbox.MessageBox;
 import edu.stanford.bmir.protege.web.client.settings.SettingsPresenter;
 import edu.stanford.bmir.protege.web.client.user.LoggedInUserManager;
+import edu.stanford.bmir.protege.web.client.uuid.UuidV4Provider;
 import edu.stanford.bmir.protege.web.shared.app.ApplicationLocation;
 import edu.stanford.bmir.protege.web.shared.app.ApplicationSettings;
 import edu.stanford.bmir.protege.web.shared.app.GetApplicationSettingsAction;
 import edu.stanford.bmir.protege.web.shared.app.SetApplicationSettingsAction;
 import edu.stanford.bmir.protege.web.shared.inject.ApplicationSingleton;
+import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
 import edu.stanford.bmir.protege.web.shared.permissions.RebuildPermissionsAction;
 import edu.stanford.bmir.protege.web.shared.permissions.RebuildPermissionsResult;
 import edu.stanford.bmir.protege.web.shared.place.ProjectListPlace;
@@ -85,6 +87,9 @@ public class ApplicationSettingsPresenter implements Presenter {
     @Nonnull
     private final ProgressDisplay progressDisplay;
 
+    @Nonnull
+    private final UuidV4Provider uuidV4Provider;
+
     @Inject
     public ApplicationSettingsPresenter(@Nonnull SystemDetailsView systemDetailsView,
                                         @Nonnull ApplicationUrlView applicationUrlView,
@@ -95,7 +100,8 @@ public class ApplicationSettingsPresenter implements Presenter {
                                         @Nonnull DispatchServiceManager dispatchServiceManager,
                                         @Nonnull SettingsPresenter settingsPresenter,
                                         @Nonnull Messages messages,
-                                        @Nonnull MessageBox messageBox, @Nonnull DispatchErrorMessageDisplay errorDisplay, @Nonnull ProgressDisplay progressDisplay) {
+                                        @Nonnull MessageBox messageBox, @Nonnull DispatchErrorMessageDisplay errorDisplay, @Nonnull ProgressDisplay progressDisplay,
+                                        @Nonnull UuidV4Provider uuidV4Provider) {
         this.systemDetailsView = checkNotNull(systemDetailsView);
         this.applicationUrlView = checkNotNull(applicationUrlView);
         this.permissionsView = checkNotNull(permissionsView);
@@ -108,6 +114,7 @@ public class ApplicationSettingsPresenter implements Presenter {
         this.messageBox = messageBox;
         this.errorDisplay = errorDisplay;
         this.progressDisplay = progressDisplay;
+        this.uuidV4Provider = checkNotNull(uuidV4Provider);
     }
 
     @Override
@@ -178,7 +185,7 @@ public class ApplicationSettingsPresenter implements Presenter {
                 emailNotificationSettingsView.isNotificationEmailsEnabled() ? SEND_NOTIFICATION_EMAILS : DO_NOT_SEND_NOTIFICATION_EMAILS,
                 parseMaxUploadSize()
         );
-        dispatchServiceManager.execute(SetApplicationSettingsAction.create(applicationSettings),
+        dispatchServiceManager.execute(SetApplicationSettingsAction.create(ChangeRequestId.get(uuidV4Provider.get()), applicationSettings),
                                        result -> messageBox.showMessage("Settings applied",
                                                                         "The application settings have successfully been applied",
                                                                         settingsPresenter::goToNextPlace));

--- a/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/bulkop/EditAnnotationsPresenter.java
+++ b/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/bulkop/EditAnnotationsPresenter.java
@@ -2,9 +2,11 @@ package edu.stanford.bmir.protege.web.client.bulkop;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.gwt.user.client.ui.AcceptsOneWidget;
+import edu.stanford.bmir.protege.web.client.uuid.UuidV4Provider;
 import edu.stanford.bmir.protege.web.shared.bulkop.EditAnnotationsAction;
 import edu.stanford.bmir.protege.web.shared.entity.OWLEntityData;
 import edu.stanford.bmir.protege.web.shared.event.WebProtegeEventBus;
+import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
 import edu.stanford.bmir.protege.web.shared.project.ProjectId;
 import org.semanticweb.owlapi.model.OWLEntity;
 
@@ -27,10 +29,16 @@ public class EditAnnotationsPresenter implements BulkEditOperationPresenter {
     @Nonnull
     private final ProjectId projectId;
 
+    @Nonnull
+    private final UuidV4Provider uuidV4Provider;
+
     @Inject
-    public EditAnnotationsPresenter(@Nonnull EditAnnotationsView view, @Nonnull ProjectId projectId) {
+    public EditAnnotationsPresenter(@Nonnull EditAnnotationsView view,
+                                    @Nonnull ProjectId projectId,
+                                    @Nonnull UuidV4Provider uuidV4Provider) {
         this.view = checkNotNull(view);
         this.projectId = checkNotNull(projectId);
+        this.uuidV4Provider = checkNotNull(uuidV4Provider);
     }
 
     @Override
@@ -69,7 +77,8 @@ public class EditAnnotationsPresenter implements BulkEditOperationPresenter {
     @Nonnull
     @Override
     public Optional<EditAnnotationsAction> createAction(@Nonnull ImmutableSet<OWLEntity> entities, String commitMessage) {
-        return Optional.of(EditAnnotationsAction.create(projectId,
+        return Optional.of(EditAnnotationsAction.create(ChangeRequestId.get(uuidV4Provider.get()),
+                                                     projectId,
                                                      entities,
                                                      view.getOperation(),
                                                      view.getAnnotationProperty(),

--- a/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/bulkop/MoveEntitiesToParentPresenter.java
+++ b/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/bulkop/MoveEntitiesToParentPresenter.java
@@ -4,10 +4,12 @@ import com.google.common.collect.ImmutableSet;
 import com.google.gwt.user.client.ui.AcceptsOneWidget;
 import edu.stanford.bmir.protege.web.client.hierarchy.HierarchyDescriptor;
 import edu.stanford.bmir.protege.web.client.hierarchy.HierarchyFieldPresenter;
+import edu.stanford.bmir.protege.web.client.uuid.UuidV4Provider;
 import edu.stanford.bmir.protege.web.shared.HasBrowserText;
 import edu.stanford.bmir.protege.web.shared.bulkop.MoveEntitiesToParentAction;
 import edu.stanford.bmir.protege.web.shared.entity.OWLEntityData;
 import edu.stanford.bmir.protege.web.shared.event.WebProtegeEventBus;
+import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
 import edu.stanford.bmir.protege.web.shared.project.ProjectId;
 import org.semanticweb.owlapi.model.EntityType;
 import org.semanticweb.owlapi.model.OWLClass;
@@ -37,14 +39,19 @@ public class MoveEntitiesToParentPresenter implements BulkEditOperationPresenter
     private final HierarchyFieldPresenter hierarchyFieldPresenter;
 
     @Nonnull
+    private final UuidV4Provider uuidV4Provider;
+
+    @Nonnull
     private EntityType<?> entityType = EntityType.CLASS;
 
     @Inject
     public MoveEntitiesToParentPresenter(@Nonnull ProjectId projectId, @Nonnull MoveToParentView view,
-                                         @Nonnull HierarchyFieldPresenter presenter) {
+                                         @Nonnull HierarchyFieldPresenter presenter,
+                                         @Nonnull UuidV4Provider uuidV4Provider) {
         this.projectId = checkNotNull(projectId);
         this.view = checkNotNull(view);
         this.hierarchyFieldPresenter = checkNotNull(presenter);
+        this.uuidV4Provider = checkNotNull(uuidV4Provider);
     }
 
     public void setEntityType(@Nonnull EntityType<?> entityType) {
@@ -101,7 +108,8 @@ public class MoveEntitiesToParentPresenter implements BulkEditOperationPresenter
                 .collect(toImmutableSet());
         return hierarchyFieldPresenter.getEntity()
                 .map(OWLEntityData::getEntity)
-                .map(entity -> MoveEntitiesToParentAction.create(projectId,
+                .map(entity -> MoveEntitiesToParentAction.create(ChangeRequestId.get(uuidV4Provider.get()),
+                                                                 projectId,
                                                                  clses,
                                                                  entity.asOWLClass(),
                                                                  commitMessage));

--- a/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/bulkop/SetAnnotationValuePresenter.java
+++ b/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/bulkop/SetAnnotationValuePresenter.java
@@ -2,12 +2,14 @@ package edu.stanford.bmir.protege.web.client.bulkop;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.gwt.user.client.ui.AcceptsOneWidget;
+import edu.stanford.bmir.protege.web.client.uuid.UuidV4Provider;
 import edu.stanford.bmir.protege.web.shared.HasBrowserText;
 import edu.stanford.bmir.protege.web.shared.bulkop.SetAnnotationValueAction;
 import edu.stanford.bmir.protege.web.shared.entity.OWLAnnotationPropertyData;
 import edu.stanford.bmir.protege.web.shared.entity.OWLEntityData;
 import edu.stanford.bmir.protege.web.shared.entity.OWLPrimitiveData;
 import edu.stanford.bmir.protege.web.shared.event.WebProtegeEventBus;
+import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
 import edu.stanford.bmir.protege.web.shared.project.ProjectId;
 import org.semanticweb.owlapi.model.OWLAnnotationProperty;
 import org.semanticweb.owlapi.model.OWLAnnotationValue;
@@ -30,11 +32,15 @@ public class SetAnnotationValuePresenter implements BulkEditOperationPresenter {
 
     private final SetAnnotationValueView view;
 
+    private final UuidV4Provider uuidV4Provider;
+
     @Inject
     public SetAnnotationValuePresenter(@Nonnull ProjectId projectId,
-                                       @Nonnull SetAnnotationValueView view) {
+                                       @Nonnull SetAnnotationValueView view,
+                                       @Nonnull UuidV4Provider uuidV4Provider) {
         this.projectId = checkNotNull(projectId);
         this.view = checkNotNull(view);
+        this.uuidV4Provider = checkNotNull(uuidV4Provider);
     }
 
     @Override
@@ -106,7 +112,8 @@ public class SetAnnotationValuePresenter implements BulkEditOperationPresenter {
                                                   @Nonnull OWLAnnotationProperty prop,
                                                   @Nonnull OWLAnnotationValue val,
                                                   @Nonnull String commitMessage) {
-        return SetAnnotationValueAction.create(projectId,
+        return SetAnnotationValueAction.create(ChangeRequestId.get(uuidV4Provider.get()),
+                                               projectId,
                                                entities,
                                                prop,
                                                val,

--- a/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/change/ChangeListPresenter.java
+++ b/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/change/ChangeListPresenter.java
@@ -10,8 +10,10 @@ import edu.stanford.bmir.protege.web.client.library.msgbox.MessageBox;
 import edu.stanford.bmir.protege.web.client.pagination.HasPagination;
 import edu.stanford.bmir.protege.web.client.permissions.LoggedInUserProjectCapabilityChecker;
 import edu.stanford.bmir.protege.web.client.progress.HasBusy;
+import edu.stanford.bmir.protege.web.client.uuid.UuidV4Provider;
 import edu.stanford.bmir.protege.web.shared.TimeUtil;
 import edu.stanford.bmir.protege.web.shared.change.*;
+import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
 import edu.stanford.bmir.protege.web.shared.diff.DiffElement;
 import edu.stanford.bmir.protege.web.shared.download.DownloadFormatExtension;
 import edu.stanford.bmir.protege.web.shared.entity.EntityDisplay;
@@ -68,19 +70,24 @@ public class ChangeListPresenter {
 
     private EntityDisplay entityDisplay;
 
+    @Nonnull
+    private final UuidV4Provider uuidV4Provider;
+
     @Inject
     public ChangeListPresenter(@Nonnull ProjectId projectId,
                                @Nonnull ChangeListView view,
                                @Nonnull DispatchServiceManager dispatch,
                                @Nonnull LoggedInUserProjectCapabilityChecker capabilityChecker,
                                @Nonnull Messages messages,
-                               @Nonnull MessageBox messageBox) {
+                               @Nonnull MessageBox messageBox,
+                               @Nonnull UuidV4Provider uuidV4Provider) {
         this.projectId = checkNotNull(projectId);
         this.view = checkNotNull(view);
         this.capabilityChecker = checkNotNull(capabilityChecker);
         this.dispatch = checkNotNull(dispatch);
         this.messages = checkNotNull(messages);
         this.messageBox = checkNotNull(messageBox);
+        this.uuidV4Provider = checkNotNull(uuidV4Provider);
         this.view.setPageNumberChangedHandler(pageNumber -> pageNumberChangedHandler.handlePageNumberChanged(pageNumber));
     }
 
@@ -210,7 +217,7 @@ public class ChangeListPresenter {
 
     private void revertChanges(ProjectChange projectChange) {
         final RevisionNumber revisionNumber = projectChange.getRevisionNumber();
-        dispatch.execute(RevertRevisionAction.create(projectId, revisionNumber),
+        dispatch.execute(RevertRevisionAction.create(ChangeRequestId.get(uuidV4Provider.get()), projectId, revisionNumber),
                          this::handleChangedReverted);
     }
 

--- a/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/entity/MergeEntitiesPresenter.java
+++ b/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/entity/MergeEntitiesPresenter.java
@@ -8,12 +8,14 @@ import edu.stanford.bmir.protege.web.client.bulkop.BulkEditOperationPresenter;
 import edu.stanford.bmir.protege.web.client.bulkop.BulkOpMessageFormatter;
 import edu.stanford.bmir.protege.web.client.hierarchy.HierarchyDescriptor;
 import edu.stanford.bmir.protege.web.client.hierarchy.HierarchyFieldPresenter;
+import edu.stanford.bmir.protege.web.client.uuid.UuidV4Provider;
 import edu.stanford.bmir.protege.web.shared.HasBrowserText;
 import edu.stanford.bmir.protege.web.shared.dispatch.Action;
 import edu.stanford.bmir.protege.web.shared.entity.MergeEntitiesAction;
 import edu.stanford.bmir.protege.web.shared.entity.OWLEntityData;
 import edu.stanford.bmir.protege.web.shared.event.WebProtegeEventBus;
 import edu.stanford.bmir.protege.web.shared.hierarchy.HierarchyId;
+import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
 import edu.stanford.bmir.protege.web.shared.project.ProjectId;
 import org.semanticweb.owlapi.model.OWLEntity;
 
@@ -44,6 +46,9 @@ public class MergeEntitiesPresenter implements BulkEditOperationPresenter {
     private final HierarchyFieldPresenter hierarchyFieldPresenter;
 
     @Nonnull
+    private final UuidV4Provider uuidV4Provider;
+
+    @Nonnull
     private HandlerRegistration selectionHandlerRegistration = () -> {
     };
 
@@ -51,11 +56,13 @@ public class MergeEntitiesPresenter implements BulkEditOperationPresenter {
     public MergeEntitiesPresenter(@Nonnull MergeEntitiesView view,
                                   @Nonnull ProjectId projectId,
                                   @Nonnull Messages messages,
-                                  @Nonnull HierarchyFieldPresenter hierarchyFieldPresenter) {
+                                  @Nonnull HierarchyFieldPresenter hierarchyFieldPresenter,
+                                  @Nonnull UuidV4Provider uuidV4Provider) {
         this.projectId = checkNotNull(projectId);
         this.messages = checkNotNull(messages);
         this.view = view;
         this.hierarchyFieldPresenter = checkNotNull(hierarchyFieldPresenter);
+        this.uuidV4Provider = checkNotNull(uuidV4Provider);
     }
 
     @Override
@@ -107,7 +114,7 @@ public class MergeEntitiesPresenter implements BulkEditOperationPresenter {
     private MergeEntitiesAction createMergeAction(@Nonnull ImmutableSet<OWLEntity> entities,
                                                   @Nonnull OWLEntityData target,
                                                   @Nonnull String commitMessage) {
-        return MergeEntitiesAction.create(projectId, entities, target.getEntity(), DELETE_MERGED_ENTITY, commitMessage);
+        return MergeEntitiesAction.create(ChangeRequestId.get(uuidV4Provider.get()), projectId, entities, target.getEntity(), DELETE_MERGED_ENTITY, commitMessage);
     }
 
     private void displayConfirmationMessage() {

--- a/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/issues/DiscussionThreadListPresenter.java
+++ b/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/issues/DiscussionThreadListPresenter.java
@@ -4,10 +4,12 @@ import com.google.gwt.user.client.ui.IsWidget;
 import edu.stanford.bmir.protege.web.client.dispatch.DispatchServiceManager;
 import edu.stanford.bmir.protege.web.client.permissions.LoggedInUserProjectCapabilityChecker;
 import edu.stanford.bmir.protege.web.client.progress.HasBusy;
+import edu.stanford.bmir.protege.web.client.uuid.UuidV4Provider;
 import edu.stanford.bmir.protege.web.shared.HasDispose;
 import edu.stanford.bmir.protege.web.shared.entity.EntityDisplay;
 import edu.stanford.bmir.protege.web.shared.event.WebProtegeEventBus;
 import edu.stanford.bmir.protege.web.shared.issues.*;
+import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
 import edu.stanford.bmir.protege.web.shared.project.ProjectId;
 import org.semanticweb.owlapi.model.OWLEntity;
 
@@ -66,6 +68,9 @@ public class DiscussionThreadListPresenter implements HasDispose {
     @Nonnull
     private final CommentEditorModal commentEditorModal;
 
+    @Nonnull
+    private final UuidV4Provider uuidV4Provider;
+
     @Inject
     public DiscussionThreadListPresenter(
             @Nonnull DiscussionThreadListView view,
@@ -73,13 +78,15 @@ public class DiscussionThreadListPresenter implements HasDispose {
             @Nonnull LoggedInUserProjectCapabilityChecker capabilityChecker,
             @Nonnull ProjectId projectId,
             @Nonnull Provider<DiscussionThreadPresenter> discussionThreadPresenterProvider,
-            @Nonnull CommentEditorModal commentEditorModal) {
+            @Nonnull CommentEditorModal commentEditorModal,
+            @Nonnull UuidV4Provider uuidV4Provider) {
         this.view = view;
         this.dispatch = dispatch;
         this.capabilityChecker = capabilityChecker;
         this.projectId = projectId;
         this.discussionThreadPresenterProvider = discussionThreadPresenterProvider;
         this.commentEditorModal = commentEditorModal;
+        this.uuidV4Provider = checkNotNull(uuidV4Provider);
     }
 
     public void setHasBusy(@Nonnull HasBusy hasBusy) {
@@ -175,7 +182,7 @@ public class DiscussionThreadListPresenter implements HasDispose {
     public void createThread() {
         displayedEntity.ifPresent(targetEntity -> {
             Consumer<String> handler = body -> dispatch.execute(
-                    CreateEntityDiscussionThreadAction.create(projectId, targetEntity, body),
+                    CreateEntityDiscussionThreadAction.create(ChangeRequestId.get(uuidV4Provider.get()), projectId, targetEntity, body),
                     result -> displayThreads(result.getThreads()));
             commentEditorModal.showModal("", handler);
         });

--- a/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/issues/DiscussionThreadPresenter.java
+++ b/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/issues/DiscussionThreadPresenter.java
@@ -5,9 +5,11 @@ import edu.stanford.bmir.protege.web.client.dispatch.DispatchServiceManager;
 import edu.stanford.bmir.protege.web.client.library.msgbox.MessageBox;
 import edu.stanford.bmir.protege.web.client.permissions.LoggedInUserProjectCapabilityChecker;
 import edu.stanford.bmir.protege.web.client.user.LoggedInUserProvider;
+import edu.stanford.bmir.protege.web.client.uuid.UuidV4Provider;
 import edu.stanford.bmir.protege.web.shared.HasDispose;
 import edu.stanford.bmir.protege.web.shared.event.HandlerRegistrationManager;
 import edu.stanford.bmir.protege.web.shared.issues.*;
+import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
 import edu.stanford.bmir.protege.web.shared.project.ProjectId;
 
 import javax.annotation.Nonnull;
@@ -19,12 +21,8 @@ import java.util.function.Consumer;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static edu.stanford.bmir.protege.web.shared.access.BuiltInCapability.*;
-import static edu.stanford.bmir.protege.web.shared.issues.AddEntityCommentAction.addComment;
 import static edu.stanford.bmir.protege.web.shared.issues.CommentPostedEvent.ON_COMMENT_POSTED;
 import static edu.stanford.bmir.protege.web.shared.issues.CommentUpdatedEvent.ON_COMMENT_UPDATED;
-import static edu.stanford.bmir.protege.web.shared.issues.DeleteEntityCommentAction.deleteComment;
-import static edu.stanford.bmir.protege.web.shared.issues.EditCommentAction.editComment;
-import static edu.stanford.bmir.protege.web.shared.issues.SetDiscussionThreadStatusAction.setDiscussionThreadStatus;
 import static edu.stanford.bmir.protege.web.shared.permissions.PermissionsChangedEvent.ON_CAPABILITIES_CHANGED;
 
 /**
@@ -64,6 +62,9 @@ public class DiscussionThreadPresenter implements HasDispose {
     @Nonnull
     private final MessageBox messageBox;
 
+    @Nonnull
+    private final UuidV4Provider uuidV4Provider;
+
     private final Map<CommentId, CommentView> commentViewMap = new HashMap<>();
 
 
@@ -80,7 +81,8 @@ public class DiscussionThreadPresenter implements HasDispose {
                                      @Nonnull LoggedInUserProvider loggedInUserProvider,
                                      @Nonnull CommentViewFactory commentViewFactory,
                                      @Nonnull MessageBox messageBox,
-                                     @Nonnull CommentEditorModal commentEditorModal) {
+                                     @Nonnull CommentEditorModal commentEditorModal,
+                                     @Nonnull UuidV4Provider uuidV4Provider) {
         this.view = checkNotNull(view);
         this.messages = checkNotNull(messages);
         this.projectId = checkNotNull(projectId);
@@ -91,6 +93,11 @@ public class DiscussionThreadPresenter implements HasDispose {
         this.commentViewFactory = checkNotNull(commentViewFactory);
         this.commentEditorModal = commentEditorModal;
         this.messageBox = checkNotNull(messageBox);
+        this.uuidV4Provider = checkNotNull(uuidV4Provider);
+    }
+
+    private ChangeRequestId newChangeRequestId() {
+        return ChangeRequestId.get(uuidV4Provider.get());
     }
 
     @Nonnull
@@ -173,7 +180,7 @@ public class DiscussionThreadPresenter implements HasDispose {
     private void handleToggleStatus(ThreadId threadId) {
         Status nextStatus = view.getStatus() == Status.OPEN ? Status.CLOSED : Status.OPEN;
         dispatch.execute(
-                setDiscussionThreadStatus(projectId, threadId, nextStatus),
+                new SetDiscussionThreadStatusAction(newChangeRequestId(), projectId, threadId, nextStatus),
                 (result) -> view.setStatus(result.getResult())
         );
     }
@@ -181,14 +188,14 @@ public class DiscussionThreadPresenter implements HasDispose {
     private void handleReplyToComment(ThreadId threadId) {
         Consumer<String> handler = body -> {
             dispatch.execute(
-                    addComment(projectId, threadId, body),
+                    AddEntityCommentAction.addComment(newChangeRequestId(), projectId, threadId, body),
                     result -> handleCommentAdded(threadId, result.getComment()));
         };
         commentEditorModal.showModal("", handler);
     }
 
     private void handleEditComment(ThreadId threadId, Comment comment) {
-        Consumer<String> handler = body -> dispatch.execute(editComment(projectId, threadId, comment.getId(), body),
+        Consumer<String> handler = body -> dispatch.execute(EditCommentAction.editComment(newChangeRequestId(), projectId, threadId, comment.getId(), body),
                                                             result -> result
                                                                     .getEditedComment()
                                                                     .ifPresent(this::updateComment));
@@ -206,7 +213,7 @@ public class DiscussionThreadPresenter implements HasDispose {
     private void handleDeleteComment(Comment comment) {
         messageBox.showYesNoConfirmBox(messages.deleteCommentConfirmationBoxTitle(),
                                        messages.deleteCommentConfirmationBoxText(),
-                                       () -> dispatch.execute(deleteComment(projectId, comment.getId()), result -> {
+                                       () -> dispatch.execute(DeleteEntityCommentAction.deleteComment(newChangeRequestId(), projectId, comment.getId()), result -> {
                                        }));
     }
 

--- a/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/lang/DisplayNameSettingsManager.java
+++ b/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/lang/DisplayNameSettingsManager.java
@@ -2,6 +2,8 @@ package edu.stanford.bmir.protege.web.client.lang;
 
 import com.google.web.bindery.event.shared.EventBus;
 import edu.stanford.bmir.protege.web.client.project.ActiveProjectManager;
+import edu.stanford.bmir.protege.web.client.uuid.UuidV4Provider;
+import edu.stanford.bmir.protege.web.shared.event.EventId;
 import edu.stanford.bmir.protege.web.shared.inject.ProjectSingleton;
 import edu.stanford.bmir.protege.web.shared.lang.DisplayNameSettings;
 import edu.stanford.bmir.protege.web.shared.lang.DisplayNameSettingsChangedEvent;
@@ -33,6 +35,9 @@ public class DisplayNameSettingsManager {
     private final ActiveProjectManager activeProjectManager;
 
     @Nonnull
+    private final UuidV4Provider uuidV4Provider;
+
+    @Nonnull
     private DisplayNameSettings displayNameSettings = DisplayNameSettings.empty();
 
     private boolean loaded = false;
@@ -41,11 +46,13 @@ public class DisplayNameSettingsManager {
     public DisplayNameSettingsManager(@Nonnull ProjectId projectId,
                                       @Nonnull EventBus eventBus,
                                       @Nonnull DisplayLanguageStorage displayLanguageStorage,
-                                      @Nonnull ActiveProjectManager activeProjectManager) {
+                                      @Nonnull ActiveProjectManager activeProjectManager,
+                                      @Nonnull UuidV4Provider uuidV4Provider) {
         this.projectId = checkNotNull(projectId);
         this.eventBus = checkNotNull(eventBus);
         this.displayLanguageStorage = checkNotNull(displayLanguageStorage);
         this.activeProjectManager = checkNotNull(activeProjectManager);
+        this.uuidV4Provider = checkNotNull(uuidV4Provider);
     }
 
     @Nonnull
@@ -64,7 +71,7 @@ public class DisplayNameSettingsManager {
         }
         this.displayNameSettings = checkNotNull(displayNameSettings);
         this.displayLanguageStorage.store(displayNameSettings);
-        eventBus.fireEventFromSource(DisplayNameSettingsChangedEvent.get(projectId, displayNameSettings).asGWTEvent(),
+        eventBus.fireEventFromSource(DisplayNameSettingsChangedEvent.get(EventId.get(uuidV4Provider.get()), projectId, displayNameSettings).asGWTEvent(),
                                      projectId);
     }
 }

--- a/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/merge/MergeUploadedProjectWorkflow.java
+++ b/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/merge/MergeUploadedProjectWorkflow.java
@@ -11,9 +11,11 @@ import edu.stanford.bmir.protege.web.client.library.dlg.WebProtegeDialog;
 import edu.stanford.bmir.protege.web.client.library.dlg.WebProtegeDialogButtonHandler;
 import edu.stanford.bmir.protege.web.client.library.dlg.WebProtegeDialogCloser;
 import edu.stanford.bmir.protege.web.client.library.msgbox.MessageBox;
+import edu.stanford.bmir.protege.web.client.uuid.UuidV4Provider;
 import edu.stanford.bmir.protege.web.shared.csv.DocumentId;
 import edu.stanford.bmir.protege.web.shared.diff.DiffElement;
 import edu.stanford.bmir.protege.web.shared.merge.*;
+import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
 import edu.stanford.bmir.protege.web.shared.project.ProjectId;
 
 import javax.annotation.Nonnull;
@@ -42,12 +44,16 @@ public class MergeUploadedProjectWorkflow {
     @Nonnull
     private final ProgressDisplay progressDisplay;
 
+    @Nonnull
+    private final UuidV4Provider uuidV4Provider;
+
     @Inject
-    public MergeUploadedProjectWorkflow(@Nonnull DispatchServiceManager dispatchServiceManager, MessageBox messageBox, @Nonnull DispatchErrorMessageDisplay errorDisplay, @Nonnull ProgressDisplay progressDisplay) {
+    public MergeUploadedProjectWorkflow(@Nonnull DispatchServiceManager dispatchServiceManager, MessageBox messageBox, @Nonnull DispatchErrorMessageDisplay errorDisplay, @Nonnull ProgressDisplay progressDisplay, @Nonnull UuidV4Provider uuidV4Provider) {
         this.dispatchServiceManager = checkNotNull(dispatchServiceManager);
         this.messageBox = checkNotNull(messageBox);
         this.errorDisplay = checkNotNull(errorDisplay);
         this.progressDisplay = checkNotNull(progressDisplay);
+        this.uuidV4Provider = checkNotNull(uuidV4Provider);
     }
 
     public void start(ProjectId projectId, DocumentId documentId) {
@@ -100,7 +106,7 @@ public class MergeUploadedProjectWorkflow {
 
     private void performMerge(ProjectId projectId, DocumentId uploadedProjectDocumentId, String commitMessage) {
 
-        dispatchServiceManager.execute(MergeUploadedProjectAction.create(projectId, uploadedProjectDocumentId, commitMessage), new DispatchServiceCallbackWithProgressDisplay<MergeUploadedProjectResult>(errorDisplay, progressDisplay) {
+        dispatchServiceManager.execute(MergeUploadedProjectAction.create(ChangeRequestId.get(uuidV4Provider.get()), projectId, uploadedProjectDocumentId, commitMessage), new DispatchServiceCallbackWithProgressDisplay<MergeUploadedProjectResult>(errorDisplay, progressDisplay) {
 
             @Override
             public String getProgressDisplayTitle() {

--- a/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/merge_add/ExistingOntologyMergeProjectWorkflow.java
+++ b/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/merge_add/ExistingOntologyMergeProjectWorkflow.java
@@ -9,9 +9,11 @@ import edu.stanford.bmir.protege.web.client.library.dlg.WebProtegeDialog;
 import edu.stanford.bmir.protege.web.client.library.dlg.WebProtegeDialogButtonHandler;
 import edu.stanford.bmir.protege.web.client.library.dlg.WebProtegeDialogCloser;
 import edu.stanford.bmir.protege.web.client.library.msgbox.MessageBox;
+import edu.stanford.bmir.protege.web.client.uuid.UuidV4Provider;
 import edu.stanford.bmir.protege.web.shared.csv.DocumentId;
 import edu.stanford.bmir.protege.web.shared.merge_add.ExistingOntologyMergeAddAction;
 import edu.stanford.bmir.protege.web.shared.merge_add.ExistingOntologyMergeAddResult;
+import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
 import edu.stanford.bmir.protege.web.shared.project.ProjectId;
 import org.semanticweb.owlapi.model.OWLOntologyID;
 
@@ -32,15 +34,20 @@ public class ExistingOntologyMergeProjectWorkflow {
     @Nonnull
     private final ProgressDisplay progressDisplay;
 
+    @Nonnull
+    private final UuidV4Provider uuidV4Provider;
+
     @Inject
     public ExistingOntologyMergeProjectWorkflow(@Nonnull DispatchServiceManager dispatchServiceManager,
                                                 @Nonnull MessageBox messageBox,
                                                 @Nonnull DispatchErrorMessageDisplay errorDisplay,
-                                                @Nonnull ProgressDisplay progressDisplay) {
+                                                @Nonnull ProgressDisplay progressDisplay,
+                                                @Nonnull UuidV4Provider uuidV4Provider) {
         this.dispatchServiceManager = dispatchServiceManager;
         this.messageBox = messageBox;
         this.errorDisplay = errorDisplay;
         this.progressDisplay = progressDisplay;
+        this.uuidV4Provider = uuidV4Provider;
     }
 
 
@@ -62,7 +69,7 @@ public class ExistingOntologyMergeProjectWorkflow {
     }
 
     private void mergeIntoExistingOntology(ProjectId projectId, DocumentId documentId, List<OWLOntologyID> selectedOntologies, OWLOntologyID targetOntology){
-        dispatchServiceManager.execute(ExistingOntologyMergeAddAction.create(projectId, documentId, selectedOntologies, targetOntology), new DispatchServiceCallbackWithProgressDisplay<ExistingOntologyMergeAddResult>(errorDisplay, progressDisplay) {
+        dispatchServiceManager.execute(ExistingOntologyMergeAddAction.create(ChangeRequestId.get(uuidV4Provider.get()), projectId, documentId, selectedOntologies, targetOntology), new DispatchServiceCallbackWithProgressDisplay<ExistingOntologyMergeAddResult>(errorDisplay, progressDisplay) {
             @Override
             public String getProgressDisplayTitle() {
                 return "Uploading and Merging Ontologies";

--- a/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/merge_add/NewOntologyMergeProjectWorkflow.java
+++ b/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/merge_add/NewOntologyMergeProjectWorkflow.java
@@ -9,9 +9,11 @@ import edu.stanford.bmir.protege.web.client.library.dlg.WebProtegeDialog;
 import edu.stanford.bmir.protege.web.client.library.dlg.WebProtegeDialogButtonHandler;
 import edu.stanford.bmir.protege.web.client.library.dlg.WebProtegeDialogCloser;
 import edu.stanford.bmir.protege.web.client.library.msgbox.MessageBox;
+import edu.stanford.bmir.protege.web.client.uuid.UuidV4Provider;
 import edu.stanford.bmir.protege.web.shared.csv.DocumentId;
 import edu.stanford.bmir.protege.web.shared.merge_add.NewOntologyMergeAddAction;
 import edu.stanford.bmir.protege.web.shared.merge_add.NewOntologyMergeAddResult;
+import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
 import edu.stanford.bmir.protege.web.shared.project.ProjectId;
 import org.semanticweb.owlapi.model.OWLOntologyID;
 
@@ -32,15 +34,20 @@ public class NewOntologyMergeProjectWorkflow {
     @Nonnull
     private final ProgressDisplay progressDisplay;
 
+    @Nonnull
+    private final UuidV4Provider uuidV4Provider;
+
     @Inject
     public NewOntologyMergeProjectWorkflow(@Nonnull DispatchServiceManager dispatchServiceManager,
                                            @Nonnull MessageBox messageBox,
                                            @Nonnull DispatchErrorMessageDisplay errorDisplay,
-                                           @Nonnull ProgressDisplay progressDisplay) {
+                                           @Nonnull ProgressDisplay progressDisplay,
+                                           @Nonnull UuidV4Provider uuidV4Provider) {
         this.dispatchServiceManager = dispatchServiceManager;
         this.messageBox = messageBox;
         this.errorDisplay = errorDisplay;
         this.progressDisplay = progressDisplay;
+        this.uuidV4Provider = uuidV4Provider;
     }
 
     public void start(ProjectId projectId, DocumentId documentId, List<OWLOntologyID> ontologyList){
@@ -61,7 +68,7 @@ public class NewOntologyMergeProjectWorkflow {
     }
 
     private void mergeAdd(ProjectId projectId, DocumentId documentId, String iri, List<OWLOntologyID> ontologyList){
-        dispatchServiceManager.execute(NewOntologyMergeAddAction.create(projectId, documentId, iri, ontologyList), new DispatchServiceCallbackWithProgressDisplay<NewOntologyMergeAddResult>(errorDisplay, progressDisplay) {
+        dispatchServiceManager.execute(NewOntologyMergeAddAction.create(ChangeRequestId.get(uuidV4Provider.get()), projectId, documentId, iri, ontologyList), new DispatchServiceCallbackWithProgressDisplay<NewOntologyMergeAddResult>(errorDisplay, progressDisplay) {
             @Override
             public String getProgressDisplayTitle() {
                 return "Uploading and Merging Ontologies";

--- a/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/ontology/annotations/OntologyAnnotationsPortletPresenter.java
+++ b/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/ontology/annotations/OntologyAnnotationsPortletPresenter.java
@@ -9,6 +9,7 @@ import edu.stanford.bmir.protege.web.client.portlet.AbstractWebProtegePortletPre
 import edu.stanford.bmir.protege.web.client.portlet.PortletUi;
 import edu.stanford.bmir.protege.web.client.selection.SelectedPathsModel;
 import edu.stanford.bmir.protege.web.client.selection.SelectionModel;
+import edu.stanford.bmir.protege.web.client.uuid.UuidV4Provider;
 import edu.stanford.bmir.protege.web.shared.access.BuiltInCapability;
 import edu.stanford.bmir.protege.web.shared.dispatch.actions.GetOntologyAnnotationsAction;
 import edu.stanford.bmir.protege.web.shared.dispatch.actions.SetOntologyAnnotationsAction;
@@ -16,6 +17,7 @@ import edu.stanford.bmir.protege.web.shared.event.OntologyFrameChangedEvent;
 import edu.stanford.bmir.protege.web.shared.event.WebProtegeEventBus;
 import edu.stanford.bmir.protege.web.shared.frame.PropertyAnnotationValue;
 import edu.stanford.bmir.protege.web.shared.permissions.PermissionsChangedEvent;
+import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
 import edu.stanford.bmir.protege.web.shared.project.ProjectId;
 import edu.stanford.webprotege.shared.annotations.Portlet;
 import org.semanticweb.owlapi.model.OWLOntologyID;
@@ -38,6 +40,9 @@ public class OntologyAnnotationsPortletPresenter extends AbstractWebProtegePortl
 
     private final LoggedInUserProjectCapabilityChecker capabilityChecker;
 
+    @Nonnull
+    private final UuidV4Provider uuidV4Provider;
+
     private Optional<List<PropertyAnnotationValue>> lastSet = Optional.empty();
 
     private Optional<OWLOntologyID> currentOntologyId = Optional.empty();
@@ -50,11 +55,13 @@ public class OntologyAnnotationsPortletPresenter extends AbstractWebProtegePortl
                                                ProjectId projectId,
                                                LoggedInUserProjectCapabilityChecker capabilityChecker,
                                                DisplayNameRenderer displayNameRenderer,
-                                               DispatchServiceManager dispatch) {
+                                               DispatchServiceManager dispatch,
+                                               @Nonnull UuidV4Provider uuidV4Provider) {
         super(selectionModel, projectId, displayNameRenderer, dispatch, selectedPathsModel);
         this.annotationsView = annotationsView;
         this.dispatchServiceManager = dispatchServiceManager;
         this.capabilityChecker = capabilityChecker;
+        this.uuidV4Provider = uuidV4Provider;
         annotationsView.addValueChangeHandler(event -> handleOntologyAnnotationsChanged());
     }
 
@@ -112,7 +119,7 @@ public class OntologyAnnotationsPortletPresenter extends AbstractWebProtegePortl
         }
         Optional<Set<PropertyAnnotationValue>> annotations = annotationsView.getValue();
         if (annotations.isPresent() && lastSet.isPresent() && currentOntologyId.isPresent()) {
-            dispatchServiceManager.execute(SetOntologyAnnotationsAction.create(getProjectId(), currentOntologyId.get(), new HashSet<>(lastSet.get()), annotations.get()),
+            dispatchServiceManager.execute(SetOntologyAnnotationsAction.create(ChangeRequestId.get(uuidV4Provider.get()), getProjectId(), currentOntologyId.get(), new HashSet<>(lastSet.get()), annotations.get()),
                     result -> {
                     });
         }

--- a/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/permissions/PermissionManager.java
+++ b/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/permissions/PermissionManager.java
@@ -12,9 +12,11 @@ import edu.stanford.bmir.protege.web.client.events.UserLoggedInEvent;
 import edu.stanford.bmir.protege.web.client.events.UserLoggedOutEvent;
 import edu.stanford.bmir.protege.web.client.project.ActiveProjectManager;
 import edu.stanford.bmir.protege.web.client.user.LoggedInUserProvider;
+import edu.stanford.bmir.protege.web.client.uuid.UuidV4Provider;
 import edu.stanford.bmir.protege.web.shared.HasDispose;
 import edu.stanford.bmir.protege.web.shared.access.BasicCapability;
 import edu.stanford.bmir.protege.web.shared.access.Capability;
+import edu.stanford.bmir.protege.web.shared.event.EventId;
 import edu.stanford.bmir.protege.web.shared.inject.ApplicationSingleton;
 import edu.stanford.bmir.protege.web.shared.permissions.GetProjectPermissionsAction;
 import edu.stanford.bmir.protege.web.shared.permissions.GetProjectPermissionsResult;
@@ -54,8 +56,10 @@ public class PermissionManager implements HasDispose {
 
     private final DispatchErrorMessageDisplay errorDisplay;
 
+    private final UuidV4Provider uuidV4Provider;
+
     @Inject
-    public PermissionManager(EventBus eventBus, DispatchServiceManager dispatchServiceManager, ActiveProjectManager activeProjectManager, LoggedInUserProvider loggedInUserProvider, DispatchErrorMessageDisplay errorDisplay) {
+    public PermissionManager(EventBus eventBus, DispatchServiceManager dispatchServiceManager, ActiveProjectManager activeProjectManager, LoggedInUserProvider loggedInUserProvider, DispatchErrorMessageDisplay errorDisplay, UuidV4Provider uuidV4Provider) {
         this.eventBus = eventBus;
         this.dispatchServiceManager = dispatchServiceManager;
         this.activeProjectManager = activeProjectManager;
@@ -63,6 +67,7 @@ public class PermissionManager implements HasDispose {
         loggedInHandler = eventBus.addHandler(UserLoggedInEvent.ON_USER_LOGGED_IN, event -> firePermissionsChanged());
         loggedOutHandler = eventBus.addHandler(UserLoggedOutEvent.ON_USER_LOGGED_OUT, event -> firePermissionsChanged());
         this.errorDisplay = errorDisplay;
+        this.uuidV4Provider = uuidV4Provider;
     }
 
     /**
@@ -82,7 +87,7 @@ public class PermissionManager implements HasDispose {
             UserIdProjectIdKey key = new UserIdProjectIdKey(userId, theProjectId);
             capabilitiesCache.putAll(key, result.getAllowedActions());
             GWT.log("[PermissionManager] Firing permissions changed for project: " + projectId);
-            eventBus.fireEventFromSource(new PermissionsChangedEvent(theProjectId).asGWTEvent(), theProjectId);
+            eventBus.fireEventFromSource(new PermissionsChangedEvent(EventId.get(uuidV4Provider.get()), theProjectId).asGWTEvent(), theProjectId);
         });
 
     }

--- a/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/perspective/PerspectivesManagerService.java
+++ b/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/perspective/PerspectivesManagerService.java
@@ -3,6 +3,7 @@ package edu.stanford.bmir.protege.web.client.perspective;
 import com.google.common.collect.ImmutableList;
 import edu.stanford.bmir.protege.web.client.dispatch.DispatchServiceManager;
 import edu.stanford.bmir.protege.web.client.user.LoggedInUserProvider;
+import edu.stanford.bmir.protege.web.client.uuid.UuidV4Provider;
 import edu.stanford.bmir.protege.web.shared.perspective.*;
 import edu.stanford.bmir.protege.web.shared.project.ProjectId;
 import edu.stanford.bmir.protege.web.shared.user.UserId;
@@ -30,13 +31,18 @@ public class PerspectivesManagerService {
     @Nonnull
     private final DispatchServiceManager dispatch;
 
+    @Nonnull
+    private final UuidV4Provider uuidV4Provider;
+
     @Inject
     public PerspectivesManagerService(@Nonnull ProjectId projectId,
                                       @Nonnull LoggedInUserProvider loggedInUserProvider,
-                                      DispatchServiceManager dispatch) {
+                                      DispatchServiceManager dispatch,
+                                      @Nonnull UuidV4Provider uuidV4Provider) {
         this.projectId = projectId;
         this.loggedInUserProvider = loggedInUserProvider;
         this.dispatch = checkNotNull(dispatch);
+        this.uuidV4Provider = checkNotNull(uuidV4Provider);
     }
 
     public void getPerspectiveDetails(Consumer<List<PerspectiveDetails>> details) {
@@ -50,19 +56,22 @@ public class PerspectivesManagerService {
     public void savePerspectives(@Nonnull ImmutableList<PerspectiveDescriptor> descriptors,
                                  @Nonnull Runnable completeHandler) {
         UserId currentUserId = loggedInUserProvider.getCurrentUserId();
-        dispatch.execute(SetPerspectivesAction.create(projectId, currentUserId, descriptors),
+        dispatch.execute(SetPerspectivesAction.create(newChangeRequestId(), projectId, currentUserId, descriptors),
                          result -> completeHandler.run());
     }
 
     public void savePerspectivesAsProjectDefaults(@Nonnull ImmutableList<PerspectiveDescriptor> descriptors,
                                                   @Nonnull Runnable completeHandler) {
-        UserId currentUserId = loggedInUserProvider.getCurrentUserId();
-        dispatch.execute(SetPerspectivesAction.create(projectId, descriptors),
+        dispatch.execute(SetPerspectivesAction.create(newChangeRequestId(), projectId, null, descriptors),
                          result -> completeHandler.run());
     }
 
     public void resetPerspectives(@Nonnull Runnable completionHandler) {
-        dispatch.execute(ResetPerspectivesAction.create(projectId),
+        dispatch.execute(ResetPerspectivesAction.create(newChangeRequestId(), projectId),
                          result -> completionHandler.run());
+    }
+
+    private ChangeRequestId newChangeRequestId() {
+        return ChangeRequestId.get(uuidV4Provider.get());
     }
 }

--- a/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/perspective/ProjectPerspectivesServiceImpl.java
+++ b/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/perspective/ProjectPerspectivesServiceImpl.java
@@ -3,6 +3,8 @@ package edu.stanford.bmir.protege.web.client.perspective;
 import com.google.common.collect.ImmutableList;
 import edu.stanford.bmir.protege.web.client.dispatch.DispatchServiceManager;
 import edu.stanford.bmir.protege.web.client.user.LoggedInUserProvider;
+import edu.stanford.bmir.protege.web.client.uuid.UuidV4Provider;
+import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
 import edu.stanford.bmir.protege.web.shared.perspective.GetPerspectivesAction;
 import edu.stanford.bmir.protege.web.shared.perspective.PerspectiveDescriptor;
 import edu.stanford.bmir.protege.web.shared.perspective.SetPerspectivesAction;
@@ -31,13 +33,18 @@ public class ProjectPerspectivesServiceImpl implements ProjectPerspectivesServic
     @Nonnull
     private final ProjectId projectId;
 
+    @Nonnull
+    private final UuidV4Provider uuidV4Provider;
+
     @Inject
     public ProjectPerspectivesServiceImpl(@Nonnull ProjectId projectId,
                                           @Nonnull DispatchServiceManager dispatch,
-                                          @Nonnull LoggedInUserProvider loggedInUserProvider) {
+                                          @Nonnull LoggedInUserProvider loggedInUserProvider,
+                                          @Nonnull UuidV4Provider uuidV4Provider) {
         this.dispatch = checkNotNull(dispatch);
         this.loggedInUserProvider = checkNotNull(loggedInUserProvider);
         this.projectId = checkNotNull(projectId);
+        this.uuidV4Provider = checkNotNull(uuidV4Provider);
     }
 
     public void getPerspectives(final PerspectiveServiceCallback callback) {
@@ -51,7 +58,8 @@ public class ProjectPerspectivesServiceImpl implements ProjectPerspectivesServic
     @Override
     public void setPerspectives(List<PerspectiveDescriptor> perspectives, PerspectiveServiceCallback callback) {
         UserId user = loggedInUserProvider.getCurrentUserId();
-        dispatch.execute(SetPerspectivesAction.create(projectId, user, ImmutableList.copyOf(perspectives)), result -> {
+        ChangeRequestId changeRequestId = ChangeRequestId.get(uuidV4Provider.get());
+        dispatch.execute(SetPerspectivesAction.create(changeRequestId, projectId, user, ImmutableList.copyOf(perspectives)), result -> {
             callback.handlePerspectives(result.getPerspectives(), result.getResettablePerspectives());
         });
     }

--- a/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/project/ProjectPrefixDeclarationsPresenter.java
+++ b/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/project/ProjectPrefixDeclarationsPresenter.java
@@ -13,6 +13,8 @@ import edu.stanford.bmir.protege.web.client.dispatch.DispatchServiceManager;
 import edu.stanford.bmir.protege.web.client.dispatch.ProgressDisplay;
 import edu.stanford.bmir.protege.web.client.library.msgbox.MessageBox;
 import edu.stanford.bmir.protege.web.client.settings.SettingsPresenter;
+import edu.stanford.bmir.protege.web.client.uuid.UuidV4Provider;
+import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
 import edu.stanford.bmir.protege.web.shared.place.ProjectPrefixDeclarationsPlace;
 import edu.stanford.bmir.protege.web.shared.project.*;
 
@@ -68,6 +70,9 @@ public class ProjectPrefixDeclarationsPresenter implements Presenter {
     @Nonnull
     private final ProgressDisplay progressDisplay;
 
+    @Nonnull
+    private final UuidV4Provider uuidV4Provider;
+
     @Inject
     public ProjectPrefixDeclarationsPresenter(@Nonnull ProjectId projectId,
                                               @Nonnull ProjectPrefixDeclarationsView view,
@@ -75,7 +80,8 @@ public class ProjectPrefixDeclarationsPresenter implements Presenter {
                                               @Nonnull DispatchServiceManager dispatchServiceManager,
                                               @Nonnull PlaceController placeController,
                                               @Nonnull SettingsPresenter settingsPresenter,
-                                              @Nonnull Messages messages, MessageBox messageBox, @Nonnull DispatchErrorMessageDisplay errorDisplay, @Nonnull ProgressDisplay progressDisplay) {
+                                              @Nonnull Messages messages, MessageBox messageBox, @Nonnull DispatchErrorMessageDisplay errorDisplay, @Nonnull ProgressDisplay progressDisplay,
+                                              @Nonnull UuidV4Provider uuidV4Provider) {
         this.projectId = checkNotNull(projectId);
         this.view = checkNotNull(view);
         this.capabilityScreener = checkNotNull(capabilityScreener);
@@ -86,6 +92,7 @@ public class ProjectPrefixDeclarationsPresenter implements Presenter {
         this.messageBox = checkNotNull(messageBox);
         this.errorDisplay = checkNotNull(errorDisplay);
         this.progressDisplay = checkNotNull(progressDisplay);
+        this.uuidV4Provider = checkNotNull(uuidV4Provider);
     }
 
     @Override
@@ -183,7 +190,7 @@ public class ProjectPrefixDeclarationsPresenter implements Presenter {
     }
 
     private void applyChanges() {
-        dispatchServiceManager.execute(SetProjectPrefixDeclarationsAction.create(projectId, view.getPrefixDeclarations()),
+        dispatchServiceManager.execute(SetProjectPrefixDeclarationsAction.create(ChangeRequestId.get(uuidV4Provider.get()), projectId, view.getPrefixDeclarations()),
                                        result -> handleChangesApplied());
     }
 

--- a/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/projectsettings/ProjectSettingsPresenter.java
+++ b/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/projectsettings/ProjectSettingsPresenter.java
@@ -12,6 +12,7 @@ import edu.stanford.bmir.protege.web.client.lang.DefaultDictionaryLanguageView;
 import edu.stanford.bmir.protege.web.client.lang.DefaultDisplayNameSettingsView;
 import edu.stanford.bmir.protege.web.client.renderer.AnnotationPropertyIriRenderer;
 import edu.stanford.bmir.protege.web.client.settings.SettingsPresenter;
+import edu.stanford.bmir.protege.web.client.uuid.UuidV4Provider;
 import edu.stanford.bmir.protege.web.shared.DataFactory;
 import edu.stanford.bmir.protege.web.shared.crud.EntityCrudKitSettings;
 import edu.stanford.bmir.protege.web.shared.crud.GetEntityCrudKitsAction;
@@ -20,6 +21,7 @@ import edu.stanford.bmir.protege.web.shared.crud.SetEntityCrudKitSettingsAction;
 import edu.stanford.bmir.protege.web.shared.entity.OWLAnnotationPropertyData;
 import edu.stanford.bmir.protege.web.shared.lang.DictionaryLanguageUsage;
 import edu.stanford.bmir.protege.web.shared.lang.DisplayNameSettings;
+import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
 import edu.stanford.bmir.protege.web.shared.project.GetProjectInfoAction;
 import edu.stanford.bmir.protege.web.shared.project.ProjectId;
 import edu.stanford.bmir.protege.web.shared.projectsettings.*;
@@ -89,6 +91,9 @@ public class ProjectSettingsPresenter {
     @Nonnull
     private final EntityDeprecationSettingsPresenter entityDeprecationSettingsPresenter;
 
+    @Nonnull
+    private final UuidV4Provider uuidV4Provider;
+
     @Inject
     public ProjectSettingsPresenter(@Nonnull ProjectId projectId,
                                     @Nonnull CapabilityScreener capabilityScreener,
@@ -105,7 +110,8 @@ public class ProjectSettingsPresenter {
                                     @Nonnull Messages messages,
                                     @Nonnull AnnotationPropertyIriRenderer annotationPropertyIriRenderer,
                                     @Nonnull ProjectSettingsService projectSettingsService,
-                                    @Nonnull EntityDeprecationSettingsPresenter entityDeprecationSettingsPresenter) {
+                                    @Nonnull EntityDeprecationSettingsPresenter entityDeprecationSettingsPresenter,
+                                    @Nonnull UuidV4Provider uuidV4Provider) {
         this.projectId = checkNotNull(projectId);
         this.capabilityScreener = checkNotNull(capabilityScreener);
         this.dispatchServiceManager = checkNotNull(dispatchServiceManager);
@@ -121,6 +127,7 @@ public class ProjectSettingsPresenter {
         this.annotationPropertyIriRenderer = checkNotNull(annotationPropertyIriRenderer);
         this.projectSettingsService = checkNotNull(projectSettingsService);
         this.entityDeprecationSettingsPresenter = checkNotNull(entityDeprecationSettingsPresenter);
+        this.uuidV4Provider = checkNotNull(uuidV4Provider);
     }
 
     public ProjectId getProjectId() {
@@ -257,12 +264,13 @@ public class ProjectSettingsPresenter {
                 webhookSettings,
                 entityDeprecationSettingsPresenter.getValue()
         );
-        dispatchServiceManager.execute(SetProjectSettingsAction.create(projectSettings), result -> {
+        dispatchServiceManager.execute(SetProjectSettingsAction.create(ChangeRequestId.get(uuidV4Provider.get()), projectId, projectSettings), result -> {
             eventBus.fireEvent(new ProjectSettingsChangedEvent(projectSettings).asGWTEvent());
             settingsPresenter.goToNextPlace();
         });
         EntityCrudKitSettings settings = entityCrudKitSettingsPresenter.getSettings();
-            dispatchServiceManager.execute(new SetEntityCrudKitSettingsAction(projectId,
+            dispatchServiceManager.execute(new SetEntityCrudKitSettingsAction(ChangeRequestId.get(uuidV4Provider.get()),
+                                                                              projectId,
                                                                               settings, settings,
                                                                               IRIPrefixUpdateStrategy.LEAVE_INTACT),
                                            result -> {});

--- a/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/search/EntitySearchSettingsService.java
+++ b/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/search/EntitySearchSettingsService.java
@@ -2,6 +2,8 @@ package edu.stanford.bmir.protege.web.client.search;
 
 import com.google.common.collect.ImmutableList;
 import edu.stanford.bmir.protege.web.client.dispatch.DispatchServiceManager;
+import edu.stanford.bmir.protege.web.client.uuid.UuidV4Provider;
+import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
 import edu.stanford.bmir.protege.web.shared.project.ProjectId;
 import edu.stanford.bmir.protege.web.shared.search.EntitySearchFilter;
 import edu.stanford.bmir.protege.web.shared.search.GetSearchSettingsAction;
@@ -26,10 +28,14 @@ public class EntitySearchSettingsService {
     @Nonnull
     private final ProjectId projectId;
 
+    @Nonnull
+    private final UuidV4Provider uuidV4Provider;
+
     @Inject
-    public EntitySearchSettingsService(DispatchServiceManager dispatch, @Nonnull ProjectId projectId) {
+    public EntitySearchSettingsService(DispatchServiceManager dispatch, @Nonnull ProjectId projectId, @Nonnull UuidV4Provider uuidV4Provider) {
         this.dispatch = checkNotNull(dispatch);
         this.projectId = checkNotNull(projectId);
+        this.uuidV4Provider = checkNotNull(uuidV4Provider);
     }
 
     public void getFilters(Consumer<ImmutableList<EntitySearchFilter>> filters) {
@@ -38,7 +44,8 @@ public class EntitySearchSettingsService {
     }
 
     public void setFilters(@Nonnull ImmutableList<EntitySearchFilter> filters) {
-        dispatch.execute(SetSearchSettingsAction.create(projectId,
+        dispatch.execute(SetSearchSettingsAction.create(ChangeRequestId.get(uuidV4Provider.get()),
+                                                        projectId,
                                                         ImmutableList.of(),
                                                         filters),
                          result -> {});

--- a/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/tag/EntityTagsSelectorPresenter.java
+++ b/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/tag/EntityTagsSelectorPresenter.java
@@ -1,6 +1,8 @@
 package edu.stanford.bmir.protege.web.client.tag;
 
 import edu.stanford.bmir.protege.web.client.dispatch.DispatchServiceManager;
+import edu.stanford.bmir.protege.web.client.uuid.UuidV4Provider;
+import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
 import edu.stanford.bmir.protege.web.shared.project.ProjectId;
 import edu.stanford.bmir.protege.web.shared.tag.*;
 import org.semanticweb.owlapi.model.OWLEntity;
@@ -33,6 +35,9 @@ public class EntityTagsSelectorPresenter {
     @Nonnull
     private final DispatchServiceManager dispatchServiceManager;
 
+    @Nonnull
+    private final UuidV4Provider uuidV4Provider;
+
     @Nullable
     private OWLEntity entity;
 
@@ -42,10 +47,12 @@ public class EntityTagsSelectorPresenter {
     @Inject
     public EntityTagsSelectorPresenter(@Nonnull ProjectId projectId,
                                        @Nonnull EntityTagsSelectorView view,
-                                       @Nonnull DispatchServiceManager dispatchServiceManager) {
+                                       @Nonnull DispatchServiceManager dispatchServiceManager,
+                                       @Nonnull UuidV4Provider uuidV4Provider) {
         this.projectId = checkNotNull(projectId);
         this.view = checkNotNull(view);
         this.dispatchServiceManager = checkNotNull(dispatchServiceManager);
+        this.uuidV4Provider = checkNotNull(uuidV4Provider);
     }
 
     public void start(@Nonnull OWLEntity entity) {
@@ -77,7 +84,8 @@ public class EntityTagsSelectorPresenter {
         List<Tag> tags = getSelectedTags();
         Set<TagId> fromTagIds = selectedTags.stream().map(Tag::getTagId).collect(toSet());
         Set<TagId> toTagIds = tags.stream().map(Tag::getTagId).collect(toSet());
-        dispatchServiceManager.execute(UpdateEntityTagsAction.create(projectId,
+        dispatchServiceManager.execute(UpdateEntityTagsAction.create(ChangeRequestId.get(uuidV4Provider.get()),
+                                                                     projectId,
                                                                      entity,
                                                                      fromTagIds,
                                                                      toTagIds),

--- a/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/tag/ProjectTagsPresenter.java
+++ b/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/tag/ProjectTagsPresenter.java
@@ -10,6 +10,8 @@ import edu.stanford.bmir.protege.web.client.app.Presenter;
 import edu.stanford.bmir.protege.web.client.dispatch.DispatchServiceManager;
 import edu.stanford.bmir.protege.web.client.permissions.LoggedInUserProjectCapabilityChecker;
 import edu.stanford.bmir.protege.web.client.settings.SettingsPresenter;
+import edu.stanford.bmir.protege.web.client.uuid.UuidV4Provider;
+import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
 import edu.stanford.bmir.protege.web.shared.project.ProjectId;
 import edu.stanford.bmir.protege.web.shared.tag.*;
 
@@ -58,6 +60,9 @@ public class ProjectTagsPresenter implements Presenter {
     @Nonnull
     private Optional<EventBus> eventBus = Optional.empty();
 
+    @Nonnull
+    private final UuidV4Provider uuidV4Provider;
+
     @Inject
     public ProjectTagsPresenter(@Nonnull ProjectId projectId,
                                 @Nonnull ProjectTagsView projectTagsView,
@@ -66,7 +71,8 @@ public class ProjectTagsPresenter implements Presenter {
                                 @Nonnull DispatchServiceManager dispatchServiceManager,
                                 @Nonnull SettingsPresenter settingsPresenter,
                                 @Nonnull TagCriteriaListPresenter tagCriteriaListPresenter,
-                                @Nonnull Messages messages) {
+                                @Nonnull Messages messages,
+                                @Nonnull UuidV4Provider uuidV4Provider) {
         this.projectId = checkNotNull(projectId);
         this.projectTagsView = checkNotNull(projectTagsView);
         this.forbiddenView = checkNotNull(forbiddenView);
@@ -75,6 +81,7 @@ public class ProjectTagsPresenter implements Presenter {
         this.settingsPresenter = checkNotNull(settingsPresenter);
         this.tagCriteriaListPresenter = checkNotNull(tagCriteriaListPresenter);
         this.messages = checkNotNull(messages);
+        this.uuidV4Provider = checkNotNull(uuidV4Provider);
     }
 
     @Override
@@ -105,7 +112,7 @@ public class ProjectTagsPresenter implements Presenter {
 
     private void handleApplyChanges() {
         getTagData().ifPresent(tagData -> {
-            dispatchServiceManager.execute(SetProjectTagsAction.create(projectId, tagData),
+            dispatchServiceManager.execute(SetProjectTagsAction.create(ChangeRequestId.get(uuidV4Provider.get()), projectId, tagData),
                                            result -> settingsPresenter.goToNextPlace());
         });
     }

--- a/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/viz/EntityGraphPresenter.java
+++ b/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/viz/EntityGraphPresenter.java
@@ -15,7 +15,9 @@ import edu.stanford.bmir.protege.web.client.graphlib.Graph;
 import edu.stanford.bmir.protege.web.client.graphlib.NodeDetails;
 import edu.stanford.bmir.protege.web.client.progress.HasBusy;
 import edu.stanford.bmir.protege.web.client.ui.ElementalUtil;
+import edu.stanford.bmir.protege.web.client.uuid.UuidV4Provider;
 import edu.stanford.bmir.protege.web.shared.entity.EntityDisplay;
+import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
 import edu.stanford.bmir.protege.web.shared.perspective.EntityTypePerspectiveMapper;
 import edu.stanford.bmir.protege.web.shared.perspective.PerspectiveId;
 import edu.stanford.bmir.protege.web.shared.place.Item;
@@ -85,19 +87,24 @@ public class EntityGraphPresenter {
 
     private int rankSpacing = 10;
 
+    @Nonnull
+    private final UuidV4Provider uuidV4Provider;
+
     @Inject
     public EntityGraphPresenter(@Nonnull EntityGraphView view,
                                 @Nonnull EntityGraphFilterTokenPresenter filterTokenPresenter,
                                 @Nonnull ProjectId projectId,
                                 @Nonnull DispatchServiceManager dispatch,
                                 @Nonnull EntityTypePerspectiveMapper typePerspectiveMapper,
-                                @Nonnull PlaceController placeController) {
+                                @Nonnull PlaceController placeController,
+                                @Nonnull UuidV4Provider uuidV4Provider) {
         this.view = view;
         this.filterTokenPresenter = filterTokenPresenter;
         this.projectId = projectId;
         this.dispatch = dispatch;
         this.typePerspectiveMapper = typePerspectiveMapper;
         this.placeController = placeController;
+        this.uuidV4Provider = checkNotNull(uuidV4Provider);
         addContextMenuItemsToView();
     }
 
@@ -118,7 +125,8 @@ public class EntityGraphPresenter {
 
     private void handleActiveFiltersChanged() {
         List<FilterName> activeFilters = filterTokenPresenter.getActiveFilters();
-        dispatch.execute(SetEntityGraphActiveFiltersAction.create(projectId,
+        dispatch.execute(SetEntityGraphActiveFiltersAction.create(ChangeRequestId.get(uuidV4Provider.get()),
+                                                                  projectId,
                                                                   ImmutableList.copyOf(activeFilters)),
                          hasBusy,
                          result -> redisplayCurrentEntity());

--- a/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/viz/EntityGraphSettingsPresenter.java
+++ b/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/viz/EntityGraphSettingsPresenter.java
@@ -6,7 +6,9 @@ import edu.stanford.bmir.protege.web.client.dispatch.DispatchServiceManager;
 import edu.stanford.bmir.protege.web.client.permissions.LoggedInUserProjectCapabilityChecker;
 import edu.stanford.bmir.protege.web.client.progress.HasBusy;
 import edu.stanford.bmir.protege.web.client.user.LoggedInUserProvider;
+import edu.stanford.bmir.protege.web.client.uuid.UuidV4Provider;
 import edu.stanford.bmir.protege.web.shared.access.BuiltInCapability;
+import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
 import edu.stanford.bmir.protege.web.shared.project.ProjectId;
 import edu.stanford.bmir.protege.web.shared.user.UserId;
 import edu.stanford.bmir.protege.web.shared.viz.*;
@@ -51,19 +53,24 @@ public class EntityGraphSettingsPresenter {
     @Nonnull
     private final LoggedInUserProvider loggedInUserProvider;
 
+    @Nonnull
+    private final UuidV4Provider uuidV4Provider;
+
     @Inject
     public EntityGraphSettingsPresenter(@Nonnull ProjectId projectId,
                                         @Nonnull EntityGraphSettingsView view,
                                         @Nonnull EntityGraphFilterListPresenter filterListPresenter,
                                         @Nonnull DispatchServiceManager dispatchServiceManager,
                                         @Nonnull LoggedInUserProjectCapabilityChecker capabilityChecker,
-                                        @Nonnull LoggedInUserProvider loggedInUserProvider) {
+                                        @Nonnull LoggedInUserProvider loggedInUserProvider,
+                                        @Nonnull UuidV4Provider uuidV4Provider) {
         this.projectId = projectId;
         this.view = view;
         this.filterListPresenter = filterListPresenter;
         this.dispatchServiceManager = dispatchServiceManager;
         this.capabilityChecker = capabilityChecker;
         this.loggedInUserProvider = loggedInUserProvider;
+        this.uuidV4Provider = checkNotNull(uuidV4Provider);
     }
 
     public void setHasBusy(@Nonnull HasBusy hasBusy) {
@@ -119,7 +126,8 @@ public class EntityGraphSettingsPresenter {
                 filterListPresenter.getFilters(),
                 view.getRankSpacing()
         );
-        dispatchServiceManager.execute(SetUserProjectEntityGraphSettingsAction.create(projectId,
+        dispatchServiceManager.execute(SetUserProjectEntityGraphSettingsAction.create(ChangeRequestId.get(uuidV4Provider.get()),
+                                                                                      projectId,
                                                                                       userId,
                                                                                       settings),
                                        hasBusy,

--- a/webprotege-gwt-ui-server-core/src/test/java/edu/stanford/bmir/protege/web/shared/app/SetApplicationSettings_Serialization_TestCase.java
+++ b/webprotege-gwt-ui-server-core/src/test/java/edu/stanford/bmir/protege/web/shared/app/SetApplicationSettings_Serialization_TestCase.java
@@ -3,6 +3,7 @@ package edu.stanford.bmir.protege.web.shared.app;
 import edu.stanford.bmir.protege.web.shared.dispatch.Action;
 import edu.stanford.bmir.protege.web.shared.dispatch.Result;
 import edu.stanford.bmir.protege.web.shared.match.JsonSerializationTestUtil;
+import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
 import edu.stanford.bmir.protege.web.shared.user.EmailAddress;
 import org.junit.Test;
 
@@ -21,7 +22,7 @@ public class SetApplicationSettings_Serialization_TestCase {
 
     @Test
     public void shouldSerializeAction() throws IOException {
-        var action = SetApplicationSettingsAction.create(new ApplicationSettings(
+        var action = SetApplicationSettingsAction.create(ChangeRequestId.generate(), new ApplicationSettings(
                 "Name",
                 new EmailAddress("Email"),
                 new ApplicationLocation("scheme", "host", "path", 20),

--- a/webprotege-gwt-ui-server-core/src/test/java/edu/stanford/bmir/protege/web/shared/bulkop/EditAnnotations_Serialization_TestCase.java
+++ b/webprotege-gwt-ui-server-core/src/test/java/edu/stanford/bmir/protege/web/shared/bulkop/EditAnnotations_Serialization_TestCase.java
@@ -5,6 +5,7 @@ import edu.stanford.bmir.protege.web.MockingUtils;
 import edu.stanford.bmir.protege.web.shared.dispatch.Action;
 import edu.stanford.bmir.protege.web.shared.dispatch.Result;
 import edu.stanford.bmir.protege.web.shared.match.JsonSerializationTestUtil;
+import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
 import edu.stanford.bmir.protege.web.shared.project.ProjectId;
 import org.junit.Test;
 import org.semanticweb.owlapi.model.OWLEntity;
@@ -23,6 +24,7 @@ public class EditAnnotations_Serialization_TestCase {
     @Test
     public void shouldSerializeAction() throws IOException {
         var action = EditAnnotationsAction.create(
+                ChangeRequestId.generate(),
                 ProjectId.getNil(),
                 ImmutableSet.<OWLEntity>of(),
                 Operation.DELETE, Optional.empty(),

--- a/webprotege-gwt-ui-server-core/src/test/java/edu/stanford/bmir/protege/web/shared/bulkop/MoveEntitiesToParent_Serialization_TestCase.java
+++ b/webprotege-gwt-ui-server-core/src/test/java/edu/stanford/bmir/protege/web/shared/bulkop/MoveEntitiesToParent_Serialization_TestCase.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableSet;
 import edu.stanford.bmir.protege.web.shared.dispatch.Action;
 import edu.stanford.bmir.protege.web.shared.dispatch.Result;
 import edu.stanford.bmir.protege.web.shared.match.JsonSerializationTestUtil;
+import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -20,7 +21,7 @@ public class MoveEntitiesToParent_Serialization_TestCase {
 
     @Test
     public void shouldSerializeAction() throws IOException {
-        var action = MoveEntitiesToParentAction.create(mockProjectId(), ImmutableSet.of(),
+        var action = MoveEntitiesToParentAction.create(ChangeRequestId.generate(), mockProjectId(), ImmutableSet.of(),
                                                        mockOWLClass(),
                                                        "Test");
         JsonSerializationTestUtil.testSerialization(action, Action.class);

--- a/webprotege-gwt-ui-server-core/src/test/java/edu/stanford/bmir/protege/web/shared/bulkop/SetAnnotationValue_Serialization_TestCase.java
+++ b/webprotege-gwt-ui-server-core/src/test/java/edu/stanford/bmir/protege/web/shared/bulkop/SetAnnotationValue_Serialization_TestCase.java
@@ -5,6 +5,7 @@ import edu.stanford.bmir.protege.web.shared.DataFactory;
 import edu.stanford.bmir.protege.web.shared.dispatch.Action;
 import edu.stanford.bmir.protege.web.shared.dispatch.Result;
 import edu.stanford.bmir.protege.web.shared.match.JsonSerializationTestUtil;
+import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -21,7 +22,7 @@ public class SetAnnotationValue_Serialization_TestCase {
 
     @Test
     public void shouldSerializeAction() throws IOException {
-        var action = SetAnnotationValueAction.create(mockProjectId(), ImmutableSet.of(),
+        var action = SetAnnotationValueAction.create(ChangeRequestId.generate(), mockProjectId(), ImmutableSet.of(),
                                                      mockOWLAnnotationProperty(), DataFactory.getOWLLiteral(33),
                                                      "Test");
         JsonSerializationTestUtil.testSerialization(action, Action.class);

--- a/webprotege-gwt-ui-server-core/src/test/java/edu/stanford/bmir/protege/web/shared/change/RevertRevision_Serialization_TestCase.java
+++ b/webprotege-gwt-ui-server-core/src/test/java/edu/stanford/bmir/protege/web/shared/change/RevertRevision_Serialization_TestCase.java
@@ -3,6 +3,7 @@ package edu.stanford.bmir.protege.web.shared.change;
 import edu.stanford.bmir.protege.web.shared.dispatch.Action;
 import edu.stanford.bmir.protege.web.shared.dispatch.Result;
 import edu.stanford.bmir.protege.web.shared.match.JsonSerializationTestUtil;
+import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
 import edu.stanford.bmir.protege.web.shared.revision.RevisionNumber;
 import org.junit.Test;
 
@@ -20,7 +21,7 @@ public class RevertRevision_Serialization_TestCase {
 
     @Test
     public void shouldSerializeAction() throws IOException {
-        var action = RevertRevisionAction.create(mockProjectId(),
+        var action = RevertRevisionAction.create(ChangeRequestId.generate(), mockProjectId(),
                                                  RevisionNumber.getHeadRevisionNumber());
         JsonSerializationTestUtil.testSerialization(action, Action.class);
     }

--- a/webprotege-gwt-ui-server-core/src/test/java/edu/stanford/bmir/protege/web/shared/dispatch/actions/SetOntologyAnnotations_Serialization_TestCase.java
+++ b/webprotege-gwt-ui-server-core/src/test/java/edu/stanford/bmir/protege/web/shared/dispatch/actions/SetOntologyAnnotations_Serialization_TestCase.java
@@ -3,6 +3,7 @@ package edu.stanford.bmir.protege.web.shared.dispatch.actions;
 import edu.stanford.bmir.protege.web.shared.dispatch.Action;
 import edu.stanford.bmir.protege.web.shared.dispatch.Result;
 import edu.stanford.bmir.protege.web.shared.match.JsonSerializationTestUtil;
+import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -20,7 +21,8 @@ public class SetOntologyAnnotations_Serialization_TestCase {
 
     @Test
     public void shouldSerializeAction() throws IOException {
-        var action = SetOntologyAnnotationsAction.create(mockProjectId(),
+        var action = SetOntologyAnnotationsAction.create(ChangeRequestId.generate(),
+                                                         mockProjectId(),
                                                          mockOWLOntologyID(),
                                                          Collections.emptySet(),
                                                          Collections.emptySet());

--- a/webprotege-gwt-ui-server-core/src/test/java/edu/stanford/bmir/protege/web/shared/entity/MergeEntities_Serialization_TestCase.java
+++ b/webprotege-gwt-ui-server-core/src/test/java/edu/stanford/bmir/protege/web/shared/entity/MergeEntities_Serialization_TestCase.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableSet;
 import edu.stanford.bmir.protege.web.shared.dispatch.Action;
 import edu.stanford.bmir.protege.web.shared.dispatch.Result;
 import edu.stanford.bmir.protege.web.shared.match.JsonSerializationTestUtil;
+import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -20,7 +21,7 @@ public class MergeEntities_Serialization_TestCase {
 
     @Test
     public void shouldSerializeAction() throws IOException {
-        var action = MergeEntitiesAction.create(mockProjectId(), ImmutableSet.of(),
+        var action = MergeEntitiesAction.create(ChangeRequestId.generate(), mockProjectId(), ImmutableSet.of(),
                                                 mockOWLClass(),
                                                 MergedEntityTreatment.DELETE_MERGED_ENTITY,
                                                 "Test");

--- a/webprotege-gwt-ui-server-core/src/test/java/edu/stanford/bmir/protege/web/shared/event/EventsSerializationTestCase.java
+++ b/webprotege-gwt-ui-server-core/src/test/java/edu/stanford/bmir/protege/web/shared/event/EventsSerializationTestCase.java
@@ -69,7 +69,7 @@ public class EventsSerializationTestCase {
     @Test
     public void shouldSerializeBrowserTextChangedEvent() throws IOException {
         JsonSerializationTestUtil.testSerialization(
-                new BrowserTextChangedEvent(mockOWLClass(), "New", mockProjectId(), ImmutableMap.of()),
+                new BrowserTextChangedEvent(EventId.generate(), mockProjectId(), mockOWLClass(), "New", ImmutableList.of()),
                 WebProtegeEvent.class
         );
     }
@@ -95,7 +95,8 @@ public class EventsSerializationTestCase {
     @Test
     public void shouldSerializeCommentUpdatedEvent() throws IOException {
         JsonSerializationTestUtil.testSerialization(
-                new CommentUpdatedEvent(mockProjectId(),
+                new CommentUpdatedEvent(EventId.generate(),
+                                        mockProjectId(),
                                         ThreadId.create(),
                                         new Comment(CommentId.create(),
                                                    mockUserId(),
@@ -137,6 +138,7 @@ public class EventsSerializationTestCase {
     public void shouldSerializeDisplayNameSettingsChangedEvent() throws IOException {
         JsonSerializationTestUtil.testSerialization(
                 DisplayNameSettingsChangedEvent.get(
+                        EventId.generate(),
                         mockProjectId(),
                         DisplayNameSettings.empty()
                 ),
@@ -147,7 +149,8 @@ public class EventsSerializationTestCase {
     @Test
     public void shouldSerializeEntityDeprecatedChangedEvent() throws IOException {
         JsonSerializationTestUtil.testSerialization(
-                new EntityDeprecatedChangedEvent(mockProjectId(),
+                new EntityDeprecatedChangedEvent(EventId.generate(),
+                                                 mockProjectId(),
                                                  mockOWLClass(),
                                                  true),
                 WebProtegeEvent.class
@@ -165,7 +168,8 @@ public class EventsSerializationTestCase {
                                               )))
         ));
         JsonSerializationTestUtil.testSerialization(
-                new EntityHierarchyChangedEvent(mockProjectId(),
+                new EntityHierarchyChangedEvent(EventId.generate(),
+                        mockProjectId(),
                         ClassHierarchyDescriptor.get(),
                                                 new GraphModelChangedEvent(changes),
                         ChangeRequestId.get("796d7b24-0d2b-4037-8c03-5eb3e55a3fcf")),
@@ -176,7 +180,8 @@ public class EventsSerializationTestCase {
     @Test
     public void shouldSerializeEntityTagsChangedEvent() throws IOException {
         JsonSerializationTestUtil.testSerialization(
-                new EntityTagsChangedEvent(mockProjectId(),
+                new EntityTagsChangedEvent(EventId.generate(),
+                                           mockProjectId(),
                                            mockOWLClass(),
                                            Collections.emptySet()),
                 WebProtegeEvent.class
@@ -186,7 +191,7 @@ public class EventsSerializationTestCase {
     @Test
     public void shouldSerializeLargeNumberOfChangesEvent() throws IOException {
         JsonSerializationTestUtil.testSerialization(
-                new LargeNumberOfChangesEvent(mockProjectId()),
+                new LargeNumberOfChangesEvent(EventId.generate(), mockProjectId()),
                 WebProtegeEvent.class
         );
     }
@@ -212,7 +217,8 @@ public class EventsSerializationTestCase {
     @Test
     public void shouldSerializeProjectChangedEvent() throws IOException {
         JsonSerializationTestUtil.testSerialization(
-                new ProjectChangedEvent(mockProjectId(),
+                new ProjectChangedEvent(EventId.generate(),
+                                        mockProjectId(),
                                         new RevisionSummary(
                                                 RevisionNumber.getHeadRevisionNumber(),
                                                 mockUserId(),
@@ -261,7 +267,8 @@ public class EventsSerializationTestCase {
     @Test
     public void shouldSerializeProjectTagsChangedEvent() throws IOException {
         JsonSerializationTestUtil.testSerialization(
-                new ProjectTagsChangedEvent(mockProjectId(),
+                new ProjectTagsChangedEvent(EventId.generate(),
+                                            mockProjectId(),
                                             Collections.emptySet()),
                 WebProtegeEvent.class
         );
@@ -270,7 +277,8 @@ public class EventsSerializationTestCase {
     @Test
     public void shouldSerializeWatchAddedEvent() throws IOException {
         JsonSerializationTestUtil.testSerialization(
-                new WatchAddedEvent(mockProjectId(),
+                new WatchAddedEvent(EventId.generate(),
+                                    mockProjectId(),
                                     Watch.create(mockUserId(),
                                                  mockOWLClass(),
                                                  WatchType.ENTITY)),
@@ -281,7 +289,8 @@ public class EventsSerializationTestCase {
     @Test
     public void shouldSerializeWatchRemovedEvent() throws IOException {
         JsonSerializationTestUtil.testSerialization(
-                new WatchRemovedEvent(mockProjectId(),
+                new WatchRemovedEvent(EventId.generate(),
+                                      mockProjectId(),
                                       Watch.create(mockUserId(),
                                                  mockOWLClass(),
                                                  WatchType.ENTITY)),

--- a/webprotege-gwt-ui-server-core/src/test/java/edu/stanford/bmir/protege/web/shared/event/EventsSerializationTestCase.java
+++ b/webprotege-gwt-ui-server-core/src/test/java/edu/stanford/bmir/protege/web/shared/event/EventsSerializationTestCase.java
@@ -209,7 +209,7 @@ public class EventsSerializationTestCase {
     @Test
     public void shouldSerializePermissionsChangedEvent() throws IOException {
         JsonSerializationTestUtil.testSerialization(
-                new PermissionsChangedEvent(mockProjectId()),
+                new PermissionsChangedEvent(EventId.generate(), mockProjectId()),
                 WebProtegeEvent.class
         );
     }

--- a/webprotege-gwt-ui-server-core/src/test/java/edu/stanford/bmir/protege/web/shared/issues/AddEntityComment_TestCase.java
+++ b/webprotege-gwt-ui-server-core/src/test/java/edu/stanford/bmir/protege/web/shared/issues/AddEntityComment_TestCase.java
@@ -6,6 +6,7 @@ import edu.stanford.bmir.protege.web.shared.dispatch.Result;
 import edu.stanford.bmir.protege.web.shared.event.EventList;
 import edu.stanford.bmir.protege.web.shared.event.EventTag;
 import edu.stanford.bmir.protege.web.shared.match.JsonSerializationTestUtil;
+import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
 import edu.stanford.bmir.protege.web.shared.project.ProjectId;
 import edu.stanford.bmir.protege.web.shared.user.UserId;
 import org.junit.Test;
@@ -29,7 +30,7 @@ public class AddEntityComment_TestCase {
 
     @Test
     public void shouldSerializeAction() throws IOException {
-        var action = AddEntityCommentAction.addComment(projectId, threadId, THE_COMMENT);
+        var action = AddEntityCommentAction.addComment(ChangeRequestId.generate(), projectId, threadId, THE_COMMENT);
         JsonSerializationTestUtil.testSerialization(action, Action.class);
     }
 

--- a/webprotege-gwt-ui-server-core/src/test/java/edu/stanford/bmir/protege/web/shared/issues/CreateEntityDiscussionThread_Serialization_TestCase.java
+++ b/webprotege-gwt-ui-server-core/src/test/java/edu/stanford/bmir/protege/web/shared/issues/CreateEntityDiscussionThread_Serialization_TestCase.java
@@ -8,6 +8,7 @@ import edu.stanford.bmir.protege.web.shared.dispatch.Result;
 import edu.stanford.bmir.protege.web.shared.event.EventList;
 import edu.stanford.bmir.protege.web.shared.event.EventTag;
 import edu.stanford.bmir.protege.web.shared.match.JsonSerializationTestUtil;
+import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
 import edu.stanford.bmir.protege.web.shared.project.ProjectId;
 import org.junit.Test;
 
@@ -24,7 +25,7 @@ public class CreateEntityDiscussionThread_Serialization_TestCase {
 
     @Test
     public void shouldSerializeAction() throws IOException {
-        var action = CreateEntityDiscussionThreadAction.create(ProjectId.getNil(), MockingUtils.mockOWLClass(),
+        var action = CreateEntityDiscussionThreadAction.create(ChangeRequestId.generate(), ProjectId.getNil(), MockingUtils.mockOWLClass(),
                                                 "The comment");
         JsonSerializationTestUtil.testSerialization(action, Action.class);
     }

--- a/webprotege-gwt-ui-server-core/src/test/java/edu/stanford/bmir/protege/web/shared/issues/DeleteEntityComment_Serialization_TestCase.java
+++ b/webprotege-gwt-ui-server-core/src/test/java/edu/stanford/bmir/protege/web/shared/issues/DeleteEntityComment_Serialization_TestCase.java
@@ -3,6 +3,7 @@ package edu.stanford.bmir.protege.web.shared.issues;
 import edu.stanford.bmir.protege.web.shared.dispatch.Action;
 import edu.stanford.bmir.protege.web.shared.dispatch.Result;
 import edu.stanford.bmir.protege.web.shared.match.JsonSerializationTestUtil;
+import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
 import edu.stanford.bmir.protege.web.shared.project.ProjectId;
 import org.junit.Test;
 
@@ -18,7 +19,8 @@ public class DeleteEntityComment_Serialization_TestCase {
 
     @Test
     public void shouldSerializeAction() throws IOException {
-        var action = new DeleteEntityCommentAction(ProjectId.getNil(),
+        var action = new DeleteEntityCommentAction(ChangeRequestId.generate(),
+                                                   ProjectId.getNil(),
                                                    CommentId.create());
         JsonSerializationTestUtil.testSerialization(action, Action.class);
     }

--- a/webprotege-gwt-ui-server-core/src/test/java/edu/stanford/bmir/protege/web/shared/issues/EditComment_Serialization_TestCase.java
+++ b/webprotege-gwt-ui-server-core/src/test/java/edu/stanford/bmir/protege/web/shared/issues/EditComment_Serialization_TestCase.java
@@ -4,6 +4,7 @@ import edu.stanford.bmir.protege.web.MockingUtils;
 import edu.stanford.bmir.protege.web.shared.dispatch.Action;
 import edu.stanford.bmir.protege.web.shared.dispatch.Result;
 import edu.stanford.bmir.protege.web.shared.match.JsonSerializationTestUtil;
+import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
 import edu.stanford.bmir.protege.web.shared.project.ProjectId;
 import org.junit.Test;
 
@@ -20,7 +21,8 @@ public class EditComment_Serialization_TestCase {
 
     @Test
     public void shouldSerializeAction() throws IOException {
-        var action = EditCommentAction.editComment(ProjectId.getNil(),
+        var action = EditCommentAction.editComment(ChangeRequestId.generate(),
+                                                   ProjectId.getNil(),
                                                    ThreadId.create(),
                                                    CommentId.create(),
                                                    "Body"); JsonSerializationTestUtil.testSerialization(action, Action.class);

--- a/webprotege-gwt-ui-server-core/src/test/java/edu/stanford/bmir/protege/web/shared/merge/MergeUploadedProject_Serialization_TestCase.java
+++ b/webprotege-gwt-ui-server-core/src/test/java/edu/stanford/bmir/protege/web/shared/merge/MergeUploadedProject_Serialization_TestCase.java
@@ -3,6 +3,7 @@ package edu.stanford.bmir.protege.web.shared.merge;
 import edu.stanford.bmir.protege.web.shared.dispatch.Action;
 import edu.stanford.bmir.protege.web.shared.dispatch.Result;
 import edu.stanford.bmir.protege.web.shared.match.JsonSerializationTestUtil;
+import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -19,7 +20,7 @@ public class MergeUploadedProject_Serialization_TestCase {
 
     @Test
     public void shouldSerializeAction() throws IOException {
-        var action = MergeUploadedProjectAction.create(mockProjectId(),
+        var action = MergeUploadedProjectAction.create(ChangeRequestId.generate(), mockProjectId(),
                                                        mockDocumentId(),
                                                        "Test");
         JsonSerializationTestUtil.testSerialization(action, Action.class);

--- a/webprotege-gwt-ui-server-core/src/test/java/edu/stanford/bmir/protege/web/shared/merge_add/ExistingOntologyMergeAdd_Serialization_TestCase.java
+++ b/webprotege-gwt-ui-server-core/src/test/java/edu/stanford/bmir/protege/web/shared/merge_add/ExistingOntologyMergeAdd_Serialization_TestCase.java
@@ -5,6 +5,7 @@ import edu.stanford.bmir.protege.web.shared.csv.DocumentId;
 import edu.stanford.bmir.protege.web.shared.dispatch.Action;
 import edu.stanford.bmir.protege.web.shared.dispatch.Result;
 import edu.stanford.bmir.protege.web.shared.match.JsonSerializationTestUtil;
+import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
 import edu.stanford.bmir.protege.web.shared.project.ProjectId;
 import org.junit.Test;
 import org.semanticweb.owlapi.model.IRI;
@@ -23,7 +24,8 @@ public class ExistingOntologyMergeAdd_Serialization_TestCase {
 
     @Test
     public void shouldSerializeAction() throws IOException {
-        var action = ExistingOntologyMergeAddAction.create(ProjectId.getNil(),
+        var action = ExistingOntologyMergeAddAction.create(ChangeRequestId.generate(),
+                                                           ProjectId.getNil(),
                                                            new DocumentId("abc"),
                                                            Collections.emptyList(),
                                                            MockingUtils.mockOWLOntologyID());

--- a/webprotege-gwt-ui-server-core/src/test/java/edu/stanford/bmir/protege/web/shared/merge_add/NewOntologyMergeAdd_Serialization_TestCase.java
+++ b/webprotege-gwt-ui-server-core/src/test/java/edu/stanford/bmir/protege/web/shared/merge_add/NewOntologyMergeAdd_Serialization_TestCase.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableList;
 import edu.stanford.bmir.protege.web.shared.dispatch.Action;
 import edu.stanford.bmir.protege.web.shared.dispatch.Result;
 import edu.stanford.bmir.protege.web.shared.match.JsonSerializationTestUtil;
+import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -20,7 +21,8 @@ public class NewOntologyMergeAdd_Serialization_TestCase {
 
     @Test
     public void shouldSerializeAction() throws IOException {
-        var action = NewOntologyMergeAddAction.create(mockProjectId(),
+        var action = NewOntologyMergeAddAction.create(ChangeRequestId.generate(),
+                                                      mockProjectId(),
                                                       mockDocumentId(),
                                                       "Iri",
                                                       ImmutableList.of());

--- a/webprotege-gwt-ui-server-core/src/test/java/edu/stanford/bmir/protege/web/shared/perspective/ResetPerspectives_Serialization_TestCase.java
+++ b/webprotege-gwt-ui-server-core/src/test/java/edu/stanford/bmir/protege/web/shared/perspective/ResetPerspectives_Serialization_TestCase.java
@@ -19,7 +19,7 @@ public class ResetPerspectives_Serialization_TestCase {
 
     @Test
     public void shouldSerializeAction() throws IOException {
-        var action = ResetPerspectivesAction.create(mockProjectId());
+        var action = ResetPerspectivesAction.create(ChangeRequestId.generate(), mockProjectId());
         JsonSerializationTestUtil.testSerialization(action, Action.class);
     }
 

--- a/webprotege-gwt-ui-server-core/src/test/java/edu/stanford/bmir/protege/web/shared/perspective/SetPerspectives_Serialization_TestCase.java
+++ b/webprotege-gwt-ui-server-core/src/test/java/edu/stanford/bmir/protege/web/shared/perspective/SetPerspectives_Serialization_TestCase.java
@@ -9,7 +9,6 @@ import edu.stanford.bmir.protege.web.shared.match.JsonSerializationTestUtil;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.util.Optional;
 
 
 import static edu.stanford.bmir.protege.web.MockingUtils.*;
@@ -23,8 +22,10 @@ public class SetPerspectives_Serialization_TestCase {
 
     @Test
     public void shouldSerializeAction() throws IOException {
-        var action = SetPerspectivesAction.create(mockProjectId(),
-                                                  Optional.of(mockUserId()), ImmutableList.of(
+        var action = SetPerspectivesAction.create(ChangeRequestId.generate(),
+                                                  mockProjectId(),
+                                                  mockUserId(),
+                                                  ImmutableList.of(
                                                           PerspectiveDescriptor.get(PerspectiveId.generate(),
                                                                                     LanguageMap.of("en", "Hello"),
                                                                                     true)

--- a/webprotege-gwt-ui-server-core/src/test/java/edu/stanford/bmir/protege/web/shared/perspective/SetPerspectives_Serialization_TestCase.java
+++ b/webprotege-gwt-ui-server-core/src/test/java/edu/stanford/bmir/protege/web/shared/perspective/SetPerspectives_Serialization_TestCase.java
@@ -9,6 +9,7 @@ import edu.stanford.bmir.protege.web.shared.match.JsonSerializationTestUtil;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.Optional;
 
 
 import static edu.stanford.bmir.protege.web.MockingUtils.*;
@@ -23,7 +24,7 @@ public class SetPerspectives_Serialization_TestCase {
     @Test
     public void shouldSerializeAction() throws IOException {
         var action = SetPerspectivesAction.create(mockProjectId(),
-                                                  mockUserId(), ImmutableList.of(
+                                                  Optional.of(mockUserId()), ImmutableList.of(
                                                           PerspectiveDescriptor.get(PerspectiveId.generate(),
                                                                                     LanguageMap.of("en", "Hello"),
                                                                                     true)

--- a/webprotege-gwt-ui-server-core/src/test/java/edu/stanford/bmir/protege/web/shared/project/SetProjectPrefixDeclarations_Serialization_TestCase.java
+++ b/webprotege-gwt-ui-server-core/src/test/java/edu/stanford/bmir/protege/web/shared/project/SetProjectPrefixDeclarations_Serialization_TestCase.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableList;
 import edu.stanford.bmir.protege.web.shared.dispatch.Action;
 import edu.stanford.bmir.protege.web.shared.dispatch.Result;
 import edu.stanford.bmir.protege.web.shared.match.JsonSerializationTestUtil;
+import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -20,7 +21,7 @@ public class SetProjectPrefixDeclarations_Serialization_TestCase {
 
     @Test
     public void shouldSerializeAction() throws IOException {
-        var action = SetProjectPrefixDeclarationsAction.create(mockProjectId(), ImmutableList.of(
+        var action = SetProjectPrefixDeclarationsAction.create(ChangeRequestId.generate(), mockProjectId(), ImmutableList.of(
                 PrefixDeclaration.get("hello:", "http://example.org/")
         ));
         JsonSerializationTestUtil.testSerialization(action, Action.class);

--- a/webprotege-gwt-ui-server-core/src/test/java/edu/stanford/bmir/protege/web/shared/projectsettings/SetProjectSettings_Serialization_TestCase.java
+++ b/webprotege-gwt-ui-server-core/src/test/java/edu/stanford/bmir/protege/web/shared/projectsettings/SetProjectSettings_Serialization_TestCase.java
@@ -5,6 +5,7 @@ import edu.stanford.bmir.protege.web.shared.dispatch.Action;
 import edu.stanford.bmir.protege.web.shared.dispatch.Result;
 import edu.stanford.bmir.protege.web.shared.lang.DisplayNameSettings;
 import edu.stanford.bmir.protege.web.shared.match.JsonSerializationTestUtil;
+import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
 import edu.stanford.bmir.protege.web.shared.shortform.DictionaryLanguage;
 import org.junit.Test;
 
@@ -22,7 +23,7 @@ public class SetProjectSettings_Serialization_TestCase {
 
     @Test
     public void shouldSerializeAction() throws IOException {
-        var action = SetProjectSettingsAction.create(ProjectSettings.get(
+        var settings = ProjectSettings.get(
                 mockProjectId(),
                 "The display name",
                 "The description",
@@ -31,7 +32,8 @@ public class SetProjectSettings_Serialization_TestCase {
                 SlackIntegrationSettings.get("url"),
                 WebhookSettings.get(ImmutableList.of()),
                 EntityDeprecationSettings.empty()
-        ));
+        );
+        var action = SetProjectSettingsAction.create(ChangeRequestId.generate(), settings.getProjectId(), settings);
         JsonSerializationTestUtil.testSerialization(action, Action.class);
     }
 

--- a/webprotege-gwt-ui-server-core/src/test/java/edu/stanford/bmir/protege/web/shared/search/SetSearchSettings_Serialization_TestCase.java
+++ b/webprotege-gwt-ui-server-core/src/test/java/edu/stanford/bmir/protege/web/shared/search/SetSearchSettings_Serialization_TestCase.java
@@ -7,6 +7,7 @@ import edu.stanford.bmir.protege.web.shared.lang.LanguageMap;
 import edu.stanford.bmir.protege.web.shared.match.JsonSerializationTestUtil;
 import edu.stanford.bmir.protege.web.shared.match.criteria.CompositeRootCriteria;
 import edu.stanford.bmir.protege.web.shared.match.criteria.MultiMatchType;
+import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -23,7 +24,7 @@ public class SetSearchSettings_Serialization_TestCase {
 
     @Test
     public void shouldSerializeAction() throws IOException {
-        var action = SetSearchSettingsAction.create(mockProjectId(), ImmutableList.of(
+        var action = SetSearchSettingsAction.create(ChangeRequestId.generate(), mockProjectId(), ImmutableList.of(
                 EntitySearchFilter.get(EntitySearchFilterId.createFilterId(),
                                        mockProjectId(),
                                        LanguageMap.of("en", "Test"), CompositeRootCriteria.get(ImmutableList.of(),

--- a/webprotege-gwt-ui-server-core/src/test/java/edu/stanford/bmir/protege/web/shared/tag/AddProjectTag_TestCase.java
+++ b/webprotege-gwt-ui-server-core/src/test/java/edu/stanford/bmir/protege/web/shared/tag/AddProjectTag_TestCase.java
@@ -4,6 +4,7 @@ import edu.stanford.bmir.protege.web.shared.color.Color;
 import edu.stanford.bmir.protege.web.shared.dispatch.Action;
 import edu.stanford.bmir.protege.web.shared.dispatch.Result;
 import edu.stanford.bmir.protege.web.shared.match.JsonSerializationTestUtil;
+import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
 import edu.stanford.bmir.protege.web.shared.project.ProjectId;
 import org.junit.Test;
 
@@ -19,7 +20,8 @@ public class AddProjectTag_TestCase {
 
     @Test
     public void shouldSerializeAddProjectTagAction() throws IOException {
-        var action = AddProjectTagAction.create(ProjectId.getNil(),
+        var action = AddProjectTagAction.create(ChangeRequestId.generate(),
+                                                ProjectId.getNil(),
                                                 "TheLabel",
                                                 "TheDescription",
                                                 Color.getWhite(),

--- a/webprotege-gwt-ui-server-core/src/test/java/edu/stanford/bmir/protege/web/shared/tag/SetProjectTags_Serialization_TestCase.java
+++ b/webprotege-gwt-ui-server-core/src/test/java/edu/stanford/bmir/protege/web/shared/tag/SetProjectTags_Serialization_TestCase.java
@@ -5,6 +5,7 @@ import edu.stanford.bmir.protege.web.shared.color.Color;
 import edu.stanford.bmir.protege.web.shared.dispatch.Action;
 import edu.stanford.bmir.protege.web.shared.dispatch.Result;
 import edu.stanford.bmir.protege.web.shared.match.JsonSerializationTestUtil;
+import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -21,7 +22,7 @@ public class SetProjectTags_Serialization_TestCase {
 
     @Test
     public void shouldSerializeAction() throws IOException {
-        var action = SetProjectTagsAction.create(mockProjectId(), ImmutableList.of(
+        var action = SetProjectTagsAction.create(ChangeRequestId.generate(), mockProjectId(), ImmutableList.of(
                 TagData.get(TagId.createTagId(),
                             "Label",
                             "Description",

--- a/webprotege-gwt-ui-server-core/src/test/java/edu/stanford/bmir/protege/web/shared/tag/UpdateEntityTags_Serialization_TestCase.java
+++ b/webprotege-gwt-ui-server-core/src/test/java/edu/stanford/bmir/protege/web/shared/tag/UpdateEntityTags_Serialization_TestCase.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableSet;
 import edu.stanford.bmir.protege.web.shared.dispatch.Action;
 import edu.stanford.bmir.protege.web.shared.dispatch.Result;
 import edu.stanford.bmir.protege.web.shared.match.JsonSerializationTestUtil;
+import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -21,7 +22,8 @@ public class UpdateEntityTags_Serialization_TestCase {
 
     @Test
     public void shouldSerializeAction() throws IOException {
-        var action = UpdateEntityTagsAction.create(mockProjectId(),
+        var action = UpdateEntityTagsAction.create(ChangeRequestId.generate(),
+                                                   mockProjectId(),
                                                    mockOWLClass(),
                                                    ImmutableSet.of(TagId.createTagId()),
                                                    ImmutableSet.of());

--- a/webprotege-gwt-ui-server-core/src/test/java/edu/stanford/bmir/protege/web/shared/viz/SetEntityGraphActiveFilters_Serialization_TestCase.java
+++ b/webprotege-gwt-ui-server-core/src/test/java/edu/stanford/bmir/protege/web/shared/viz/SetEntityGraphActiveFilters_Serialization_TestCase.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableList;
 import edu.stanford.bmir.protege.web.shared.dispatch.Action;
 import edu.stanford.bmir.protege.web.shared.dispatch.Result;
 import edu.stanford.bmir.protege.web.shared.match.JsonSerializationTestUtil;
+import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -20,7 +21,7 @@ public class SetEntityGraphActiveFilters_Serialization_TestCase {
 
     @Test
     public void shouldSerializeAction() throws IOException {
-        var action = SetEntityGraphActiveFiltersAction.create(mockProjectId(), ImmutableList.of(
+        var action = SetEntityGraphActiveFiltersAction.create(ChangeRequestId.generate(), mockProjectId(), ImmutableList.of(
                 FilterName.get("Hello")
         ));
         JsonSerializationTestUtil.testSerialization(action, Action.class);

--- a/webprotege-gwt-ui-server-core/src/test/java/edu/stanford/bmir/protege/web/shared/viz/SetUserProjectEntityGraphSettings_Serialization_TestCase.java
+++ b/webprotege-gwt-ui-server-core/src/test/java/edu/stanford/bmir/protege/web/shared/viz/SetUserProjectEntityGraphSettings_Serialization_TestCase.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableList;
 import edu.stanford.bmir.protege.web.shared.dispatch.Action;
 import edu.stanford.bmir.protege.web.shared.dispatch.Result;
 import edu.stanford.bmir.protege.web.shared.match.JsonSerializationTestUtil;
+import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -20,7 +21,8 @@ public abstract class SetUserProjectEntityGraphSettings_Serialization_TestCase {
 
     @Test
     public void shouldSerializeAction() throws IOException {
-        var action = SetUserProjectEntityGraphSettingsAction.create(mockProjectId(),
+        var action = SetUserProjectEntityGraphSettingsAction.create(ChangeRequestId.generate(),
+                                                                    mockProjectId(),
                                                                     mockUserId(),
                                                                     EntityGraphSettings.get(
                                                                             ImmutableList.of(),

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/app/SetApplicationSettingsAction.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/app/SetApplicationSettingsAction.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.auto.value.AutoValue;
 import com.google.common.annotations.GwtCompatible;
-import com.google.common.annotations.GwtIncompatible;
 import edu.stanford.bmir.protege.web.shared.annotations.GwtSerializationConstructor;
 import edu.stanford.bmir.protege.web.shared.dispatch.Action;
 import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
@@ -13,8 +12,6 @@ import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
 import javax.annotation.Nonnull;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-
-import java.util.UUID;
 
 /**
  * Matthew Horridge
@@ -25,11 +22,6 @@ import java.util.UUID;
 @GwtCompatible(serializable = true)
 @JsonTypeName("webprotege.application.SetApplicationSettings")
 public abstract class SetApplicationSettingsAction implements Action<SetApplicationSettingsResult> {
-
-    @GwtIncompatible
-    public static SetApplicationSettingsAction create(@Nonnull ApplicationSettings applicationSettings) {
-        return create(ChangeRequestId.get(UUID.randomUUID().toString()), applicationSettings);
-    }
 
     @JsonCreator
     public static SetApplicationSettingsAction create(@JsonProperty("changeRequestId") @Nonnull ChangeRequestId changeRequestId,

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/app/SetApplicationSettingsAction.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/app/SetApplicationSettingsAction.java
@@ -5,14 +5,16 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.auto.value.AutoValue;
 import com.google.common.annotations.GwtCompatible;
+import com.google.common.annotations.GwtIncompatible;
 import edu.stanford.bmir.protege.web.shared.annotations.GwtSerializationConstructor;
 import edu.stanford.bmir.protege.web.shared.dispatch.Action;
 import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
 
 import javax.annotation.Nonnull;
-import java.util.UUID;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.UUID;
 
 /**
  * Matthew Horridge
@@ -24,6 +26,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 @JsonTypeName("webprotege.application.SetApplicationSettings")
 public abstract class SetApplicationSettingsAction implements Action<SetApplicationSettingsResult> {
 
+    @GwtIncompatible
     public static SetApplicationSettingsAction create(@Nonnull ApplicationSettings applicationSettings) {
         return create(ChangeRequestId.get(UUID.randomUUID().toString()), applicationSettings);
     }

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/app/SetApplicationSettingsAction.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/app/SetApplicationSettingsAction.java
@@ -7,8 +7,10 @@ import com.google.auto.value.AutoValue;
 import com.google.common.annotations.GwtCompatible;
 import edu.stanford.bmir.protege.web.shared.annotations.GwtSerializationConstructor;
 import edu.stanford.bmir.protege.web.shared.dispatch.Action;
+import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
 
 import javax.annotation.Nonnull;
+import java.util.UUID;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -22,10 +24,19 @@ import static com.google.common.base.Preconditions.checkNotNull;
 @JsonTypeName("webprotege.application.SetApplicationSettings")
 public abstract class SetApplicationSettingsAction implements Action<SetApplicationSettingsResult> {
 
-    @JsonCreator
-    public static SetApplicationSettingsAction create(@JsonProperty("applicationSettings") @Nonnull ApplicationSettings applicationSettings) {
-        return new AutoValue_SetApplicationSettingsAction(applicationSettings);
+    public static SetApplicationSettingsAction create(@Nonnull ApplicationSettings applicationSettings) {
+        return create(ChangeRequestId.get(UUID.randomUUID().toString()), applicationSettings);
     }
+
+    @JsonCreator
+    public static SetApplicationSettingsAction create(@JsonProperty("changeRequestId") @Nonnull ChangeRequestId changeRequestId,
+                                                      @JsonProperty("applicationSettings") @Nonnull ApplicationSettings applicationSettings) {
+        return new AutoValue_SetApplicationSettingsAction(changeRequestId, applicationSettings);
+    }
+
+    @Nonnull
+    @JsonProperty("changeRequestId")
+    public abstract ChangeRequestId getChangeRequestId();
 
     public abstract ApplicationSettings getApplicationSettings();
 }

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/bulkop/EditAnnotationsAction.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/bulkop/EditAnnotationsAction.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.auto.value.AutoValue;
 import com.google.common.annotations.GwtCompatible;
-import com.google.common.annotations.GwtIncompatible;
 import com.google.common.collect.ImmutableSet;
 import edu.stanford.bmir.protege.web.shared.annotations.GwtSerializationConstructor;
 import edu.stanford.bmir.protege.web.shared.dispatch.ProjectAction;
@@ -17,7 +16,6 @@ import org.semanticweb.owlapi.model.OWLEntity;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Optional;
-import java.util.UUID;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -31,18 +29,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 @JsonTypeName("webprotege.bulkop.EditAnnotations")
 public abstract class EditAnnotationsAction implements ProjectAction<EditAnnotationsResult>, HasCommitMessage {
 
-    @GwtIncompatible
-    public static EditAnnotationsAction create(@Nonnull ProjectId projectId,
-                                            @Nonnull ImmutableSet<OWLEntity> entities,
-                                            Operation operation,
-                                            @Nonnull Optional<OWLAnnotationProperty> property,
-                                            @Nonnull Optional<String> lexicalValueExpression,
-                                            boolean lexicalValueExpressionIsRegEx,
-                                            @Nonnull Optional<String> langTagExpression,
-                                            @Nonnull NewAnnotationData newAnnotationData,
-                                            @Nonnull String commitMessage) {
-        return create(ChangeRequestId.get(UUID.randomUUID().toString()), projectId, entities, operation, property, lexicalValueExpression, lexicalValueExpressionIsRegEx, langTagExpression, newAnnotationData, commitMessage);
-    }
 
     @JsonCreator
     public static EditAnnotationsAction create(@JsonProperty("changeRequestId") @Nonnull ChangeRequestId changeRequestId,

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/bulkop/EditAnnotationsAction.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/bulkop/EditAnnotationsAction.java
@@ -8,6 +8,7 @@ import com.google.common.annotations.GwtCompatible;
 import com.google.common.collect.ImmutableSet;
 import edu.stanford.bmir.protege.web.shared.annotations.GwtSerializationConstructor;
 import edu.stanford.bmir.protege.web.shared.dispatch.ProjectAction;
+import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
 import edu.stanford.bmir.protege.web.shared.project.ProjectId;
 import org.semanticweb.owlapi.model.OWLAnnotationProperty;
 import org.semanticweb.owlapi.model.OWLEntity;
@@ -15,6 +16,7 @@ import org.semanticweb.owlapi.model.OWLEntity;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Optional;
+import java.util.UUID;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -28,8 +30,21 @@ import static com.google.common.base.Preconditions.checkNotNull;
 @JsonTypeName("webprotege.bulkop.EditAnnotations")
 public abstract class EditAnnotationsAction implements ProjectAction<EditAnnotationsResult>, HasCommitMessage {
 
+    public static EditAnnotationsAction create(@Nonnull ProjectId projectId,
+                                            @Nonnull ImmutableSet<OWLEntity> entities,
+                                            Operation operation,
+                                            @Nonnull Optional<OWLAnnotationProperty> property,
+                                            @Nonnull Optional<String> lexicalValueExpression,
+                                            boolean lexicalValueExpressionIsRegEx,
+                                            @Nonnull Optional<String> langTagExpression,
+                                            @Nonnull NewAnnotationData newAnnotationData,
+                                            @Nonnull String commitMessage) {
+        return create(ChangeRequestId.get(UUID.randomUUID().toString()), projectId, entities, operation, property, lexicalValueExpression, lexicalValueExpressionIsRegEx, langTagExpression, newAnnotationData, commitMessage);
+    }
+
     @JsonCreator
-    public static EditAnnotationsAction create(@JsonProperty("projectId") @Nonnull ProjectId projectId,
+    public static EditAnnotationsAction create(@JsonProperty("changeRequestId") @Nonnull ChangeRequestId changeRequestId,
+                                            @JsonProperty("projectId") @Nonnull ProjectId projectId,
                                             @JsonProperty("entities") @Nonnull ImmutableSet<OWLEntity> entities,
                                             @JsonProperty("operation") Operation operation,
                                             @JsonProperty("property") @Nonnull Optional<OWLAnnotationProperty> property,
@@ -38,8 +53,12 @@ public abstract class EditAnnotationsAction implements ProjectAction<EditAnnotat
                                             @JsonProperty("langTagExpression") @Nonnull Optional<String> langTagExpression,
                                             @JsonProperty("newAnnotationData") @Nonnull NewAnnotationData newAnnotationData,
                                             @JsonProperty("commitMessage") @Nonnull String commitMessage) {
-        return new AutoValue_EditAnnotationsAction(projectId, entities, operation, property, lexicalValueExpression, lexicalValueExpressionIsRegEx, langTagExpression, newAnnotationData, commitMessage);
+        return new AutoValue_EditAnnotationsAction(changeRequestId, projectId, entities, operation, property, lexicalValueExpression, lexicalValueExpressionIsRegEx, langTagExpression, newAnnotationData, commitMessage);
     }
+
+    @Nonnull
+    @JsonProperty("changeRequestId")
+    public abstract ChangeRequestId getChangeRequestId();
 
     @Nonnull
     @Override

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/bulkop/EditAnnotationsAction.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/bulkop/EditAnnotationsAction.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.auto.value.AutoValue;
 import com.google.common.annotations.GwtCompatible;
+import com.google.common.annotations.GwtIncompatible;
 import com.google.common.collect.ImmutableSet;
 import edu.stanford.bmir.protege.web.shared.annotations.GwtSerializationConstructor;
 import edu.stanford.bmir.protege.web.shared.dispatch.ProjectAction;
@@ -30,6 +31,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 @JsonTypeName("webprotege.bulkop.EditAnnotations")
 public abstract class EditAnnotationsAction implements ProjectAction<EditAnnotationsResult>, HasCommitMessage {
 
+    @GwtIncompatible
     public static EditAnnotationsAction create(@Nonnull ProjectId projectId,
                                             @Nonnull ImmutableSet<OWLEntity> entities,
                                             Operation operation,

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/bulkop/MoveEntitiesToParentAction.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/bulkop/MoveEntitiesToParentAction.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.auto.value.AutoValue;
 import com.google.common.annotations.GwtCompatible;
+import com.google.common.annotations.GwtIncompatible;
 import com.google.common.collect.ImmutableSet;
 import edu.stanford.bmir.protege.web.shared.dispatch.ProjectAction;
 import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
@@ -14,9 +15,10 @@ import org.semanticweb.owlapi.model.OWLClass;
 import org.semanticweb.owlapi.model.OWLEntity;
 
 import javax.annotation.Nonnull;
-import java.util.UUID;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.UUID;
 
 /**
  * Matthew Horridge
@@ -28,6 +30,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 @JsonTypeName("webprotege.entities.MoveEntitiesToParent")
 public abstract class MoveEntitiesToParentAction implements ProjectAction<MoveEntitiesToParentResult>, HasCommitMessage {
 
+    @GwtIncompatible
     public static MoveEntitiesToParentAction create(@Nonnull ProjectId projectId,
                                                     @Nonnull ImmutableSet<OWLClass> entities,
                                                     @Nonnull OWLClass entity,

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/bulkop/MoveEntitiesToParentAction.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/bulkop/MoveEntitiesToParentAction.java
@@ -7,12 +7,14 @@ import com.google.auto.value.AutoValue;
 import com.google.common.annotations.GwtCompatible;
 import com.google.common.collect.ImmutableSet;
 import edu.stanford.bmir.protege.web.shared.dispatch.ProjectAction;
+import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
 import edu.stanford.bmir.protege.web.shared.project.ProjectId;
 import jsinterop.annotations.JsProperty;
 import org.semanticweb.owlapi.model.OWLClass;
 import org.semanticweb.owlapi.model.OWLEntity;
 
 import javax.annotation.Nonnull;
+import java.util.UUID;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -26,13 +28,25 @@ import static com.google.common.base.Preconditions.checkNotNull;
 @JsonTypeName("webprotege.entities.MoveEntitiesToParent")
 public abstract class MoveEntitiesToParentAction implements ProjectAction<MoveEntitiesToParentResult>, HasCommitMessage {
 
+    public static MoveEntitiesToParentAction create(@Nonnull ProjectId projectId,
+                                                    @Nonnull ImmutableSet<OWLClass> entities,
+                                                    @Nonnull OWLClass entity,
+                                                    @Nonnull String commitMessage) {
+        return create(ChangeRequestId.get(UUID.randomUUID().toString()), projectId, entities, entity, commitMessage);
+    }
+
     @JsonCreator
-    public static MoveEntitiesToParentAction create(@JsonProperty("projectId") @Nonnull ProjectId projectId,
+    public static MoveEntitiesToParentAction create(@JsonProperty("changeRequestId") @Nonnull ChangeRequestId changeRequestId,
+                                                    @JsonProperty("projectId") @Nonnull ProjectId projectId,
                                                     @JsonProperty("entities") @Nonnull ImmutableSet<OWLClass> entities,
                                                     @JsonProperty("parentEntity") @Nonnull OWLClass entity,
                                                     @JsonProperty("commitMessage") @Nonnull String commitMessage) {
-        return new AutoValue_MoveEntitiesToParentAction(projectId, entities, entity, commitMessage);
+        return new AutoValue_MoveEntitiesToParentAction(changeRequestId, projectId, entities, entity, commitMessage);
     }
+
+    @Nonnull
+    @JsonProperty("changeRequestId")
+    public abstract ChangeRequestId getChangeRequestId();
 
     @Nonnull
     @Override

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/bulkop/MoveEntitiesToParentAction.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/bulkop/MoveEntitiesToParentAction.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.auto.value.AutoValue;
 import com.google.common.annotations.GwtCompatible;
-import com.google.common.annotations.GwtIncompatible;
 import com.google.common.collect.ImmutableSet;
 import edu.stanford.bmir.protege.web.shared.dispatch.ProjectAction;
 import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
@@ -18,7 +17,6 @@ import javax.annotation.Nonnull;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import java.util.UUID;
 
 /**
  * Matthew Horridge
@@ -30,13 +28,6 @@ import java.util.UUID;
 @JsonTypeName("webprotege.entities.MoveEntitiesToParent")
 public abstract class MoveEntitiesToParentAction implements ProjectAction<MoveEntitiesToParentResult>, HasCommitMessage {
 
-    @GwtIncompatible
-    public static MoveEntitiesToParentAction create(@Nonnull ProjectId projectId,
-                                                    @Nonnull ImmutableSet<OWLClass> entities,
-                                                    @Nonnull OWLClass entity,
-                                                    @Nonnull String commitMessage) {
-        return create(ChangeRequestId.get(UUID.randomUUID().toString()), projectId, entities, entity, commitMessage);
-    }
 
     @JsonCreator
     public static MoveEntitiesToParentAction create(@JsonProperty("changeRequestId") @Nonnull ChangeRequestId changeRequestId,

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/bulkop/SetAnnotationValueAction.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/bulkop/SetAnnotationValueAction.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.auto.value.AutoValue;
 import com.google.common.annotations.GwtCompatible;
+import com.google.common.annotations.GwtIncompatible;
 import com.google.common.collect.ImmutableSet;
 import edu.stanford.bmir.protege.web.shared.annotations.GwtSerializationConstructor;
 import edu.stanford.bmir.protege.web.shared.dispatch.ProjectAction;
@@ -15,9 +16,10 @@ import org.semanticweb.owlapi.model.OWLAnnotationValue;
 import org.semanticweb.owlapi.model.OWLEntity;
 
 import javax.annotation.Nonnull;
-import java.util.UUID;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.UUID;
 
 /**
  * Matthew Horridge
@@ -30,6 +32,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 public abstract class SetAnnotationValueAction implements ProjectAction<SetAnnotationValueResult>, HasCommitMessage {
 
 
+    @GwtIncompatible
     public static SetAnnotationValueAction create(@Nonnull ProjectId projectId,
                                                   @Nonnull ImmutableSet<OWLEntity> entities,
                                                   @Nonnull OWLAnnotationProperty property,

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/bulkop/SetAnnotationValueAction.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/bulkop/SetAnnotationValueAction.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.auto.value.AutoValue;
 import com.google.common.annotations.GwtCompatible;
-import com.google.common.annotations.GwtIncompatible;
 import com.google.common.collect.ImmutableSet;
 import edu.stanford.bmir.protege.web.shared.annotations.GwtSerializationConstructor;
 import edu.stanford.bmir.protege.web.shared.dispatch.ProjectAction;
@@ -19,7 +18,6 @@ import javax.annotation.Nonnull;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import java.util.UUID;
 
 /**
  * Matthew Horridge
@@ -32,14 +30,6 @@ import java.util.UUID;
 public abstract class SetAnnotationValueAction implements ProjectAction<SetAnnotationValueResult>, HasCommitMessage {
 
 
-    @GwtIncompatible
-    public static SetAnnotationValueAction create(@Nonnull ProjectId projectId,
-                                                  @Nonnull ImmutableSet<OWLEntity> entities,
-                                                  @Nonnull OWLAnnotationProperty property,
-                                                  @Nonnull OWLAnnotationValue value,
-                                                  @Nonnull String commitMessage) {
-        return create(ChangeRequestId.get(UUID.randomUUID().toString()), projectId, entities, property, value, commitMessage);
-    }
 
     @JsonCreator
     public static SetAnnotationValueAction create(@JsonProperty("changeRequestId") @Nonnull ChangeRequestId changeRequestId,

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/bulkop/SetAnnotationValueAction.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/bulkop/SetAnnotationValueAction.java
@@ -8,12 +8,14 @@ import com.google.common.annotations.GwtCompatible;
 import com.google.common.collect.ImmutableSet;
 import edu.stanford.bmir.protege.web.shared.annotations.GwtSerializationConstructor;
 import edu.stanford.bmir.protege.web.shared.dispatch.ProjectAction;
+import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
 import edu.stanford.bmir.protege.web.shared.project.ProjectId;
 import org.semanticweb.owlapi.model.OWLAnnotationProperty;
 import org.semanticweb.owlapi.model.OWLAnnotationValue;
 import org.semanticweb.owlapi.model.OWLEntity;
 
 import javax.annotation.Nonnull;
+import java.util.UUID;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -28,14 +30,27 @@ import static com.google.common.base.Preconditions.checkNotNull;
 public abstract class SetAnnotationValueAction implements ProjectAction<SetAnnotationValueResult>, HasCommitMessage {
 
 
+    public static SetAnnotationValueAction create(@Nonnull ProjectId projectId,
+                                                  @Nonnull ImmutableSet<OWLEntity> entities,
+                                                  @Nonnull OWLAnnotationProperty property,
+                                                  @Nonnull OWLAnnotationValue value,
+                                                  @Nonnull String commitMessage) {
+        return create(ChangeRequestId.get(UUID.randomUUID().toString()), projectId, entities, property, value, commitMessage);
+    }
+
     @JsonCreator
-    public static SetAnnotationValueAction create(@JsonProperty("projectId") @Nonnull ProjectId projectId,
+    public static SetAnnotationValueAction create(@JsonProperty("changeRequestId") @Nonnull ChangeRequestId changeRequestId,
+                                                  @JsonProperty("projectId") @Nonnull ProjectId projectId,
                                                   @JsonProperty("entities") @Nonnull ImmutableSet<OWLEntity> entities,
                                                   @JsonProperty("property") @Nonnull OWLAnnotationProperty property,
                                                   @JsonProperty("value") @Nonnull OWLAnnotationValue value,
                                                   @JsonProperty("commitMessage") @Nonnull String commitMessage) {
-        return new AutoValue_SetAnnotationValueAction(projectId, entities, property, value, commitMessage);
+        return new AutoValue_SetAnnotationValueAction(changeRequestId, projectId, entities, property, value, commitMessage);
     }
+
+    @Nonnull
+    @JsonProperty("changeRequestId")
+    public abstract ChangeRequestId getChangeRequestId();
 
     @Nonnull
     @Override

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/change/RevertRevisionAction.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/change/RevertRevisionAction.java
@@ -3,7 +3,6 @@ package edu.stanford.bmir.protege.web.shared.change;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import com.google.common.annotations.GwtIncompatible;
 import com.google.common.base.Objects;
 import edu.stanford.bmir.protege.web.shared.dispatch.ProjectAction;
 import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
@@ -15,7 +14,6 @@ import javax.annotation.Nonnull;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import java.util.UUID;
 
 /**
  * Matthew Horridge
@@ -43,11 +41,6 @@ public class RevertRevisionAction implements ProjectAction<RevertRevisionResult>
         this.revisionNumber = checkNotNull(revisionNumber);
     }
 
-    @GwtIncompatible
-    public static RevertRevisionAction create(ProjectId projectId,
-                                              RevisionNumber revisionNumber) {
-        return create(ChangeRequestId.get(UUID.randomUUID().toString()), projectId, revisionNumber);
-    }
 
     @JsonCreator
     public static RevertRevisionAction create(@JsonProperty("changeRequestId") ChangeRequestId changeRequestId,

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/change/RevertRevisionAction.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/change/RevertRevisionAction.java
@@ -3,6 +3,7 @@ package edu.stanford.bmir.protege.web.shared.change;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.google.common.annotations.GwtIncompatible;
 import com.google.common.base.Objects;
 import edu.stanford.bmir.protege.web.shared.dispatch.ProjectAction;
 import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
@@ -10,10 +11,11 @@ import edu.stanford.bmir.protege.web.shared.project.ProjectId;
 import edu.stanford.bmir.protege.web.shared.revision.RevisionNumber;
 
 import javax.annotation.Nonnull;
-import java.util.UUID;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.UUID;
 
 /**
  * Matthew Horridge
@@ -41,6 +43,7 @@ public class RevertRevisionAction implements ProjectAction<RevertRevisionResult>
         this.revisionNumber = checkNotNull(revisionNumber);
     }
 
+    @GwtIncompatible
     public static RevertRevisionAction create(ProjectId projectId,
                                               RevisionNumber revisionNumber) {
         return create(ChangeRequestId.get(UUID.randomUUID().toString()), projectId, revisionNumber);

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/change/RevertRevisionAction.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/change/RevertRevisionAction.java
@@ -5,10 +5,12 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.common.base.Objects;
 import edu.stanford.bmir.protege.web.shared.dispatch.ProjectAction;
+import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
 import edu.stanford.bmir.protege.web.shared.project.ProjectId;
 import edu.stanford.bmir.protege.web.shared.revision.RevisionNumber;
 
 import javax.annotation.Nonnull;
+import java.util.UUID;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -21,6 +23,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
 @JsonTypeName("webprotege.history.RevertRevision")
 public class RevertRevisionAction implements ProjectAction<RevertRevisionResult> {
 
+    private ChangeRequestId changeRequestId;
+
     private RevisionNumber revisionNumber;
 
     private ProjectId projectId;
@@ -31,15 +35,28 @@ public class RevertRevisionAction implements ProjectAction<RevertRevisionResult>
     private RevertRevisionAction() {
     }
 
-    private RevertRevisionAction(ProjectId projectId, RevisionNumber revisionNumber) {
+    private RevertRevisionAction(ChangeRequestId changeRequestId, ProjectId projectId, RevisionNumber revisionNumber) {
+        this.changeRequestId = checkNotNull(changeRequestId);
         this.projectId = checkNotNull(projectId);
         this.revisionNumber = checkNotNull(revisionNumber);
     }
 
+    public static RevertRevisionAction create(ProjectId projectId,
+                                              RevisionNumber revisionNumber) {
+        return create(ChangeRequestId.get(UUID.randomUUID().toString()), projectId, revisionNumber);
+    }
+
     @JsonCreator
-    public static RevertRevisionAction create(@JsonProperty("projectId") ProjectId projectId,
+    public static RevertRevisionAction create(@JsonProperty("changeRequestId") ChangeRequestId changeRequestId,
+                                              @JsonProperty("projectId") ProjectId projectId,
                                               @JsonProperty("revisionNumber") RevisionNumber revisionNumber) {
-        return new RevertRevisionAction(projectId, revisionNumber);
+        return new RevertRevisionAction(changeRequestId, projectId, revisionNumber);
+    }
+
+    @Nonnull
+    @JsonProperty("changeRequestId")
+    public ChangeRequestId getChangeRequestId() {
+        return changeRequestId;
     }
 
     @Nonnull

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/crud/SetEntityCrudKitSettingsAction.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/crud/SetEntityCrudKitSettingsAction.java
@@ -3,14 +3,12 @@ package edu.stanford.bmir.protege.web.shared.crud;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import com.google.common.annotations.GwtIncompatible;
 import edu.stanford.bmir.protege.web.shared.dispatch.ProjectAction;
 import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
 import edu.stanford.bmir.protege.web.shared.project.ProjectId;
 
 import javax.annotation.Nonnull;
 
-import java.util.UUID;
 
 /**
  * Author: Matthew Horridge<br>
@@ -50,10 +48,6 @@ public class SetEntityCrudKitSettingsAction implements ProjectAction<SetEntityCr
         this.prefixUpdateStrategy = prefixUpdateStrategy;
     }
 
-    @GwtIncompatible
-    public SetEntityCrudKitSettingsAction(ProjectId projectId, EntityCrudKitSettings fromSettings, EntityCrudKitSettings toSettings, IRIPrefixUpdateStrategy prefixUpdateStrategy) {
-        this(ChangeRequestId.get(UUID.randomUUID().toString()), projectId, fromSettings, toSettings, prefixUpdateStrategy);
-    }
 
     @Nonnull
     @JsonProperty("changeRequestId")

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/crud/SetEntityCrudKitSettingsAction.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/crud/SetEntityCrudKitSettingsAction.java
@@ -3,11 +3,13 @@ package edu.stanford.bmir.protege.web.shared.crud;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.google.common.annotations.GwtIncompatible;
 import edu.stanford.bmir.protege.web.shared.dispatch.ProjectAction;
 import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
 import edu.stanford.bmir.protege.web.shared.project.ProjectId;
 
 import javax.annotation.Nonnull;
+
 import java.util.UUID;
 
 /**
@@ -48,6 +50,7 @@ public class SetEntityCrudKitSettingsAction implements ProjectAction<SetEntityCr
         this.prefixUpdateStrategy = prefixUpdateStrategy;
     }
 
+    @GwtIncompatible
     public SetEntityCrudKitSettingsAction(ProjectId projectId, EntityCrudKitSettings fromSettings, EntityCrudKitSettings toSettings, IRIPrefixUpdateStrategy prefixUpdateStrategy) {
         this(ChangeRequestId.get(UUID.randomUUID().toString()), projectId, fromSettings, toSettings, prefixUpdateStrategy);
     }

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/crud/SetEntityCrudKitSettingsAction.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/crud/SetEntityCrudKitSettingsAction.java
@@ -1,10 +1,14 @@
 package edu.stanford.bmir.protege.web.shared.crud;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import edu.stanford.bmir.protege.web.shared.dispatch.ProjectAction;
+import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
 import edu.stanford.bmir.protege.web.shared.project.ProjectId;
 
 import javax.annotation.Nonnull;
+import java.util.UUID;
 
 /**
  * Author: Matthew Horridge<br>
@@ -14,6 +18,8 @@ import javax.annotation.Nonnull;
  */
 @JsonTypeName("webprotege.projects.SetEntityCrudKitSettings")
 public class SetEntityCrudKitSettingsAction implements ProjectAction<SetEntityCrudKitSettingsResult> {
+
+    private ChangeRequestId changeRequestId;
 
     private ProjectId projectId;
 
@@ -29,11 +35,27 @@ public class SetEntityCrudKitSettingsAction implements ProjectAction<SetEntityCr
     private SetEntityCrudKitSettingsAction() {
     }
 
-    public SetEntityCrudKitSettingsAction(ProjectId projectId, EntityCrudKitSettings fromSettings, EntityCrudKitSettings toSettings, IRIPrefixUpdateStrategy prefixUpdateStrategy) {
+    @JsonCreator
+    public SetEntityCrudKitSettingsAction(@JsonProperty("changeRequestId") ChangeRequestId changeRequestId,
+                                          @JsonProperty("projectId") ProjectId projectId,
+                                          @JsonProperty("fromSettings") EntityCrudKitSettings fromSettings,
+                                          @JsonProperty("toSettings") EntityCrudKitSettings toSettings,
+                                          @JsonProperty("prefixUpdateStrategy") IRIPrefixUpdateStrategy prefixUpdateStrategy) {
+        this.changeRequestId = changeRequestId;
         this.projectId = projectId;
         this.toSettings = toSettings;
         this.fromSettings = fromSettings;
         this.prefixUpdateStrategy = prefixUpdateStrategy;
+    }
+
+    public SetEntityCrudKitSettingsAction(ProjectId projectId, EntityCrudKitSettings fromSettings, EntityCrudKitSettings toSettings, IRIPrefixUpdateStrategy prefixUpdateStrategy) {
+        this(ChangeRequestId.get(UUID.randomUUID().toString()), projectId, fromSettings, toSettings, prefixUpdateStrategy);
+    }
+
+    @Nonnull
+    @JsonProperty("changeRequestId")
+    public ChangeRequestId getChangeRequestId() {
+        return changeRequestId;
     }
 
     @Nonnull

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/dispatch/actions/GetRootOntologyIdResult.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/dispatch/actions/GetRootOntologyIdResult.java
@@ -25,7 +25,7 @@ public abstract class GetRootOntologyIdResult implements Result, HasProjectId {
 
     @JsonCreator
     public static GetRootOntologyIdResult create(@JsonProperty("projectId") ProjectId projectId,
-                                                 @JsonProperty("ontologyId") OWLOntologyID owlOntologyID) {
+                                                 @JsonProperty("rootOntologyId") OWLOntologyID owlOntologyID) {
         return new AutoValue_GetRootOntologyIdResult(projectId, owlOntologyID);
     }
 
@@ -38,5 +38,6 @@ public abstract class GetRootOntologyIdResult implements Result, HasProjectId {
     @Override
     public abstract ProjectId getProjectId();
 
+    @JsonProperty("rootOntologyId")
     public abstract OWLOntologyID getOntologyId();
 }

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/dispatch/actions/SetOntologyAnnotationsAction.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/dispatch/actions/SetOntologyAnnotationsAction.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.auto.value.AutoValue;
 import com.google.common.annotations.GwtCompatible;
+import com.google.common.annotations.GwtIncompatible;
 import edu.stanford.bmir.protege.web.shared.annotations.GwtSerializationConstructor;
 import edu.stanford.bmir.protege.web.shared.dispatch.AbstractHasProjectAction;
 import edu.stanford.bmir.protege.web.shared.frame.PropertyAnnotationValue;
@@ -31,6 +32,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 public abstract class SetOntologyAnnotationsAction extends AbstractHasProjectAction<SetOntologyAnnotationsResult> {
 
 
+    @GwtIncompatible
     public static SetOntologyAnnotationsAction create(ProjectId projectId,
                                                       OWLOntologyID ontologyID,
                                                       Set<PropertyAnnotationValue> fromAnnotations,

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/dispatch/actions/SetOntologyAnnotationsAction.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/dispatch/actions/SetOntologyAnnotationsAction.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.auto.value.AutoValue;
 import com.google.common.annotations.GwtCompatible;
-import com.google.common.annotations.GwtIncompatible;
 import edu.stanford.bmir.protege.web.shared.annotations.GwtSerializationConstructor;
 import edu.stanford.bmir.protege.web.shared.dispatch.AbstractHasProjectAction;
 import edu.stanford.bmir.protege.web.shared.frame.PropertyAnnotationValue;
@@ -16,7 +15,6 @@ import org.semanticweb.owlapi.model.OWLOntologyID;
 import javax.annotation.Nonnull;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.UUID;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -32,13 +30,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 public abstract class SetOntologyAnnotationsAction extends AbstractHasProjectAction<SetOntologyAnnotationsResult> {
 
 
-    @GwtIncompatible
-    public static SetOntologyAnnotationsAction create(ProjectId projectId,
-                                                      OWLOntologyID ontologyID,
-                                                      Set<PropertyAnnotationValue> fromAnnotations,
-                                                      Set<PropertyAnnotationValue> toAnnotations) {
-        return create(ChangeRequestId.get(UUID.randomUUID().toString()), projectId, ontologyID, fromAnnotations, toAnnotations);
-    }
 
     @JsonCreator
     public static SetOntologyAnnotationsAction create(@JsonProperty("changeRequestId") ChangeRequestId changeRequestId,

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/dispatch/actions/SetOntologyAnnotationsAction.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/dispatch/actions/SetOntologyAnnotationsAction.java
@@ -8,12 +8,14 @@ import com.google.common.annotations.GwtCompatible;
 import edu.stanford.bmir.protege.web.shared.annotations.GwtSerializationConstructor;
 import edu.stanford.bmir.protege.web.shared.dispatch.AbstractHasProjectAction;
 import edu.stanford.bmir.protege.web.shared.frame.PropertyAnnotationValue;
+import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
 import edu.stanford.bmir.protege.web.shared.project.ProjectId;
 import org.semanticweb.owlapi.model.OWLOntologyID;
 
 import javax.annotation.Nonnull;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.UUID;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -29,13 +31,25 @@ import static com.google.common.base.Preconditions.checkNotNull;
 public abstract class SetOntologyAnnotationsAction extends AbstractHasProjectAction<SetOntologyAnnotationsResult> {
 
 
+    public static SetOntologyAnnotationsAction create(ProjectId projectId,
+                                                      OWLOntologyID ontologyID,
+                                                      Set<PropertyAnnotationValue> fromAnnotations,
+                                                      Set<PropertyAnnotationValue> toAnnotations) {
+        return create(ChangeRequestId.get(UUID.randomUUID().toString()), projectId, ontologyID, fromAnnotations, toAnnotations);
+    }
+
     @JsonCreator
-    public static SetOntologyAnnotationsAction create(@JsonProperty("projectId") ProjectId projectId,
+    public static SetOntologyAnnotationsAction create(@JsonProperty("changeRequestId") ChangeRequestId changeRequestId,
+                                                      @JsonProperty("projectId") ProjectId projectId,
                                                       @JsonProperty("ontologyId") OWLOntologyID ontologyID,
                                                       @JsonProperty("fromAnnotations") Set<PropertyAnnotationValue> fromAnnotations,
                                                       @JsonProperty("toAnnotations") Set<PropertyAnnotationValue> toAnnotations) {
-        return new AutoValue_SetOntologyAnnotationsAction(projectId, ontologyID, fromAnnotations, toAnnotations);
+        return new AutoValue_SetOntologyAnnotationsAction(changeRequestId, projectId, ontologyID, fromAnnotations, toAnnotations);
     }
+
+    @Nonnull
+    @JsonProperty("changeRequestId")
+    public abstract ChangeRequestId getChangeRequestId();
 
     @Nonnull
     @Override

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/entity/MergeEntitiesAction.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/entity/MergeEntitiesAction.java
@@ -10,10 +10,12 @@ import com.google.common.collect.ImmutableSet;
 import edu.stanford.bmir.protege.web.shared.annotations.GwtSerializationConstructor;
 import edu.stanford.bmir.protege.web.shared.bulkop.HasCommitMessage;
 import edu.stanford.bmir.protege.web.shared.dispatch.AbstractHasProjectAction;
+import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
 import edu.stanford.bmir.protege.web.shared.project.ProjectId;
 import org.semanticweb.owlapi.model.OWLEntity;
 
 import javax.annotation.Nonnull;
+import java.util.UUID;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -46,14 +48,27 @@ public abstract class MergeEntitiesAction extends AbstractHasProjectAction<Merge
         return create(projectId, sourceEntities, targetEntity, treatment, commitMessage);
     }
 
+    public static MergeEntitiesAction create(@Nonnull ProjectId projectId,
+                                             @Nonnull ImmutableSet<OWLEntity> sourceEntities,
+                                             @Nonnull OWLEntity targetEntity,
+                                             @Nonnull MergedEntityTreatment treatment,
+                                             @Nonnull String commitMessage) {
+        return create(ChangeRequestId.get(UUID.randomUUID().toString()), projectId, sourceEntities, targetEntity, treatment, commitMessage);
+    }
+
     @JsonCreator
-    public static MergeEntitiesAction create(@JsonProperty("projectId") @Nonnull ProjectId projectId,
+    public static MergeEntitiesAction create(@JsonProperty("changeRequestId") @Nonnull ChangeRequestId changeRequestId,
+                                             @JsonProperty("projectId") @Nonnull ProjectId projectId,
                                              @JsonProperty("sourceEntities") @Nonnull ImmutableSet<OWLEntity> sourceEntities,
                                              @JsonProperty("targetEntity") @Nonnull OWLEntity targetEntity,
                                              @JsonProperty("treatment") @Nonnull MergedEntityTreatment treatment,
                                              @JsonProperty("commitMessage") @Nonnull String commitMessage) {
-        return new AutoValue_MergeEntitiesAction(projectId, sourceEntities, targetEntity, treatment, commitMessage);
+        return new AutoValue_MergeEntitiesAction(changeRequestId, projectId, sourceEntities, targetEntity, treatment, commitMessage);
     }
+
+    @Nonnull
+    @JsonProperty("changeRequestId")
+    public abstract ChangeRequestId getChangeRequestId();
 
     @Nonnull
     @Override

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/entity/MergeEntitiesAction.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/entity/MergeEntitiesAction.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.auto.value.AutoValue;
 import com.google.common.annotations.GwtCompatible;
+import com.google.common.annotations.GwtIncompatible;
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableSet;
 import edu.stanford.bmir.protege.web.shared.annotations.GwtSerializationConstructor;
@@ -15,10 +16,11 @@ import edu.stanford.bmir.protege.web.shared.project.ProjectId;
 import org.semanticweb.owlapi.model.OWLEntity;
 
 import javax.annotation.Nonnull;
-import java.util.UUID;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.UUID;
 
 /**
  * Matthew Horridge
@@ -40,6 +42,7 @@ public abstract class MergeEntitiesAction extends AbstractHasProjectAction<Merge
      * @param treatment The treatment for the merged entity that specifies whether the merged entity
      *                  will be deleted or deprecated.
      */
+    @GwtIncompatible
     public static MergeEntitiesAction mergeEntities(@Nonnull ProjectId projectId,
                                                     @Nonnull ImmutableSet<OWLEntity> sourceEntities,
                                                     @Nonnull OWLEntity targetEntity,
@@ -48,6 +51,7 @@ public abstract class MergeEntitiesAction extends AbstractHasProjectAction<Merge
         return create(projectId, sourceEntities, targetEntity, treatment, commitMessage);
     }
 
+    @GwtIncompatible
     public static MergeEntitiesAction create(@Nonnull ProjectId projectId,
                                              @Nonnull ImmutableSet<OWLEntity> sourceEntities,
                                              @Nonnull OWLEntity targetEntity,

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/entity/MergeEntitiesAction.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/entity/MergeEntitiesAction.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.auto.value.AutoValue;
 import com.google.common.annotations.GwtCompatible;
-import com.google.common.annotations.GwtIncompatible;
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableSet;
 import edu.stanford.bmir.protege.web.shared.annotations.GwtSerializationConstructor;
@@ -20,7 +19,6 @@ import javax.annotation.Nonnull;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import java.util.UUID;
 
 /**
  * Matthew Horridge
@@ -33,32 +31,6 @@ import java.util.UUID;
 public abstract class MergeEntitiesAction extends AbstractHasProjectAction<MergeEntitiesResult> implements HasCommitMessage {
 
 
-    /**
-     * Creates a {@link MergeEntitiesAction}.  An entity merge is directional – one entity is merged into
-     * another entity.
-     * @param projectId The project to perform the merge in.
-     * @param sourceEntities The entities that will be merged into another entity.
-     * @param targetEntity The entity that will have the source entity merged into it.
-     * @param treatment The treatment for the merged entity that specifies whether the merged entity
-     *                  will be deleted or deprecated.
-     */
-    @GwtIncompatible
-    public static MergeEntitiesAction mergeEntities(@Nonnull ProjectId projectId,
-                                                    @Nonnull ImmutableSet<OWLEntity> sourceEntities,
-                                                    @Nonnull OWLEntity targetEntity,
-                                                    @Nonnull MergedEntityTreatment treatment,
-                                                    @Nonnull String commitMessage) {
-        return create(projectId, sourceEntities, targetEntity, treatment, commitMessage);
-    }
-
-    @GwtIncompatible
-    public static MergeEntitiesAction create(@Nonnull ProjectId projectId,
-                                             @Nonnull ImmutableSet<OWLEntity> sourceEntities,
-                                             @Nonnull OWLEntity targetEntity,
-                                             @Nonnull MergedEntityTreatment treatment,
-                                             @Nonnull String commitMessage) {
-        return create(ChangeRequestId.get(UUID.randomUUID().toString()), projectId, sourceEntities, targetEntity, treatment, commitMessage);
-    }
 
     @JsonCreator
     public static MergeEntitiesAction create(@JsonProperty("changeRequestId") @Nonnull ChangeRequestId changeRequestId,

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/event/BrowserTextChangedEvent.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/event/BrowserTextChangedEvent.java
@@ -30,6 +30,8 @@ public class BrowserTextChangedEvent extends ProjectEvent<BrowserTextChangedHand
     public transient static final Event.Type<BrowserTextChangedHandler> ON_BROWSER_TEXT_CHANGED = new Event.Type<>();
 
 
+    private String eventId;
+
     private OWLEntity entity;
 
     private String newBrowserText;
@@ -44,11 +46,13 @@ public class BrowserTextChangedEvent extends ProjectEvent<BrowserTextChangedHand
     }
 
     @JsonCreator
-    protected BrowserTextChangedEvent(@JsonProperty("entity") OWLEntity entity,
-                                      @JsonProperty("newBrowserText") String newBrowserText,
+    protected BrowserTextChangedEvent(@JsonProperty("eventId") String eventId,
                                       @JsonProperty("projectId") ProjectId projectId,
+                                      @JsonProperty("entity") OWLEntity entity,
+                                      @JsonProperty("newBrowserText") String newBrowserText,
                                       @JsonProperty("shortForms") ImmutableList<ShortForm> shortForms) {
         super(projectId);
+        this.eventId = eventId;
         this.entity = entity;
         this.newBrowserText = newBrowserText;
         this.shortForms = shortForms.stream()
@@ -59,6 +63,11 @@ public class BrowserTextChangedEvent extends ProjectEvent<BrowserTextChangedHand
      * For serialization purposes only
      */
     private BrowserTextChangedEvent() {
+    }
+
+    @JsonProperty("eventId")
+    public String getEventId() {
+        return eventId;
     }
 
     public OWLEntity getEntity() {
@@ -84,6 +93,7 @@ public class BrowserTextChangedEvent extends ProjectEvent<BrowserTextChangedHand
     }
 
 
+    @JsonIgnore
     @Override
     public Event.Type<BrowserTextChangedHandler> getAssociatedType() {
         return ON_BROWSER_TEXT_CHANGED;

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/event/BrowserTextChangedEvent.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/event/BrowserTextChangedEvent.java
@@ -30,7 +30,7 @@ public class BrowserTextChangedEvent extends ProjectEvent<BrowserTextChangedHand
     public transient static final Event.Type<BrowserTextChangedHandler> ON_BROWSER_TEXT_CHANGED = new Event.Type<>();
 
 
-    private String eventId;
+    private EventId eventId;
 
     private OWLEntity entity;
 
@@ -38,15 +38,8 @@ public class BrowserTextChangedEvent extends ProjectEvent<BrowserTextChangedHand
 
     private ImmutableMap<DictionaryLanguage, String> shortForms;
 
-    public BrowserTextChangedEvent(OWLEntity entity, String newBrowserText, ProjectId projectId, ImmutableMap<DictionaryLanguage, String> shortForms) {
-        super(projectId);
-        this.entity = entity;
-        this.newBrowserText = newBrowserText;
-        this.shortForms = shortForms;
-    }
-
     @JsonCreator
-    protected BrowserTextChangedEvent(@JsonProperty("eventId") String eventId,
+    protected BrowserTextChangedEvent(@JsonProperty("eventId") EventId eventId,
                                       @JsonProperty("projectId") ProjectId projectId,
                                       @JsonProperty("entity") OWLEntity entity,
                                       @JsonProperty("newBrowserText") String newBrowserText,
@@ -66,7 +59,7 @@ public class BrowserTextChangedEvent extends ProjectEvent<BrowserTextChangedHand
     }
 
     @JsonProperty("eventId")
-    public String getEventId() {
+    public EventId getEventId() {
         return eventId;
     }
 

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/event/EntityDeprecatedChangedEvent.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/event/EntityDeprecatedChangedEvent.java
@@ -21,20 +21,14 @@ public class EntityDeprecatedChangedEvent extends ProjectEvent<EntityDeprecatedC
 
     public transient static final Event.Type<EntityDeprecatedChangedHandler> ON_ENTITY_DEPRECATED = new Event.Type<EntityDeprecatedChangedHandler>();
 
-    private String eventId;
+    private EventId eventId;
 
     private OWLEntity entity;
 
     private boolean deprecated;
 
-    public EntityDeprecatedChangedEvent(ProjectId source, OWLEntity entity, boolean deprecated) {
-        super(source);
-        this.entity = entity;
-        this.deprecated = deprecated;
-    }
-
     @JsonCreator
-    public EntityDeprecatedChangedEvent(@JsonProperty("eventId") String eventId,
+    public EntityDeprecatedChangedEvent(@JsonProperty("eventId") EventId eventId,
                                         @JsonProperty("projectId") ProjectId source,
                                         @JsonProperty("entity") OWLEntity entity,
                                         @JsonProperty("deprecated") boolean deprecated) {
@@ -51,7 +45,7 @@ public class EntityDeprecatedChangedEvent extends ProjectEvent<EntityDeprecatedC
     }
 
     @JsonProperty("eventId")
-    public String getEventId() {
+    public EventId getEventId() {
         return eventId;
     }
 

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/event/EntityDeprecatedChangedEvent.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/event/EntityDeprecatedChangedEvent.java
@@ -1,5 +1,8 @@
 package edu.stanford.bmir.protege.web.shared.event;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.web.bindery.event.shared.Event;
 import edu.stanford.bmir.protege.web.shared.project.ProjectId;
@@ -18,6 +21,8 @@ public class EntityDeprecatedChangedEvent extends ProjectEvent<EntityDeprecatedC
 
     public transient static final Event.Type<EntityDeprecatedChangedHandler> ON_ENTITY_DEPRECATED = new Event.Type<EntityDeprecatedChangedHandler>();
 
+    private String eventId;
+
     private OWLEntity entity;
 
     private boolean deprecated;
@@ -28,10 +33,26 @@ public class EntityDeprecatedChangedEvent extends ProjectEvent<EntityDeprecatedC
         this.deprecated = deprecated;
     }
 
+    @JsonCreator
+    public EntityDeprecatedChangedEvent(@JsonProperty("eventId") String eventId,
+                                        @JsonProperty("projectId") ProjectId source,
+                                        @JsonProperty("entity") OWLEntity entity,
+                                        @JsonProperty("deprecated") boolean deprecated) {
+        super(source);
+        this.eventId = eventId;
+        this.entity = entity;
+        this.deprecated = deprecated;
+    }
+
     /**
      * For serialization only
      */
     private EntityDeprecatedChangedEvent() {
+    }
+
+    @JsonProperty("eventId")
+    public String getEventId() {
+        return eventId;
     }
 
     public OWLEntity getEntity() {
@@ -42,6 +63,7 @@ public class EntityDeprecatedChangedEvent extends ProjectEvent<EntityDeprecatedC
         return deprecated;
     }
 
+    @JsonIgnore
     @Override
     public Event.Type<EntityDeprecatedChangedHandler> getAssociatedType() {
         return ON_ENTITY_DEPRECATED;

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/event/EventId.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/event/EventId.java
@@ -1,0 +1,85 @@
+package edu.stanford.bmir.protege.web.shared.event;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.google.common.annotations.GwtCompatible;
+import com.google.common.annotations.GwtIncompatible;
+import com.google.gwt.user.client.rpc.IsSerializable;
+import edu.stanford.bmir.protege.web.shared.annotations.GwtSerializationConstructor;
+
+import javax.annotation.Nonnull;
+import java.io.Serializable;
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * Identifier for an event sent over the wire. Mirrors the backend's
+ * {@code edu.stanford.protege.webprotege.common.EventId} record. The JSON form
+ * is just the raw UUID string (via {@code @JsonValue}), so a client
+ * {@code EventId} is wire-compatible with both the backend {@code EventId}
+ * and a plain {@code String}.
+ */
+@GwtCompatible(serializable = true)
+public class EventId implements Serializable, IsSerializable {
+
+    private String id;
+
+    private EventId(@Nonnull String id) {
+        this.id = Objects.requireNonNull(id);
+    }
+
+    @GwtSerializationConstructor
+    private EventId() {
+    }
+
+    @JsonCreator
+    @Nonnull
+    public static EventId get(@Nonnull String id) {
+        return new EventId(id);
+    }
+
+    @Nonnull
+    public static EventId valueOf(@Nonnull String id) {
+        return get(id);
+    }
+
+    /**
+     * Mints a fresh {@link EventId} backed by a random UUID.
+     *
+     * <p>JVM-only helper, mirroring {@code ChangeRequestId.generate()} and
+     * {@code PerspectiveId.generate()}. Client code mints {@code EventId} via
+     * {@code EventId.get(uuidV4Provider.get())} instead.</p>
+     */
+    @GwtIncompatible
+    @Nonnull
+    public static EventId generate() {
+        return get(UUID.randomUUID().toString());
+    }
+
+    @JsonValue
+    @Nonnull
+    public String id() {
+        return id;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof EventId)) {
+            return false;
+        }
+        return Objects.equals(this.id, ((EventId) obj).id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(id);
+    }
+
+    @Override
+    public String toString() {
+        return "EventId{" + id + "}";
+    }
+}

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/event/LargeNumberOfChangesEvent.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/event/LargeNumberOfChangesEvent.java
@@ -1,5 +1,8 @@
 package edu.stanford.bmir.protege.web.shared.event;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.web.bindery.event.shared.Event;
 import edu.stanford.bmir.protege.web.shared.annotations.GwtSerializationConstructor;
@@ -15,14 +18,29 @@ public class LargeNumberOfChangesEvent extends ProjectEvent<LargeNumberOfChanges
 
     public static final Event.Type<LargeNumberOfChangesHandler> LARGE_NUMBER_OF_CHANGES = new Event.Type<>();
 
+    private String eventId;
+
     public LargeNumberOfChangesEvent(ProjectId source) {
         super(source);
+    }
+
+    @JsonCreator
+    public LargeNumberOfChangesEvent(@JsonProperty("eventId") String eventId,
+                                     @JsonProperty("projectId") ProjectId source) {
+        super(source);
+        this.eventId = eventId;
     }
 
     @GwtSerializationConstructor
     private LargeNumberOfChangesEvent() {
     }
 
+    @JsonProperty("eventId")
+    public String getEventId() {
+        return eventId;
+    }
+
+    @JsonIgnore
     @Override
     public Event.Type<LargeNumberOfChangesHandler> getAssociatedType() {
         return LARGE_NUMBER_OF_CHANGES;

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/event/LargeNumberOfChangesEvent.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/event/LargeNumberOfChangesEvent.java
@@ -18,14 +18,10 @@ public class LargeNumberOfChangesEvent extends ProjectEvent<LargeNumberOfChanges
 
     public static final Event.Type<LargeNumberOfChangesHandler> LARGE_NUMBER_OF_CHANGES = new Event.Type<>();
 
-    private String eventId;
-
-    public LargeNumberOfChangesEvent(ProjectId source) {
-        super(source);
-    }
+    private EventId eventId;
 
     @JsonCreator
-    public LargeNumberOfChangesEvent(@JsonProperty("eventId") String eventId,
+    public LargeNumberOfChangesEvent(@JsonProperty("eventId") EventId eventId,
                                      @JsonProperty("projectId") ProjectId source) {
         super(source);
         this.eventId = eventId;
@@ -36,7 +32,7 @@ public class LargeNumberOfChangesEvent extends ProjectEvent<LargeNumberOfChanges
     }
 
     @JsonProperty("eventId")
-    public String getEventId() {
+    public EventId getEventId() {
         return eventId;
     }
 

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/event/ProjectChangedEvent.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/event/ProjectChangedEvent.java
@@ -1,6 +1,9 @@
 package edu.stanford.bmir.protege.web.shared.event;
 
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.common.base.MoreObjects;
 import com.google.web.bindery.event.shared.Event;
@@ -27,6 +30,8 @@ public class ProjectChangedEvent extends ProjectEvent<ProjectChangedHandler> {
 
     public transient static final Event.Type<ProjectChangedHandler> TYPE = new Event.Type<ProjectChangedHandler>();
 
+    private String eventId;
+
     private Set<OWLEntityData> subjects;
 
     private RevisionSummary revisionSummary;
@@ -50,6 +55,22 @@ public class ProjectChangedEvent extends ProjectEvent<ProjectChangedHandler> {
         this.subjects = new HashSet<OWLEntityData>(subjects);
     }
 
+    @JsonCreator
+    public ProjectChangedEvent(@JsonProperty("eventId") String eventId,
+                               @JsonProperty("projectId") ProjectId source,
+                               @JsonProperty("revisionSummary") RevisionSummary revisionSummary,
+                               @JsonProperty("subjects") Set<OWLEntityData> subjects) {
+        super(source);
+        this.eventId = eventId;
+        this.revisionSummary = checkNotNull(revisionSummary);
+        this.subjects = new HashSet<OWLEntityData>(subjects);
+    }
+
+    @JsonProperty("eventId")
+    public String getEventId() {
+        return eventId;
+    }
+
     /**
      * Gets the revision summary for this event.
      * @return The {@link RevisionSummary}.  Not {@code null}.
@@ -62,6 +83,7 @@ public class ProjectChangedEvent extends ProjectEvent<ProjectChangedHandler> {
      * Gets the {@link RevisionNumber} of the project after the changes were applied.
      * @return The {@link RevisionNumber}.  Not {@code null}.
      */
+    @JsonIgnore
     public RevisionNumber getRevisionNumber() {
         return revisionSummary.getRevisionNumber();
     }
@@ -70,6 +92,7 @@ public class ProjectChangedEvent extends ProjectEvent<ProjectChangedHandler> {
      * Gets the {@link UserId} of the user that caused the changes to be applied.
      * @return The {@link UserId} of the user.  Not {@code null}.
      */
+    @JsonIgnore
     public UserId getUserId() {
         return revisionSummary.getUserId();
     }
@@ -78,6 +101,7 @@ public class ProjectChangedEvent extends ProjectEvent<ProjectChangedHandler> {
      * Gets the timestamp that represents the time the changes were applied.
      * @return The timestamp.
      */
+    @JsonIgnore
     public long getTimestamp() {
         return revisionSummary.getTimestamp();
     }
@@ -93,6 +117,7 @@ public class ProjectChangedEvent extends ProjectEvent<ProjectChangedHandler> {
 
 
 
+    @JsonIgnore
     @Override
     public Event.Type<ProjectChangedHandler> getAssociatedType() {
         return TYPE;

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/event/ProjectChangedEvent.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/event/ProjectChangedEvent.java
@@ -30,7 +30,7 @@ public class ProjectChangedEvent extends ProjectEvent<ProjectChangedHandler> {
 
     public transient static final Event.Type<ProjectChangedHandler> TYPE = new Event.Type<ProjectChangedHandler>();
 
-    private String eventId;
+    private EventId eventId;
 
     private Set<OWLEntityData> subjects;
 
@@ -42,21 +42,8 @@ public class ProjectChangedEvent extends ProjectEvent<ProjectChangedHandler> {
     private ProjectChangedEvent() {
     }
 
-    /**
-     * Creates a {@link ProjectChangedEvent}.
-     * @param source The source of the event.  The project that was changed.  Not {@code null}.
-     * @param revisionSummary The summary of the revision to the project.  Not {@code null}.
-     * @param subjects The possibly empty set of subjects of the changes.  Not {@code null}.
-     * @throws NullPointerException if any parameters are {@code null}.
-     */
-    public ProjectChangedEvent(ProjectId source, RevisionSummary revisionSummary, Set<OWLEntityData> subjects) {
-        super(source);
-        this.revisionSummary = checkNotNull(revisionSummary);
-        this.subjects = new HashSet<OWLEntityData>(subjects);
-    }
-
     @JsonCreator
-    public ProjectChangedEvent(@JsonProperty("eventId") String eventId,
+    public ProjectChangedEvent(@JsonProperty("eventId") EventId eventId,
                                @JsonProperty("projectId") ProjectId source,
                                @JsonProperty("revisionSummary") RevisionSummary revisionSummary,
                                @JsonProperty("subjects") Set<OWLEntityData> subjects) {
@@ -67,7 +54,7 @@ public class ProjectChangedEvent extends ProjectEvent<ProjectChangedHandler> {
     }
 
     @JsonProperty("eventId")
-    public String getEventId() {
+    public EventId getEventId() {
         return eventId;
     }
 

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/hierarchy/EntityHierarchyChangedEvent.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/hierarchy/EntityHierarchyChangedEvent.java
@@ -19,6 +19,7 @@ import javax.annotation.Nonnull;
 import java.util.Objects;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import edu.stanford.bmir.protege.web.shared.event.EventId;
 
 /**
  * Matthew Horridge Stanford Center for Biomedical Informatics Research 1 Dec 2017
@@ -28,7 +29,7 @@ public class EntityHierarchyChangedEvent extends ProjectEvent<EntityHierarchyCha
 
     public static final transient Event.Type<EntityHierarchyChangedHandler> ON_HIERARCHY_CHANGED = new Event.Type<>();
 
-    private String eventId;
+    private EventId eventId;
 
     private HierarchyDescriptor hierarchyDescriptor;
 
@@ -36,18 +37,8 @@ public class EntityHierarchyChangedEvent extends ProjectEvent<EntityHierarchyCha
 
     private ChangeRequestId changeRequestId;
 
-    public EntityHierarchyChangedEvent(@Nonnull ProjectId source,
-                                       @Nonnull HierarchyDescriptor hierarchyDescriptor,
-                                       @Nonnull GraphModelChangedEvent<EntityNode> changeEvent,
-                                       ChangeRequestId changeRequestId) {
-        super(source);
-        this.hierarchyDescriptor = checkNotNull(hierarchyDescriptor);
-        this.changeEvent = checkNotNull(changeEvent);
-        this.changeRequestId = changeRequestId;
-    }
-
     @JsonCreator
-    public EntityHierarchyChangedEvent(@JsonProperty("eventId") String eventId,
+    public EntityHierarchyChangedEvent(@JsonProperty("eventId") EventId eventId,
                                        @JsonProperty("projectId") @Nonnull ProjectId source,
                                        @JsonProperty("hierarchyDescriptor") @Nonnull HierarchyDescriptor hierarchyDescriptor,
                                        @JsonProperty("changeEvent") @Nonnull GraphModelChangedEvent<EntityNode> changeEvent,
@@ -60,7 +51,7 @@ public class EntityHierarchyChangedEvent extends ProjectEvent<EntityHierarchyCha
     }
 
     @JsonProperty("eventId")
-    public String getEventId() {
+    public EventId getEventId() {
         return eventId;
     }
 

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/hierarchy/EntityHierarchyChangedEvent.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/hierarchy/EntityHierarchyChangedEvent.java
@@ -1,6 +1,7 @@
 package edu.stanford.bmir.protege.web.shared.hierarchy;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.web.bindery.event.shared.Event;
@@ -27,21 +28,40 @@ public class EntityHierarchyChangedEvent extends ProjectEvent<EntityHierarchyCha
 
     public static final transient Event.Type<EntityHierarchyChangedHandler> ON_HIERARCHY_CHANGED = new Event.Type<>();
 
+    private String eventId;
+
     private HierarchyDescriptor hierarchyDescriptor;
 
     private GraphModelChangedEvent<EntityNode> changeEvent;
 
     private ChangeRequestId changeRequestId;
 
-    @JsonCreator
-    public EntityHierarchyChangedEvent(@JsonProperty("projectId") @Nonnull ProjectId source,
-                                       @JsonProperty("hierarchyDescriptor") @Nonnull HierarchyDescriptor hierarchyDescriptor,
-                                       @JsonProperty("changeEvent") @Nonnull GraphModelChangedEvent<EntityNode> changeEvent,
-                                       @JsonProperty("changeRequestId") ChangeRequestId changeRequestId) {
+    public EntityHierarchyChangedEvent(@Nonnull ProjectId source,
+                                       @Nonnull HierarchyDescriptor hierarchyDescriptor,
+                                       @Nonnull GraphModelChangedEvent<EntityNode> changeEvent,
+                                       ChangeRequestId changeRequestId) {
         super(source);
         this.hierarchyDescriptor = checkNotNull(hierarchyDescriptor);
         this.changeEvent = checkNotNull(changeEvent);
         this.changeRequestId = changeRequestId;
+    }
+
+    @JsonCreator
+    public EntityHierarchyChangedEvent(@JsonProperty("eventId") String eventId,
+                                       @JsonProperty("projectId") @Nonnull ProjectId source,
+                                       @JsonProperty("hierarchyDescriptor") @Nonnull HierarchyDescriptor hierarchyDescriptor,
+                                       @JsonProperty("changeEvent") @Nonnull GraphModelChangedEvent<EntityNode> changeEvent,
+                                       @JsonProperty("changeRequestId") ChangeRequestId changeRequestId) {
+        super(source);
+        this.eventId = eventId;
+        this.hierarchyDescriptor = checkNotNull(hierarchyDescriptor);
+        this.changeEvent = checkNotNull(changeEvent);
+        this.changeRequestId = changeRequestId;
+    }
+
+    @JsonProperty("eventId")
+    public String getEventId() {
+        return eventId;
     }
 
     @JsonProperty("hierarchyDescriptor")
@@ -60,6 +80,7 @@ public class EntityHierarchyChangedEvent extends ProjectEvent<EntityHierarchyCha
         return changeRequestId;
     }
 
+    @JsonIgnore
     @Override
     public Event.Type<EntityHierarchyChangedHandler> getAssociatedType() {
         return ON_HIERARCHY_CHANGED;

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/hierarchy/GetHierarchySiblingsResult.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/hierarchy/GetHierarchySiblingsResult.java
@@ -24,9 +24,10 @@ import static com.google.common.base.Preconditions.checkNotNull;
 public abstract class GetHierarchySiblingsResult implements Result {
 
     @JsonCreator
-    public static GetHierarchySiblingsResult create(@JsonProperty("siblings") Page<GraphNode<EntityNode>> siblingsPage) {
+    public static GetHierarchySiblingsResult create(@JsonProperty("siblingsPage") Page<GraphNode<EntityNode>> siblingsPage) {
         return new AutoValue_GetHierarchySiblingsResult(siblingsPage);
     }
 
+    @JsonProperty("siblingsPage")
     public abstract Page<GraphNode<EntityNode>> getSiblings();
 }

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/individuals/GetIndividualsAction.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/individuals/GetIndividualsAction.java
@@ -1,5 +1,6 @@
 package edu.stanford.bmir.protege.web.shared.individuals;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.common.base.MoreObjects;
 import edu.stanford.bmir.protege.web.shared.annotations.GwtSerializationConstructor;
@@ -70,6 +71,13 @@ public class GetIndividualsAction extends AbstractHasProjectAction<GetIndividual
                                               @Nonnull InstanceRetrievalMode instanceRetrievalMode,
                                               @Nonnull Optional<PageRequest> pageRequest) {
         return new GetIndividualsAction(projectId, type, filterString, instanceRetrievalMode, pageRequest);
+    }
+
+    @Nonnull
+    @Override
+    @JsonProperty("projectId")
+    public ProjectId getProjectId() {
+        return super.getProjectId();
     }
 
     /**

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/issues/AddEntityCommentAction.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/issues/AddEntityCommentAction.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.auto.value.AutoValue;
 import com.google.common.annotations.GwtCompatible;
-import com.google.common.annotations.GwtIncompatible;
 import edu.stanford.bmir.protege.web.shared.dispatch.ProjectAction;
 import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
 import edu.stanford.bmir.protege.web.shared.project.HasProjectId;
@@ -13,7 +12,6 @@ import edu.stanford.bmir.protege.web.shared.project.ProjectId;
 
 import javax.annotation.Nonnull;
 
-import java.util.UUID;
 
 /**
  * Matthew Horridge
@@ -25,12 +23,6 @@ import java.util.UUID;
 @JsonTypeName("webprotege.discussions.AddComment")
 public abstract class AddEntityCommentAction implements ProjectAction<AddEntityCommentResult>, HasProjectId {
 
-    @GwtIncompatible
-    public static AddEntityCommentAction addComment(@Nonnull ProjectId projectId,
-                                                    @Nonnull ThreadId threadId,
-                                                    @Nonnull String comment) {
-        return addComment(ChangeRequestId.get(UUID.randomUUID().toString()), projectId, threadId, comment);
-    }
 
     @JsonCreator
     public static AddEntityCommentAction addComment(@JsonProperty("changeRequestId") @Nonnull ChangeRequestId changeRequestId,

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/issues/AddEntityCommentAction.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/issues/AddEntityCommentAction.java
@@ -5,12 +5,14 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.auto.value.AutoValue;
 import com.google.common.annotations.GwtCompatible;
+import com.google.common.annotations.GwtIncompatible;
 import edu.stanford.bmir.protege.web.shared.dispatch.ProjectAction;
 import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
 import edu.stanford.bmir.protege.web.shared.project.HasProjectId;
 import edu.stanford.bmir.protege.web.shared.project.ProjectId;
 
 import javax.annotation.Nonnull;
+
 import java.util.UUID;
 
 /**
@@ -23,6 +25,7 @@ import java.util.UUID;
 @JsonTypeName("webprotege.discussions.AddComment")
 public abstract class AddEntityCommentAction implements ProjectAction<AddEntityCommentResult>, HasProjectId {
 
+    @GwtIncompatible
     public static AddEntityCommentAction addComment(@Nonnull ProjectId projectId,
                                                     @Nonnull ThreadId threadId,
                                                     @Nonnull String comment) {

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/issues/AddEntityCommentAction.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/issues/AddEntityCommentAction.java
@@ -6,10 +6,12 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.auto.value.AutoValue;
 import com.google.common.annotations.GwtCompatible;
 import edu.stanford.bmir.protege.web.shared.dispatch.ProjectAction;
+import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
 import edu.stanford.bmir.protege.web.shared.project.HasProjectId;
 import edu.stanford.bmir.protege.web.shared.project.ProjectId;
 
 import javax.annotation.Nonnull;
+import java.util.UUID;
 
 /**
  * Matthew Horridge
@@ -21,12 +23,23 @@ import javax.annotation.Nonnull;
 @JsonTypeName("webprotege.discussions.AddComment")
 public abstract class AddEntityCommentAction implements ProjectAction<AddEntityCommentResult>, HasProjectId {
 
+    public static AddEntityCommentAction addComment(@Nonnull ProjectId projectId,
+                                                    @Nonnull ThreadId threadId,
+                                                    @Nonnull String comment) {
+        return addComment(ChangeRequestId.get(UUID.randomUUID().toString()), projectId, threadId, comment);
+    }
+
     @JsonCreator
-    public static AddEntityCommentAction addComment(@JsonProperty("projectId") @Nonnull ProjectId projectId,
+    public static AddEntityCommentAction addComment(@JsonProperty("changeRequestId") @Nonnull ChangeRequestId changeRequestId,
+                                                    @JsonProperty("projectId") @Nonnull ProjectId projectId,
                                                     @JsonProperty("threadId") @Nonnull ThreadId threadId,
                                                     @JsonProperty("comment") @Nonnull String comment) {
-        return new AutoValue_AddEntityCommentAction(projectId, threadId, comment);
+        return new AutoValue_AddEntityCommentAction(changeRequestId, projectId, threadId, comment);
     }
+
+    @Nonnull
+    @JsonProperty("changeRequestId")
+    public abstract ChangeRequestId getChangeRequestId();
 
     @Nonnull
     @JsonProperty("projectId")

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/issues/CommentUpdatedEvent.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/issues/CommentUpdatedEvent.java
@@ -1,5 +1,8 @@
 package edu.stanford.bmir.protege.web.shared.issues;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.web.bindery.event.shared.Event;
 import edu.stanford.bmir.protege.web.shared.annotations.GwtSerializationConstructor;
@@ -23,6 +26,8 @@ public class CommentUpdatedEvent extends ProjectEvent<CommentUpdatedHandler> imp
 
     public static final transient Event.Type<CommentUpdatedHandler> ON_COMMENT_UPDATED = new Event.Type<>();
 
+    private String eventId;
+
     private ProjectId projectId;
 
     private ThreadId threadId;
@@ -38,10 +43,28 @@ public class CommentUpdatedEvent extends ProjectEvent<CommentUpdatedHandler> imp
         this.comment = checkNotNull(comment);
     }
 
+    @JsonCreator
+    public CommentUpdatedEvent(@JsonProperty("eventId") String eventId,
+                               @JsonProperty("projectId") @Nonnull ProjectId projectId,
+                               @JsonProperty("threadId") @Nonnull ThreadId threadId,
+                               @JsonProperty("comment") @Nonnull Comment comment) {
+        super(projectId);
+        this.eventId = eventId;
+        this.projectId = checkNotNull(projectId);
+        this.threadId = checkNotNull(threadId);
+        this.comment = checkNotNull(comment);
+    }
+
     @GwtSerializationConstructor
     private CommentUpdatedEvent() {
     }
 
+    @JsonProperty("eventId")
+    public String getEventId() {
+        return eventId;
+    }
+
+    @JsonIgnore
     @Override
     public Event.Type<CommentUpdatedHandler> getAssociatedType() {
         return ON_COMMENT_UPDATED;

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/issues/CommentUpdatedEvent.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/issues/CommentUpdatedEvent.java
@@ -15,6 +15,7 @@ import javax.annotation.Nonnull;
 import java.util.Objects;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import edu.stanford.bmir.protege.web.shared.event.EventId;
 
 /**
  * Matthew Horridge
@@ -26,7 +27,7 @@ public class CommentUpdatedEvent extends ProjectEvent<CommentUpdatedHandler> imp
 
     public static final transient Event.Type<CommentUpdatedHandler> ON_COMMENT_UPDATED = new Event.Type<>();
 
-    private String eventId;
+    private EventId eventId;
 
     private ProjectId projectId;
 
@@ -34,17 +35,8 @@ public class CommentUpdatedEvent extends ProjectEvent<CommentUpdatedHandler> imp
 
     private Comment comment;
 
-    public CommentUpdatedEvent(@Nonnull ProjectId projectId,
-                               @Nonnull ThreadId threadId,
-                               @Nonnull Comment comment) {
-        super(projectId);
-        this.projectId = checkNotNull(projectId);
-        this.threadId = checkNotNull(threadId);
-        this.comment = checkNotNull(comment);
-    }
-
     @JsonCreator
-    public CommentUpdatedEvent(@JsonProperty("eventId") String eventId,
+    public CommentUpdatedEvent(@JsonProperty("eventId") EventId eventId,
                                @JsonProperty("projectId") @Nonnull ProjectId projectId,
                                @JsonProperty("threadId") @Nonnull ThreadId threadId,
                                @JsonProperty("comment") @Nonnull Comment comment) {
@@ -60,7 +52,7 @@ public class CommentUpdatedEvent extends ProjectEvent<CommentUpdatedHandler> imp
     }
 
     @JsonProperty("eventId")
-    public String getEventId() {
+    public EventId getEventId() {
         return eventId;
     }
 

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/issues/CreateEntityDiscussionThreadAction.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/issues/CreateEntityDiscussionThreadAction.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.auto.value.AutoValue;
 import com.google.common.annotations.GwtCompatible;
-import com.google.common.annotations.GwtIncompatible;
 import edu.stanford.bmir.protege.web.shared.annotations.GwtSerializationConstructor;
 import edu.stanford.bmir.protege.web.shared.dispatch.ProjectAction;
 import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
@@ -16,7 +15,6 @@ import javax.annotation.Nonnull;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import java.util.UUID;
 
 /**
  * Matthew Horridge
@@ -40,12 +38,6 @@ public abstract class CreateEntityDiscussionThreadAction implements ProjectActio
     @Nonnull
     public abstract String getComment();
 
-    @GwtIncompatible
-    public static CreateEntityDiscussionThreadAction create(ProjectId projectId,
-                                                            OWLEntity entity,
-                                                            String comment) {
-        return create(ChangeRequestId.get(UUID.randomUUID().toString()), projectId, entity, comment);
-    }
 
     @JsonCreator
     public static CreateEntityDiscussionThreadAction create(@JsonProperty("changeRequestId") ChangeRequestId changeRequestId,

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/issues/CreateEntityDiscussionThreadAction.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/issues/CreateEntityDiscussionThreadAction.java
@@ -7,10 +7,12 @@ import com.google.auto.value.AutoValue;
 import com.google.common.annotations.GwtCompatible;
 import edu.stanford.bmir.protege.web.shared.annotations.GwtSerializationConstructor;
 import edu.stanford.bmir.protege.web.shared.dispatch.ProjectAction;
+import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
 import edu.stanford.bmir.protege.web.shared.project.ProjectId;
 import org.semanticweb.owlapi.model.OWLEntity;
 
 import javax.annotation.Nonnull;
+import java.util.UUID;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -25,6 +27,10 @@ import static com.google.common.base.Preconditions.checkNotNull;
 public abstract class CreateEntityDiscussionThreadAction implements ProjectAction<CreateEntityDiscussionThreadResult> {
 
     @Nonnull
+    @JsonProperty("changeRequestId")
+    public abstract ChangeRequestId getChangeRequestId();
+
+    @Nonnull
     public abstract ProjectId getProjectId();
 
     public abstract OWLEntity getEntity();
@@ -32,11 +38,18 @@ public abstract class CreateEntityDiscussionThreadAction implements ProjectActio
     @Nonnull
     public abstract String getComment();
 
+    public static CreateEntityDiscussionThreadAction create(ProjectId projectId,
+                                                            OWLEntity entity,
+                                                            String comment) {
+        return create(ChangeRequestId.get(UUID.randomUUID().toString()), projectId, entity, comment);
+    }
+
     @JsonCreator
-    public static CreateEntityDiscussionThreadAction create(@JsonProperty("projectId") ProjectId projectId,
+    public static CreateEntityDiscussionThreadAction create(@JsonProperty("changeRequestId") ChangeRequestId changeRequestId,
+                                                            @JsonProperty("projectId") ProjectId projectId,
                                                             @JsonProperty("entity") OWLEntity entity,
                                                             @JsonProperty("comment") String comment) {
-        return new AutoValue_CreateEntityDiscussionThreadAction(projectId, entity, comment);
+        return new AutoValue_CreateEntityDiscussionThreadAction(changeRequestId, projectId, entity, comment);
     }
 
 

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/issues/CreateEntityDiscussionThreadAction.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/issues/CreateEntityDiscussionThreadAction.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.auto.value.AutoValue;
 import com.google.common.annotations.GwtCompatible;
+import com.google.common.annotations.GwtIncompatible;
 import edu.stanford.bmir.protege.web.shared.annotations.GwtSerializationConstructor;
 import edu.stanford.bmir.protege.web.shared.dispatch.ProjectAction;
 import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
@@ -12,9 +13,10 @@ import edu.stanford.bmir.protege.web.shared.project.ProjectId;
 import org.semanticweb.owlapi.model.OWLEntity;
 
 import javax.annotation.Nonnull;
-import java.util.UUID;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.UUID;
 
 /**
  * Matthew Horridge
@@ -38,6 +40,7 @@ public abstract class CreateEntityDiscussionThreadAction implements ProjectActio
     @Nonnull
     public abstract String getComment();
 
+    @GwtIncompatible
     public static CreateEntityDiscussionThreadAction create(ProjectId projectId,
                                                             OWLEntity entity,
                                                             String comment) {

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/issues/DeleteEntityCommentAction.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/issues/DeleteEntityCommentAction.java
@@ -3,7 +3,6 @@ package edu.stanford.bmir.protege.web.shared.issues;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import com.google.common.annotations.GwtIncompatible;
 import com.google.common.base.Objects;
 import edu.stanford.bmir.protege.web.shared.annotations.GwtSerializationConstructor;
 import edu.stanford.bmir.protege.web.shared.dispatch.ProjectAction;
@@ -14,7 +13,6 @@ import javax.annotation.Nonnull;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import java.util.UUID;
 
 /**
  * Matthew Horridge
@@ -30,11 +28,6 @@ public class DeleteEntityCommentAction implements ProjectAction<DeleteEntityComm
 
     private CommentId commentId;
 
-    @GwtIncompatible
-    public static DeleteEntityCommentAction deleteComment(@Nonnull ProjectId projectId,
-                                                          @Nonnull CommentId commentId) {
-        return deleteComment(ChangeRequestId.get(UUID.randomUUID().toString()), projectId, commentId);
-    }
 
     @JsonCreator
     public static DeleteEntityCommentAction deleteComment(@JsonProperty("changeRequestId") @Nonnull ChangeRequestId changeRequestId,
@@ -51,11 +44,6 @@ public class DeleteEntityCommentAction implements ProjectAction<DeleteEntityComm
         this.projectId = checkNotNull(projectId);
     }
 
-    @GwtIncompatible
-    public DeleteEntityCommentAction(@Nonnull ProjectId projectId,
-                                     @Nonnull CommentId commentId) {
-        this(ChangeRequestId.get(UUID.randomUUID().toString()), projectId, commentId);
-    }
 
     @GwtSerializationConstructor
     private DeleteEntityCommentAction() {

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/issues/DeleteEntityCommentAction.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/issues/DeleteEntityCommentAction.java
@@ -3,6 +3,7 @@ package edu.stanford.bmir.protege.web.shared.issues;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.google.common.annotations.GwtIncompatible;
 import com.google.common.base.Objects;
 import edu.stanford.bmir.protege.web.shared.annotations.GwtSerializationConstructor;
 import edu.stanford.bmir.protege.web.shared.dispatch.ProjectAction;
@@ -10,9 +11,10 @@ import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
 import edu.stanford.bmir.protege.web.shared.project.ProjectId;
 
 import javax.annotation.Nonnull;
-import java.util.UUID;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.UUID;
 
 /**
  * Matthew Horridge
@@ -28,6 +30,7 @@ public class DeleteEntityCommentAction implements ProjectAction<DeleteEntityComm
 
     private CommentId commentId;
 
+    @GwtIncompatible
     public static DeleteEntityCommentAction deleteComment(@Nonnull ProjectId projectId,
                                                           @Nonnull CommentId commentId) {
         return deleteComment(ChangeRequestId.get(UUID.randomUUID().toString()), projectId, commentId);
@@ -48,6 +51,7 @@ public class DeleteEntityCommentAction implements ProjectAction<DeleteEntityComm
         this.projectId = checkNotNull(projectId);
     }
 
+    @GwtIncompatible
     public DeleteEntityCommentAction(@Nonnull ProjectId projectId,
                                      @Nonnull CommentId commentId) {
         this(ChangeRequestId.get(UUID.randomUUID().toString()), projectId, commentId);

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/issues/DeleteEntityCommentAction.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/issues/DeleteEntityCommentAction.java
@@ -6,9 +6,11 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.common.base.Objects;
 import edu.stanford.bmir.protege.web.shared.annotations.GwtSerializationConstructor;
 import edu.stanford.bmir.protege.web.shared.dispatch.ProjectAction;
+import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
 import edu.stanford.bmir.protege.web.shared.project.ProjectId;
 
 import javax.annotation.Nonnull;
+import java.util.UUID;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -20,24 +22,45 @@ import static com.google.common.base.Preconditions.checkNotNull;
 @JsonTypeName("webprotege.discussions.DeleteComment")
 public class DeleteEntityCommentAction implements ProjectAction<DeleteEntityCommentResult> {
 
+    private ChangeRequestId changeRequestId;
+
     private ProjectId projectId;
 
     private CommentId commentId;
 
-    @JsonCreator
-    public static DeleteEntityCommentAction deleteComment(@JsonProperty("projectId") @Nonnull ProjectId projectId,
-                                                          @JsonProperty("commentId") @Nonnull CommentId commentId) {
-        return new DeleteEntityCommentAction(projectId, commentId);
+    public static DeleteEntityCommentAction deleteComment(@Nonnull ProjectId projectId,
+                                                          @Nonnull CommentId commentId) {
+        return deleteComment(ChangeRequestId.get(UUID.randomUUID().toString()), projectId, commentId);
     }
 
-    public DeleteEntityCommentAction(@Nonnull ProjectId projectId,
+    @JsonCreator
+    public static DeleteEntityCommentAction deleteComment(@JsonProperty("changeRequestId") @Nonnull ChangeRequestId changeRequestId,
+                                                          @JsonProperty("projectId") @Nonnull ProjectId projectId,
+                                                          @JsonProperty("commentId") @Nonnull CommentId commentId) {
+        return new DeleteEntityCommentAction(changeRequestId, projectId, commentId);
+    }
+
+    public DeleteEntityCommentAction(@Nonnull ChangeRequestId changeRequestId,
+                                     @Nonnull ProjectId projectId,
                                      @Nonnull CommentId commentId) {
+        this.changeRequestId = checkNotNull(changeRequestId);
         this.commentId = checkNotNull(commentId);
         this.projectId = checkNotNull(projectId);
     }
 
+    public DeleteEntityCommentAction(@Nonnull ProjectId projectId,
+                                     @Nonnull CommentId commentId) {
+        this(ChangeRequestId.get(UUID.randomUUID().toString()), projectId, commentId);
+    }
+
     @GwtSerializationConstructor
     private DeleteEntityCommentAction() {
+    }
+
+    @Nonnull
+    @JsonProperty("changeRequestId")
+    public ChangeRequestId getChangeRequestId() {
+        return changeRequestId;
     }
 
     @Nonnull

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/issues/EditCommentAction.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/issues/EditCommentAction.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.auto.value.AutoValue;
 import com.google.common.annotations.GwtCompatible;
-import com.google.common.annotations.GwtIncompatible;
 import edu.stanford.bmir.protege.web.shared.annotations.GwtSerializationConstructor;
 import edu.stanford.bmir.protege.web.shared.dispatch.ProjectAction;
 import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
@@ -15,7 +14,6 @@ import javax.annotation.Nonnull;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import java.util.UUID;
 
 /**
  * Matthew Horridge
@@ -27,13 +25,6 @@ import java.util.UUID;
 @JsonTypeName("webprotege.discussions.UpdateComment")
 public abstract class EditCommentAction implements ProjectAction<EditCommentResult> {
 
-    @GwtIncompatible
-    public static EditCommentAction editComment(@Nonnull ProjectId projectId,
-                                                @Nonnull ThreadId threadId,
-                                                @Nonnull CommentId commentId,
-                                                @Nonnull String body) {
-        return editComment(ChangeRequestId.get(UUID.randomUUID().toString()), projectId, threadId, commentId, body);
-    }
 
     @JsonCreator
     public static EditCommentAction editComment(@JsonProperty("changeRequestId") @Nonnull ChangeRequestId changeRequestId,

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/issues/EditCommentAction.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/issues/EditCommentAction.java
@@ -7,9 +7,11 @@ import com.google.auto.value.AutoValue;
 import com.google.common.annotations.GwtCompatible;
 import edu.stanford.bmir.protege.web.shared.annotations.GwtSerializationConstructor;
 import edu.stanford.bmir.protege.web.shared.dispatch.ProjectAction;
+import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
 import edu.stanford.bmir.protege.web.shared.project.ProjectId;
 
 import javax.annotation.Nonnull;
+import java.util.UUID;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -23,13 +25,25 @@ import static com.google.common.base.Preconditions.checkNotNull;
 @JsonTypeName("webprotege.discussions.UpdateComment")
 public abstract class EditCommentAction implements ProjectAction<EditCommentResult> {
 
+    public static EditCommentAction editComment(@Nonnull ProjectId projectId,
+                                                @Nonnull ThreadId threadId,
+                                                @Nonnull CommentId commentId,
+                                                @Nonnull String body) {
+        return editComment(ChangeRequestId.get(UUID.randomUUID().toString()), projectId, threadId, commentId, body);
+    }
+
     @JsonCreator
-    public static EditCommentAction editComment(@JsonProperty("projectId") @Nonnull ProjectId projectId,
+    public static EditCommentAction editComment(@JsonProperty("changeRequestId") @Nonnull ChangeRequestId changeRequestId,
+                                                @JsonProperty("projectId") @Nonnull ProjectId projectId,
                                                 @JsonProperty("threadId") @Nonnull ThreadId threadId,
                                                 @JsonProperty("commentId") @Nonnull CommentId commentId,
                                                 @JsonProperty("body") @Nonnull String body) {
-        return new AutoValue_EditCommentAction(projectId, threadId, commentId, body);
+        return new AutoValue_EditCommentAction(changeRequestId, projectId, threadId, commentId, body);
     }
+
+    @Nonnull
+    @JsonProperty("changeRequestId")
+    public abstract ChangeRequestId getChangeRequestId();
 
     @Nonnull
     @Override

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/issues/EditCommentAction.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/issues/EditCommentAction.java
@@ -5,15 +5,17 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.auto.value.AutoValue;
 import com.google.common.annotations.GwtCompatible;
+import com.google.common.annotations.GwtIncompatible;
 import edu.stanford.bmir.protege.web.shared.annotations.GwtSerializationConstructor;
 import edu.stanford.bmir.protege.web.shared.dispatch.ProjectAction;
 import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
 import edu.stanford.bmir.protege.web.shared.project.ProjectId;
 
 import javax.annotation.Nonnull;
-import java.util.UUID;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.UUID;
 
 /**
  * Matthew Horridge
@@ -25,6 +27,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 @JsonTypeName("webprotege.discussions.UpdateComment")
 public abstract class EditCommentAction implements ProjectAction<EditCommentResult> {
 
+    @GwtIncompatible
     public static EditCommentAction editComment(@Nonnull ProjectId projectId,
                                                 @Nonnull ThreadId threadId,
                                                 @Nonnull CommentId commentId,

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/issues/SetDiscussionThreadStatusAction.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/issues/SetDiscussionThreadStatusAction.java
@@ -3,7 +3,6 @@ package edu.stanford.bmir.protege.web.shared.issues;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import com.google.common.annotations.GwtIncompatible;
 import edu.stanford.bmir.protege.web.shared.annotations.GwtSerializationConstructor;
 import edu.stanford.bmir.protege.web.shared.dispatch.ProjectAction;
 import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
@@ -13,7 +12,6 @@ import javax.annotation.Nonnull;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import java.util.UUID;
 
 /**
  * Matthew Horridge
@@ -42,22 +40,9 @@ public class SetDiscussionThreadStatusAction implements ProjectAction<SetDiscuss
         this.status = checkNotNull(status);
     }
 
-    @GwtIncompatible
-    public SetDiscussionThreadStatusAction(@Nonnull ProjectId projectId,
-                                           @Nonnull ThreadId threadId,
-                                           @Nonnull Status status) {
-        this(ChangeRequestId.get(UUID.randomUUID().toString()), projectId, threadId, status);
-    }
 
     @GwtSerializationConstructor
     private SetDiscussionThreadStatusAction() {
-    }
-
-    @GwtIncompatible
-    public static SetDiscussionThreadStatusAction setDiscussionThreadStatus(@Nonnull ProjectId projectId,
-                                                                            @Nonnull ThreadId threadId,
-                                                                            @Nonnull Status status) {
-        return new SetDiscussionThreadStatusAction(projectId, threadId, status);
     }
 
     @Nonnull

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/issues/SetDiscussionThreadStatusAction.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/issues/SetDiscussionThreadStatusAction.java
@@ -1,11 +1,15 @@
 package edu.stanford.bmir.protege.web.shared.issues;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import edu.stanford.bmir.protege.web.shared.annotations.GwtSerializationConstructor;
 import edu.stanford.bmir.protege.web.shared.dispatch.ProjectAction;
+import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
 import edu.stanford.bmir.protege.web.shared.project.ProjectId;
 
 import javax.annotation.Nonnull;
+import java.util.UUID;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -17,18 +21,29 @@ import static com.google.common.base.Preconditions.checkNotNull;
 @JsonTypeName("webprotege.discussions.SetDiscussionThreadStatus")
 public class SetDiscussionThreadStatusAction implements ProjectAction<SetDiscussionThreadStatusResult> {
 
+    private ChangeRequestId changeRequestId;
+
     private ProjectId projectId;
 
     private ThreadId threadId;
 
     private Status status;
 
-    public SetDiscussionThreadStatusAction(@Nonnull ProjectId projectId,
-                                           @Nonnull ThreadId threadId,
-                                           @Nonnull Status status) {
+    @JsonCreator
+    public SetDiscussionThreadStatusAction(@JsonProperty("changeRequestId") @Nonnull ChangeRequestId changeRequestId,
+                                           @JsonProperty("projectId") @Nonnull ProjectId projectId,
+                                           @JsonProperty("threadId") @Nonnull ThreadId threadId,
+                                           @JsonProperty("status") @Nonnull Status status) {
+        this.changeRequestId = checkNotNull(changeRequestId);
         this.projectId = checkNotNull(projectId);
         this.threadId = checkNotNull(threadId);
         this.status = checkNotNull(status);
+    }
+
+    public SetDiscussionThreadStatusAction(@Nonnull ProjectId projectId,
+                                           @Nonnull ThreadId threadId,
+                                           @Nonnull Status status) {
+        this(ChangeRequestId.get(UUID.randomUUID().toString()), projectId, threadId, status);
     }
 
     @GwtSerializationConstructor
@@ -39,6 +54,12 @@ public class SetDiscussionThreadStatusAction implements ProjectAction<SetDiscuss
                                                                             @Nonnull ThreadId threadId,
                                                                             @Nonnull Status status) {
         return new SetDiscussionThreadStatusAction(projectId, threadId, status);
+    }
+
+    @Nonnull
+    @JsonProperty("changeRequestId")
+    public ChangeRequestId getChangeRequestId() {
+        return changeRequestId;
     }
 
     @Override

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/issues/SetDiscussionThreadStatusAction.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/issues/SetDiscussionThreadStatusAction.java
@@ -3,15 +3,17 @@ package edu.stanford.bmir.protege.web.shared.issues;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.google.common.annotations.GwtIncompatible;
 import edu.stanford.bmir.protege.web.shared.annotations.GwtSerializationConstructor;
 import edu.stanford.bmir.protege.web.shared.dispatch.ProjectAction;
 import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
 import edu.stanford.bmir.protege.web.shared.project.ProjectId;
 
 import javax.annotation.Nonnull;
-import java.util.UUID;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.UUID;
 
 /**
  * Matthew Horridge
@@ -40,6 +42,7 @@ public class SetDiscussionThreadStatusAction implements ProjectAction<SetDiscuss
         this.status = checkNotNull(status);
     }
 
+    @GwtIncompatible
     public SetDiscussionThreadStatusAction(@Nonnull ProjectId projectId,
                                            @Nonnull ThreadId threadId,
                                            @Nonnull Status status) {
@@ -50,6 +53,7 @@ public class SetDiscussionThreadStatusAction implements ProjectAction<SetDiscuss
     private SetDiscussionThreadStatusAction() {
     }
 
+    @GwtIncompatible
     public static SetDiscussionThreadStatusAction setDiscussionThreadStatus(@Nonnull ProjectId projectId,
                                                                             @Nonnull ThreadId threadId,
                                                                             @Nonnull Status status) {

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/lang/DisplayNameSettingsChangedEvent.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/lang/DisplayNameSettingsChangedEvent.java
@@ -1,6 +1,7 @@
 package edu.stanford.bmir.protege.web.shared.lang;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.web.bindery.event.shared.Event;
@@ -23,6 +24,8 @@ public class DisplayNameSettingsChangedEvent extends ProjectEvent<DisplayNameSet
 
     public static final transient Event.Type<DisplayNameSettingsChangedHandler> ON_DISPLAY_LANGUAGE_CHANGED = new Event.Type<>();
 
+    private String eventId;
+
     @Nonnull
     private final DisplayNameSettings displayNameSettings;
 
@@ -32,10 +35,29 @@ public class DisplayNameSettingsChangedEvent extends ProjectEvent<DisplayNameSet
         this.displayNameSettings = checkNotNull(displayNameSettings);
     }
 
-    @JsonCreator
-    public static DisplayNameSettingsChangedEvent get(@JsonProperty("projectId") @Nonnull ProjectId projectId,
-                                                      @JsonProperty("displayNameSettings") @Nonnull DisplayNameSettings displayNameSettings) {
+    private DisplayNameSettingsChangedEvent(String eventId,
+                                            @Nonnull ProjectId source,
+                                            @Nonnull DisplayNameSettings displayNameSettings) {
+        super(source);
+        this.eventId = eventId;
+        this.displayNameSettings = checkNotNull(displayNameSettings);
+    }
+
+    public static DisplayNameSettingsChangedEvent get(@Nonnull ProjectId projectId,
+                                                      @Nonnull DisplayNameSettings displayNameSettings) {
         return new DisplayNameSettingsChangedEvent(projectId, displayNameSettings);
+    }
+
+    @JsonCreator
+    public static DisplayNameSettingsChangedEvent get(@JsonProperty("eventId") String eventId,
+                                                      @JsonProperty("projectId") @Nonnull ProjectId projectId,
+                                                      @JsonProperty("displayNameSettings") @Nonnull DisplayNameSettings displayNameSettings) {
+        return new DisplayNameSettingsChangedEvent(eventId, projectId, displayNameSettings);
+    }
+
+    @JsonProperty("eventId")
+    public String getEventId() {
+        return eventId;
     }
 
     @Nonnull
@@ -43,6 +65,7 @@ public class DisplayNameSettingsChangedEvent extends ProjectEvent<DisplayNameSet
         return ON_DISPLAY_LANGUAGE_CHANGED;
     }
 
+    @JsonIgnore
     @Override
     public Event.Type<DisplayNameSettingsChangedHandler> getAssociatedType() {
         return ON_DISPLAY_LANGUAGE_CHANGED;

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/lang/DisplayNameSettingsChangedEvent.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/lang/DisplayNameSettingsChangedEvent.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.web.bindery.event.shared.Event;
+import edu.stanford.bmir.protege.web.shared.event.EventId;
 import edu.stanford.bmir.protege.web.shared.event.ProjectEvent;
 import edu.stanford.bmir.protege.web.shared.project.ProjectId;
 
@@ -24,18 +25,12 @@ public class DisplayNameSettingsChangedEvent extends ProjectEvent<DisplayNameSet
 
     public static final transient Event.Type<DisplayNameSettingsChangedHandler> ON_DISPLAY_LANGUAGE_CHANGED = new Event.Type<>();
 
-    private String eventId;
+    private EventId eventId;
 
     @Nonnull
     private final DisplayNameSettings displayNameSettings;
 
-    private DisplayNameSettingsChangedEvent(@Nonnull ProjectId source,
-                                            @Nonnull DisplayNameSettings displayNameSettings) {
-        super(source);
-        this.displayNameSettings = checkNotNull(displayNameSettings);
-    }
-
-    private DisplayNameSettingsChangedEvent(String eventId,
+    private DisplayNameSettingsChangedEvent(EventId eventId,
                                             @Nonnull ProjectId source,
                                             @Nonnull DisplayNameSettings displayNameSettings) {
         super(source);
@@ -43,20 +38,15 @@ public class DisplayNameSettingsChangedEvent extends ProjectEvent<DisplayNameSet
         this.displayNameSettings = checkNotNull(displayNameSettings);
     }
 
-    public static DisplayNameSettingsChangedEvent get(@Nonnull ProjectId projectId,
-                                                      @Nonnull DisplayNameSettings displayNameSettings) {
-        return new DisplayNameSettingsChangedEvent(projectId, displayNameSettings);
-    }
-
     @JsonCreator
-    public static DisplayNameSettingsChangedEvent get(@JsonProperty("eventId") String eventId,
+    public static DisplayNameSettingsChangedEvent get(@JsonProperty("eventId") EventId eventId,
                                                       @JsonProperty("projectId") @Nonnull ProjectId projectId,
                                                       @JsonProperty("displayNameSettings") @Nonnull DisplayNameSettings displayNameSettings) {
         return new DisplayNameSettingsChangedEvent(eventId, projectId, displayNameSettings);
     }
 
     @JsonProperty("eventId")
-    public String getEventId() {
+    public EventId getEventId() {
         return eventId;
     }
 

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/merge/MergeUploadedProjectAction.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/merge/MergeUploadedProjectAction.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.auto.value.AutoValue;
 import com.google.common.annotations.GwtCompatible;
-import com.google.common.annotations.GwtIncompatible;
 import edu.stanford.bmir.protege.web.shared.csv.DocumentId;
 import edu.stanford.bmir.protege.web.shared.dispatch.AbstractHasProjectAction;
 import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
@@ -13,7 +12,6 @@ import edu.stanford.bmir.protege.web.shared.project.ProjectId;
 
 import javax.annotation.Nonnull;
 
-import java.util.UUID;
 
 /**
  * Matthew Horridge
@@ -25,12 +23,6 @@ import java.util.UUID;
 @JsonTypeName("webprotege.projects.MergeUploadedProject")
 public abstract class MergeUploadedProjectAction extends AbstractHasProjectAction<MergeUploadedProjectResult> {
 
-    @GwtIncompatible
-    public static MergeUploadedProjectAction create(ProjectId projectId,
-                                                    DocumentId uploadedDocumentId,
-                                                    String commitMessage) {
-        return create(ChangeRequestId.get(UUID.randomUUID().toString()), projectId, uploadedDocumentId, commitMessage);
-    }
 
     @JsonCreator
     public static MergeUploadedProjectAction create(@JsonProperty("changeRequestId") ChangeRequestId changeRequestId,

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/merge/MergeUploadedProjectAction.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/merge/MergeUploadedProjectAction.java
@@ -7,9 +7,11 @@ import com.google.auto.value.AutoValue;
 import com.google.common.annotations.GwtCompatible;
 import edu.stanford.bmir.protege.web.shared.csv.DocumentId;
 import edu.stanford.bmir.protege.web.shared.dispatch.AbstractHasProjectAction;
+import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
 import edu.stanford.bmir.protege.web.shared.project.ProjectId;
 
 import javax.annotation.Nonnull;
+import java.util.UUID;
 
 /**
  * Matthew Horridge
@@ -21,12 +23,23 @@ import javax.annotation.Nonnull;
 @JsonTypeName("webprotege.projects.MergeUploadedProject")
 public abstract class MergeUploadedProjectAction extends AbstractHasProjectAction<MergeUploadedProjectResult> {
 
+    public static MergeUploadedProjectAction create(ProjectId projectId,
+                                                    DocumentId uploadedDocumentId,
+                                                    String commitMessage) {
+        return create(ChangeRequestId.get(UUID.randomUUID().toString()), projectId, uploadedDocumentId, commitMessage);
+    }
+
     @JsonCreator
-    public static MergeUploadedProjectAction create(@JsonProperty("projectId") ProjectId projectId,
+    public static MergeUploadedProjectAction create(@JsonProperty("changeRequestId") ChangeRequestId changeRequestId,
+                                                    @JsonProperty("projectId") ProjectId projectId,
                                                     @JsonProperty("documentId") DocumentId uploadedDocumentId,
                                                     @JsonProperty("commitMessage") String commitMessage) {
-        return new AutoValue_MergeUploadedProjectAction(projectId, uploadedDocumentId, commitMessage);
+        return new AutoValue_MergeUploadedProjectAction(changeRequestId, projectId, uploadedDocumentId, commitMessage);
     }
+
+    @Nonnull
+    @JsonProperty("changeRequestId")
+    public abstract ChangeRequestId getChangeRequestId();
 
     @Nonnull
     @Override

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/merge/MergeUploadedProjectAction.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/merge/MergeUploadedProjectAction.java
@@ -5,12 +5,14 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.auto.value.AutoValue;
 import com.google.common.annotations.GwtCompatible;
+import com.google.common.annotations.GwtIncompatible;
 import edu.stanford.bmir.protege.web.shared.csv.DocumentId;
 import edu.stanford.bmir.protege.web.shared.dispatch.AbstractHasProjectAction;
 import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
 import edu.stanford.bmir.protege.web.shared.project.ProjectId;
 
 import javax.annotation.Nonnull;
+
 import java.util.UUID;
 
 /**
@@ -23,6 +25,7 @@ import java.util.UUID;
 @JsonTypeName("webprotege.projects.MergeUploadedProject")
 public abstract class MergeUploadedProjectAction extends AbstractHasProjectAction<MergeUploadedProjectResult> {
 
+    @GwtIncompatible
     public static MergeUploadedProjectAction create(ProjectId projectId,
                                                     DocumentId uploadedDocumentId,
                                                     String commitMessage) {

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/merge_add/ExistingOntologyMergeAddAction.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/merge_add/ExistingOntologyMergeAddAction.java
@@ -15,7 +15,7 @@ import java.util.List;
 
 @AutoValue
 @GwtCompatible(serializable = true)
-@JsonTypeName("webprotege.ontologies.ExistingOntologyMergeAdd")
+@JsonTypeName("webprotege.ontologies.MergeOntologies")
 public abstract class ExistingOntologyMergeAddAction implements ProjectAction<ExistingOntologyMergeAddResult> {
 
     @JsonCreator

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/merge_add/ExistingOntologyMergeAddAction.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/merge_add/ExistingOntologyMergeAddAction.java
@@ -8,6 +8,7 @@ import com.google.common.annotations.GwtCompatible;
 import edu.stanford.bmir.protege.web.shared.csv.DocumentId;
 import edu.stanford.bmir.protege.web.shared.dispatch.AbstractHasProjectAction;
 import edu.stanford.bmir.protege.web.shared.dispatch.ProjectAction;
+import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
 import edu.stanford.bmir.protege.web.shared.project.ProjectId;
 import org.semanticweb.owlapi.model.OWLOntologyID;
 
@@ -19,12 +20,19 @@ import java.util.List;
 public abstract class ExistingOntologyMergeAddAction implements ProjectAction<ExistingOntologyMergeAddResult> {
 
     @JsonCreator
-    public static ExistingOntologyMergeAddAction create(@JsonProperty("projectId") ProjectId projectId,
+    public static ExistingOntologyMergeAddAction create(@JsonProperty("changeRequestId") ChangeRequestId changeRequestId,
+                                                        @JsonProperty("projectId") ProjectId projectId,
                                                         @JsonProperty("documentId") DocumentId documentId,
                                                         @JsonProperty("selectedOntologies") List<OWLOntologyID> selectedOntologies,
                                                         @JsonProperty("targetOntology") OWLOntologyID targetOntology) {
-        return new AutoValue_ExistingOntologyMergeAddAction(projectId, documentId, selectedOntologies, targetOntology);
+        return new AutoValue_ExistingOntologyMergeAddAction(changeRequestId, projectId, documentId, selectedOntologies, targetOntology);
     }
+
+    @JsonProperty("changeRequestId")
+    public abstract ChangeRequestId getChangeRequestId();
+
+    @JsonProperty("projectId")
+    public abstract ProjectId getProjectId();
 
     public abstract DocumentId getDocumentId();
 

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/merge_add/ExistingOntologyMergeAddAction.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/merge_add/ExistingOntologyMergeAddAction.java
@@ -16,7 +16,7 @@ import java.util.List;
 
 @AutoValue
 @GwtCompatible(serializable = true)
-@JsonTypeName("webprotege.ontologies.MergeOntologies")
+@JsonTypeName("webprotege.ontologies.ExistingOntologyMergeAdd")
 public abstract class ExistingOntologyMergeAddAction implements ProjectAction<ExistingOntologyMergeAddResult> {
 
     @JsonCreator

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/merge_add/ExistingOntologyMergeAddAction.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/merge_add/ExistingOntologyMergeAddAction.java
@@ -15,7 +15,7 @@ import java.util.List;
 
 @AutoValue
 @GwtCompatible(serializable = true)
-@JsonTypeName("webprotege.ontologies.MergeOntologies")
+@JsonTypeName("webprotege.ontologies.ExistingOntologyMergeAdd")
 public abstract class ExistingOntologyMergeAddAction implements ProjectAction<ExistingOntologyMergeAddResult> {
 
     @JsonCreator

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/merge_add/ExistingOntologyMergeAddResult.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/merge_add/ExistingOntologyMergeAddResult.java
@@ -8,7 +8,7 @@ import edu.stanford.bmir.protege.web.shared.dispatch.Result;
 
 @AutoValue
 @GwtCompatible(serializable = true)
-@JsonTypeName("webprotege.ontologies.MergeOntologies")
+@JsonTypeName("webprotege.ontologies.ExistingOntologyMergeAdd")
 public class ExistingOntologyMergeAddResult implements Result {
 
     @JsonCreator

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/merge_add/NewOntologyMergeAddAction.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/merge_add/NewOntologyMergeAddAction.java
@@ -7,6 +7,7 @@ import com.google.auto.value.AutoValue;
 import com.google.common.annotations.GwtCompatible;
 import edu.stanford.bmir.protege.web.shared.csv.DocumentId;
 import edu.stanford.bmir.protege.web.shared.dispatch.AbstractHasProjectAction;
+import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
 import edu.stanford.bmir.protege.web.shared.project.ProjectId;
 import org.semanticweb.owlapi.model.OWLOntologyID;
 
@@ -15,16 +16,20 @@ import java.util.List;
 
 @AutoValue
 @GwtCompatible(serializable = true)
-@JsonTypeName("NewOntologyMergeAdd")
+@JsonTypeName("webprotege.ontologies.MergeOntologies")
 public abstract class NewOntologyMergeAddAction extends AbstractHasProjectAction<NewOntologyMergeAddResult> {
 
     @JsonCreator
-    public static NewOntologyMergeAddAction create(@JsonProperty("projectId") ProjectId projectId,
+    public static NewOntologyMergeAddAction create(@JsonProperty("changeRequestId") ChangeRequestId changeRequestId,
+                                                   @JsonProperty("projectId") ProjectId projectId,
                                                    @JsonProperty("documentId") DocumentId documentId,
                                                    @JsonProperty("iri") String iri,
                                                    @JsonProperty("ontologyList") List<OWLOntologyID> ontologyList) {
-        return new AutoValue_NewOntologyMergeAddAction(projectId, documentId, iri, ontologyList);
+        return new AutoValue_NewOntologyMergeAddAction(changeRequestId, projectId, documentId, iri, ontologyList);
     }
+
+    @JsonProperty("changeRequestId")
+    public abstract ChangeRequestId getChangeRequestId();
 
     @Nonnull
     @Override

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/merge_add/NewOntologyMergeAddResult.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/merge_add/NewOntologyMergeAddResult.java
@@ -9,7 +9,7 @@ import edu.stanford.bmir.protege.web.shared.dispatch.Result;
 
 @AutoValue
 @GwtCompatible(serializable = true)
-@JsonTypeName("NewOntologyMergeAdd")
+@JsonTypeName("webprotege.ontologies.MergeOntologies")
 public abstract class NewOntologyMergeAddResult implements Result {
 
     @JsonCreator

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/permissions/PermissionsChangedEvent.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/permissions/PermissionsChangedEvent.java
@@ -1,5 +1,8 @@
 package edu.stanford.bmir.protege.web.shared.permissions;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.common.base.Objects;
 import com.google.web.bindery.event.shared.Event;
@@ -25,15 +28,29 @@ public class PermissionsChangedEvent extends ProjectEvent<PermissionsChangedHand
 
     public static final transient Event.Type<PermissionsChangedHandler> ON_CAPABILITIES_CHANGED = new Event.Type<>();
 
+    private String eventId;
 
     public PermissionsChangedEvent(@Nonnull ProjectId source) {
         super(checkNotNull(source));
+    }
+
+    @JsonCreator
+    public PermissionsChangedEvent(@JsonProperty("eventId") String eventId,
+                                   @JsonProperty("projectId") @Nonnull ProjectId source) {
+        super(checkNotNull(source));
+        this.eventId = eventId;
     }
 
     @GwtSerializationConstructor
     private PermissionsChangedEvent() {
     }
 
+    @JsonProperty("eventId")
+    public String getEventId() {
+        return eventId;
+    }
+
+    @JsonIgnore
     @Override
     public Event.Type<PermissionsChangedHandler> getAssociatedType() {
         return ON_CAPABILITIES_CHANGED;

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/permissions/PermissionsChangedEvent.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/permissions/PermissionsChangedEvent.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.common.base.Objects;
 import com.google.web.bindery.event.shared.Event;
 import edu.stanford.bmir.protege.web.shared.annotations.GwtSerializationConstructor;
+import edu.stanford.bmir.protege.web.shared.event.EventId;
 import edu.stanford.bmir.protege.web.shared.event.ProjectEvent;
 import edu.stanford.bmir.protege.web.shared.project.ProjectId;
 
@@ -28,14 +29,10 @@ public class PermissionsChangedEvent extends ProjectEvent<PermissionsChangedHand
 
     public static final transient Event.Type<PermissionsChangedHandler> ON_CAPABILITIES_CHANGED = new Event.Type<>();
 
-    private String eventId;
-
-    public PermissionsChangedEvent(@Nonnull ProjectId source) {
-        super(checkNotNull(source));
-    }
+    private EventId eventId;
 
     @JsonCreator
-    public PermissionsChangedEvent(@JsonProperty("eventId") String eventId,
+    public PermissionsChangedEvent(@JsonProperty("eventId") EventId eventId,
                                    @JsonProperty("projectId") @Nonnull ProjectId source) {
         super(checkNotNull(source));
         this.eventId = eventId;
@@ -46,7 +43,7 @@ public class PermissionsChangedEvent extends ProjectEvent<PermissionsChangedHand
     }
 
     @JsonProperty("eventId")
-    public String getEventId() {
+    public EventId getEventId() {
         return eventId;
     }
 

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/perspective/ChangeRequestId.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/perspective/ChangeRequestId.java
@@ -2,6 +2,7 @@ package edu.stanford.bmir.protege.web.shared.perspective;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
+import com.google.common.annotations.GwtIncompatible;
 import com.google.gwt.user.client.rpc.IsSerializable;
 import edu.stanford.bmir.protege.web.shared.annotations.GwtSerializationConstructor;
 import edu.stanford.bmir.protege.web.shared.util.UUIDUtil;
@@ -10,6 +11,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.Serializable;
 import java.util.Optional;
+import java.util.UUID;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -72,6 +74,21 @@ public class ChangeRequestId implements Serializable, IsSerializable {
     @Nonnull
     public static ChangeRequestId getNil() {
         return get(UUIDUtil.getNilUuid());
+    }
+
+    /**
+     * Mints a fresh {@link ChangeRequestId} backed by a random UUID.
+     *
+     * <p>JVM-only helper intended for tests — mirrors the convention used by
+     * {@code PerspectiveId.generate()}, {@code FormId.generate()}, etc. The GWT
+     * compile skips this method because {@code java.util.UUID} is not emulated
+     * on the client; client code mints {@code ChangeRequestId} via
+     * {@code ChangeRequestId.get(uuidV4Provider.get())} instead.</p>
+     */
+    @GwtIncompatible
+    @Nonnull
+    public static ChangeRequestId generate() {
+        return get(UUID.randomUUID().toString());
     }
 
     public static ChangeRequestId valueOf(@Nonnull String uuid) throws IllegalArgumentException {

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/perspective/ResetPerspectivesAction.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/perspective/ResetPerspectivesAction.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.auto.value.AutoValue;
 import com.google.common.annotations.GwtCompatible;
-import com.google.common.annotations.GwtIncompatible;
 import edu.stanford.bmir.protege.web.shared.annotations.GwtSerializationConstructor;
 import edu.stanford.bmir.protege.web.shared.dispatch.ProjectAction;
 import edu.stanford.bmir.protege.web.shared.project.ProjectId;
@@ -14,7 +13,6 @@ import javax.annotation.Nonnull;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import java.util.UUID;
 
 /**
  * Matthew Horridge
@@ -26,10 +24,6 @@ import java.util.UUID;
 @JsonTypeName("webprotege.perspectives.ResetPerspectives")
 public abstract class ResetPerspectivesAction implements ProjectAction<ResetPerspectivesResult> {
 
-    @GwtIncompatible
-    public static ResetPerspectivesAction create(@Nonnull ProjectId projectId) {
-        return create(ChangeRequestId.get(UUID.randomUUID().toString()), projectId);
-    }
 
     @JsonCreator
     public static ResetPerspectivesAction create(@JsonProperty("changeRequestId") @Nonnull ChangeRequestId changeRequestId,

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/perspective/ResetPerspectivesAction.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/perspective/ResetPerspectivesAction.java
@@ -10,6 +10,7 @@ import edu.stanford.bmir.protege.web.shared.dispatch.ProjectAction;
 import edu.stanford.bmir.protege.web.shared.project.ProjectId;
 
 import javax.annotation.Nonnull;
+import java.util.UUID;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -23,11 +24,19 @@ import static com.google.common.base.Preconditions.checkNotNull;
 @JsonTypeName("webprotege.perspectives.ResetPerspectives")
 public abstract class ResetPerspectivesAction implements ProjectAction<ResetPerspectivesResult> {
 
+    public static ResetPerspectivesAction create(@Nonnull ProjectId projectId) {
+        return create(ChangeRequestId.get(UUID.randomUUID().toString()), projectId);
+    }
 
     @JsonCreator
-    public static ResetPerspectivesAction create(@JsonProperty("projectId") @Nonnull ProjectId projectId) {
-        return new AutoValue_ResetPerspectivesAction(projectId);
+    public static ResetPerspectivesAction create(@JsonProperty("changeRequestId") @Nonnull ChangeRequestId changeRequestId,
+                                                 @JsonProperty("projectId") @Nonnull ProjectId projectId) {
+        return new AutoValue_ResetPerspectivesAction(changeRequestId, projectId);
     }
+
+    @Nonnull
+    @JsonProperty("changeRequestId")
+    public abstract ChangeRequestId getChangeRequestId();
 
     @Nonnull
     @Override

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/perspective/ResetPerspectivesAction.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/perspective/ResetPerspectivesAction.java
@@ -5,14 +5,16 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.auto.value.AutoValue;
 import com.google.common.annotations.GwtCompatible;
+import com.google.common.annotations.GwtIncompatible;
 import edu.stanford.bmir.protege.web.shared.annotations.GwtSerializationConstructor;
 import edu.stanford.bmir.protege.web.shared.dispatch.ProjectAction;
 import edu.stanford.bmir.protege.web.shared.project.ProjectId;
 
 import javax.annotation.Nonnull;
-import java.util.UUID;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.UUID;
 
 /**
  * Matthew Horridge
@@ -24,6 +26,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 @JsonTypeName("webprotege.perspectives.ResetPerspectives")
 public abstract class ResetPerspectivesAction implements ProjectAction<ResetPerspectivesResult> {
 
+    @GwtIncompatible
     public static ResetPerspectivesAction create(@Nonnull ProjectId projectId) {
         return create(ChangeRequestId.get(UUID.randomUUID().toString()), projectId);
     }

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/perspective/SetPerspectivesAction.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/perspective/SetPerspectivesAction.java
@@ -7,7 +7,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.auto.value.AutoValue;
 import com.google.common.annotations.GwtCompatible;
-import com.google.common.annotations.GwtIncompatible;
 import com.google.common.collect.ImmutableList;
 import edu.stanford.bmir.protege.web.shared.dispatch.ProjectAction;
 import edu.stanford.bmir.protege.web.shared.project.HasProjectId;
@@ -18,7 +17,6 @@ import jsinterop.annotations.JsIgnore;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Optional;
-import java.util.UUID;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -33,18 +31,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 public abstract class SetPerspectivesAction implements ProjectAction<SetPerspectivesResult>, HasProjectId {
 
 
-    @GwtIncompatible
-    public static SetPerspectivesAction create(@Nonnull ProjectId projectId,
-                                               @Nonnull ImmutableList<PerspectiveDescriptor> perspectives) {
-        return create(ChangeRequestId.get(UUID.randomUUID().toString()), projectId, null, perspectives);
-    }
 
-    @GwtIncompatible
-    public static SetPerspectivesAction create(@Nonnull ProjectId projectId,
-                                               @Nonnull Optional<UserId> userId,
-                                               @Nonnull ImmutableList<PerspectiveDescriptor> perspectiveIds) {
-        return create(ChangeRequestId.get(UUID.randomUUID().toString()), projectId, userId.orElse(null), perspectiveIds);
-    }
 
     @JsonCreator
     public static SetPerspectivesAction create(@JsonProperty("changeRequestId") @Nonnull ChangeRequestId changeRequestId,

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/perspective/SetPerspectivesAction.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/perspective/SetPerspectivesAction.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.auto.value.AutoValue;
 import com.google.common.annotations.GwtCompatible;
+import com.google.common.annotations.GwtIncompatible;
 import com.google.common.collect.ImmutableList;
 import edu.stanford.bmir.protege.web.shared.dispatch.ProjectAction;
 import edu.stanford.bmir.protege.web.shared.project.HasProjectId;
@@ -16,7 +17,6 @@ import jsinterop.annotations.JsIgnore;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import javax.validation.constraints.Null;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -33,13 +33,13 @@ import static com.google.common.base.Preconditions.checkNotNull;
 public abstract class SetPerspectivesAction implements ProjectAction<SetPerspectivesResult>, HasProjectId {
 
 
+    @GwtIncompatible
     public static SetPerspectivesAction create(@Nonnull ProjectId projectId,
                                                @Nonnull ImmutableList<PerspectiveDescriptor> perspectives) {
         return create(ChangeRequestId.get(UUID.randomUUID().toString()), projectId, null, perspectives);
     }
 
-
-
+    @GwtIncompatible
     public static SetPerspectivesAction create(@Nonnull ProjectId projectId,
                                                @Nonnull Optional<UserId> userId,
                                                @Nonnull ImmutableList<PerspectiveDescriptor> perspectiveIds) {

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/perspective/SetPerspectivesAction.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/perspective/SetPerspectivesAction.java
@@ -18,6 +18,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.validation.constraints.Null;
 import java.util.Optional;
+import java.util.UUID;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -34,7 +35,7 @@ public abstract class SetPerspectivesAction implements ProjectAction<SetPerspect
 
     public static SetPerspectivesAction create(@Nonnull ProjectId projectId,
                                                @Nonnull ImmutableList<PerspectiveDescriptor> perspectives) {
-        return new AutoValue_SetPerspectivesAction(projectId, null, perspectives);
+        return create(ChangeRequestId.get(UUID.randomUUID().toString()), projectId, null, perspectives);
     }
 
 
@@ -42,15 +43,20 @@ public abstract class SetPerspectivesAction implements ProjectAction<SetPerspect
     public static SetPerspectivesAction create(@Nonnull ProjectId projectId,
                                                @Nonnull Optional<UserId> userId,
                                                @Nonnull ImmutableList<PerspectiveDescriptor> perspectiveIds) {
-        return new AutoValue_SetPerspectivesAction(projectId, userId.orElse(null), perspectiveIds);
+        return create(ChangeRequestId.get(UUID.randomUUID().toString()), projectId, userId.orElse(null), perspectiveIds);
     }
 
     @JsonCreator
-    public static SetPerspectivesAction create(@JsonProperty("projectId") @Nonnull ProjectId projectId,
+    public static SetPerspectivesAction create(@JsonProperty("changeRequestId") @Nonnull ChangeRequestId changeRequestId,
+                                               @JsonProperty("projectId") @Nonnull ProjectId projectId,
                                                @JsonProperty("userId") @Nullable UserId userId,
                                                @JsonProperty("perspectives") @Nonnull ImmutableList<PerspectiveDescriptor> perspectiveIds) {
-        return new AutoValue_SetPerspectivesAction(projectId, userId, perspectiveIds);
+        return new AutoValue_SetPerspectivesAction(changeRequestId, projectId, userId, perspectiveIds);
     }
+
+    @JsonProperty("changeRequestId")
+    @Nonnull
+    public abstract ChangeRequestId getChangeRequestId();
 
     @JsonProperty("projectId")
     @Nonnull

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/project/CreateNewProjectAction.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/project/CreateNewProjectAction.java
@@ -28,12 +28,13 @@ public class CreateNewProjectAction implements Action<CreateNewProjectResult> {
     }
 
     @JsonCreator
-    public CreateNewProjectAction(@JsonProperty("projectId") ProjectId newProjectId,
+    public CreateNewProjectAction(@JsonProperty("newProjectId") ProjectId newProjectId,
                                   @JsonProperty("newProjectSettings") NewProjectSettings newProjectSettings) {
         this.newProjectId = newProjectId;
         this.newProjectSettings = checkNotNull(newProjectSettings);
     }
 
+    @JsonProperty("newProjectId")
     public ProjectId getNewProjectId() {
         return newProjectId;
     }

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/project/SetProjectPrefixDeclarationsAction.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/project/SetProjectPrefixDeclarationsAction.java
@@ -1,13 +1,17 @@
 package edu.stanford.bmir.protege.web.shared.project;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.common.base.Objects;
 import edu.stanford.bmir.protege.web.shared.annotations.GwtSerializationConstructor;
 import edu.stanford.bmir.protege.web.shared.dispatch.ProjectAction;
+import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
 
 import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -20,12 +24,17 @@ import static com.google.common.base.Preconditions.checkNotNull;
 @JsonTypeName("webprotege.projects.SetProjectPrefixDeclarations")
 public class SetProjectPrefixDeclarationsAction implements ProjectAction<SetProjectPrefixDeclarationsResult> {
 
+    private ChangeRequestId changeRequestId;
+
     private ProjectId projectId;
 
     private List<PrefixDeclaration> prefixDeclarations;
 
-    private SetProjectPrefixDeclarationsAction(@Nonnull ProjectId projectId,
-                                               @Nonnull List<PrefixDeclaration> prefixDeclarations) {
+    @JsonCreator
+    private SetProjectPrefixDeclarationsAction(@JsonProperty("changeRequestId") @Nonnull ChangeRequestId changeRequestId,
+                                               @JsonProperty("projectId") @Nonnull ProjectId projectId,
+                                               @JsonProperty("prefixDeclarations") @Nonnull List<PrefixDeclaration> prefixDeclarations) {
+        this.changeRequestId = checkNotNull(changeRequestId);
         this.projectId = checkNotNull(projectId);
         this.prefixDeclarations = new ArrayList<>(checkNotNull(prefixDeclarations));
     }
@@ -36,7 +45,13 @@ public class SetProjectPrefixDeclarationsAction implements ProjectAction<SetProj
 
     public static SetProjectPrefixDeclarationsAction create(@Nonnull ProjectId projectId,
                                                             @Nonnull List<PrefixDeclaration> prefixDeclarations) {
-        return new SetProjectPrefixDeclarationsAction(projectId, prefixDeclarations);
+        return new SetProjectPrefixDeclarationsAction(ChangeRequestId.get(UUID.randomUUID().toString()), projectId, prefixDeclarations);
+    }
+
+    @Nonnull
+    @JsonProperty("changeRequestId")
+    public ChangeRequestId getChangeRequestId() {
+        return changeRequestId;
     }
 
     @Nonnull

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/project/SetProjectPrefixDeclarationsAction.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/project/SetProjectPrefixDeclarationsAction.java
@@ -3,7 +3,6 @@ package edu.stanford.bmir.protege.web.shared.project;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import com.google.common.annotations.GwtIncompatible;
 import com.google.common.base.Objects;
 import edu.stanford.bmir.protege.web.shared.annotations.GwtSerializationConstructor;
 import edu.stanford.bmir.protege.web.shared.dispatch.ProjectAction;
@@ -12,7 +11,6 @@ import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
 import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.UUID;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -44,11 +42,6 @@ public class SetProjectPrefixDeclarationsAction implements ProjectAction<SetProj
     private SetProjectPrefixDeclarationsAction() {
     }
 
-    @GwtIncompatible
-    public static SetProjectPrefixDeclarationsAction create(@Nonnull ProjectId projectId,
-                                                            @Nonnull List<PrefixDeclaration> prefixDeclarations) {
-        return new SetProjectPrefixDeclarationsAction(ChangeRequestId.get(UUID.randomUUID().toString()), projectId, prefixDeclarations);
-    }
 
     public static SetProjectPrefixDeclarationsAction create(@Nonnull ChangeRequestId changeRequestId,
                                                             @Nonnull ProjectId projectId,

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/project/SetProjectPrefixDeclarationsAction.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/project/SetProjectPrefixDeclarationsAction.java
@@ -3,6 +3,7 @@ package edu.stanford.bmir.protege.web.shared.project;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.google.common.annotations.GwtIncompatible;
 import com.google.common.base.Objects;
 import edu.stanford.bmir.protege.web.shared.annotations.GwtSerializationConstructor;
 import edu.stanford.bmir.protege.web.shared.dispatch.ProjectAction;
@@ -43,9 +44,16 @@ public class SetProjectPrefixDeclarationsAction implements ProjectAction<SetProj
     private SetProjectPrefixDeclarationsAction() {
     }
 
+    @GwtIncompatible
     public static SetProjectPrefixDeclarationsAction create(@Nonnull ProjectId projectId,
                                                             @Nonnull List<PrefixDeclaration> prefixDeclarations) {
         return new SetProjectPrefixDeclarationsAction(ChangeRequestId.get(UUID.randomUUID().toString()), projectId, prefixDeclarations);
+    }
+
+    public static SetProjectPrefixDeclarationsAction create(@Nonnull ChangeRequestId changeRequestId,
+                                                            @Nonnull ProjectId projectId,
+                                                            @Nonnull List<PrefixDeclaration> prefixDeclarations) {
+        return new SetProjectPrefixDeclarationsAction(changeRequestId, projectId, prefixDeclarations);
     }
 
     @Nonnull

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/projectsettings/SetProjectSettingsAction.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/projectsettings/SetProjectSettingsAction.java
@@ -1,9 +1,18 @@
 package edu.stanford.bmir.protege.web.shared.projectsettings;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import edu.stanford.bmir.protege.web.shared.dispatch.AbstractHasProjectAction;
+import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
+import edu.stanford.bmir.protege.web.shared.project.ProjectId;
+
+import javax.annotation.Nonnull;
+import java.util.UUID;
+
+import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * Matthew Horridge
@@ -13,6 +22,8 @@ import edu.stanford.bmir.protege.web.shared.dispatch.AbstractHasProjectAction;
 @JsonTypeName("webprotege.projects.SetProjectSettings")
 public class SetProjectSettingsAction extends AbstractHasProjectAction<SetProjectSettingsResult> {
 
+    private ChangeRequestId changeRequestId;
+
     private ProjectSettings projectSettings;
 
     /**
@@ -21,15 +32,41 @@ public class SetProjectSettingsAction extends AbstractHasProjectAction<SetProjec
     private SetProjectSettingsAction() {
     }
 
-    private SetProjectSettingsAction(ProjectSettings projectSettings) {
-        super(projectSettings.getProjectId());
-        this.projectSettings = projectSettings;
+    private SetProjectSettingsAction(ChangeRequestId changeRequestId,
+                                     ProjectId projectId,
+                                     ProjectSettings projectSettings) {
+        super(projectId);
+        this.changeRequestId = checkNotNull(changeRequestId);
+        this.projectSettings = checkNotNull(projectSettings);
     }
 
     public static SetProjectSettingsAction create(ProjectSettings projectSettings) {
-        return new SetProjectSettingsAction(projectSettings);
+        return create(ChangeRequestId.get(UUID.randomUUID().toString()),
+                      projectSettings.getProjectId(),
+                      projectSettings);
     }
 
+    @JsonCreator
+    public static SetProjectSettingsAction create(@JsonProperty("changeRequestId") ChangeRequestId changeRequestId,
+                                                  @JsonProperty("projectId") ProjectId projectId,
+                                                  @JsonProperty("settings") ProjectSettings projectSettings) {
+        return new SetProjectSettingsAction(changeRequestId, projectId, projectSettings);
+    }
+
+    @Nonnull
+    @JsonProperty("changeRequestId")
+    public ChangeRequestId getChangeRequestId() {
+        return changeRequestId;
+    }
+
+    @Nonnull
+    @Override
+    @JsonProperty("projectId")
+    public ProjectId getProjectId() {
+        return super.getProjectId();
+    }
+
+    @JsonProperty("settings")
     public ProjectSettings getProjectSettings() {
         return projectSettings;
     }

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/projectsettings/SetProjectSettingsAction.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/projectsettings/SetProjectSettingsAction.java
@@ -3,6 +3,7 @@ package edu.stanford.bmir.protege.web.shared.projectsettings;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.google.common.annotations.GwtIncompatible;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import edu.stanford.bmir.protege.web.shared.dispatch.AbstractHasProjectAction;
@@ -10,9 +11,10 @@ import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
 import edu.stanford.bmir.protege.web.shared.project.ProjectId;
 
 import javax.annotation.Nonnull;
-import java.util.UUID;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.UUID;
 
 /**
  * Matthew Horridge
@@ -40,6 +42,7 @@ public class SetProjectSettingsAction extends AbstractHasProjectAction<SetProjec
         this.projectSettings = checkNotNull(projectSettings);
     }
 
+    @GwtIncompatible
     public static SetProjectSettingsAction create(ProjectSettings projectSettings) {
         return create(ChangeRequestId.get(UUID.randomUUID().toString()),
                       projectSettings.getProjectId(),

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/projectsettings/SetProjectSettingsAction.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/projectsettings/SetProjectSettingsAction.java
@@ -3,7 +3,6 @@ package edu.stanford.bmir.protege.web.shared.projectsettings;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import com.google.common.annotations.GwtIncompatible;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import edu.stanford.bmir.protege.web.shared.dispatch.AbstractHasProjectAction;
@@ -14,7 +13,6 @@ import javax.annotation.Nonnull;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import java.util.UUID;
 
 /**
  * Matthew Horridge
@@ -42,12 +40,6 @@ public class SetProjectSettingsAction extends AbstractHasProjectAction<SetProjec
         this.projectSettings = checkNotNull(projectSettings);
     }
 
-    @GwtIncompatible
-    public static SetProjectSettingsAction create(ProjectSettings projectSettings) {
-        return create(ChangeRequestId.get(UUID.randomUUID().toString()),
-                      projectSettings.getProjectId(),
-                      projectSettings);
-    }
 
     @JsonCreator
     public static SetProjectSettingsAction create(@JsonProperty("changeRequestId") ChangeRequestId changeRequestId,

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/projectsettings/SetProjectSettingsResult.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/projectsettings/SetProjectSettingsResult.java
@@ -1,5 +1,7 @@
 package edu.stanford.bmir.protege.web.shared.projectsettings;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
@@ -27,10 +29,12 @@ public class SetProjectSettingsResult implements Result {
         this.projectSettings = checkNotNull(projectSettings);
     }
 
-    public static SetProjectSettingsResult create(@Nonnull ProjectSettings projectSettings) {
+    @JsonCreator
+    public static SetProjectSettingsResult create(@JsonProperty("settings") @Nonnull ProjectSettings projectSettings) {
         return new SetProjectSettingsResult(projectSettings);
     }
 
+    @JsonProperty("settings")
     public ProjectSettings getProjectSettings() {
         return projectSettings;
     }

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/revision/GetHeadRevisionNumberResult.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/revision/GetHeadRevisionNumberResult.java
@@ -1,8 +1,13 @@
 package edu.stanford.bmir.protege.web.shared.revision;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.common.base.Objects;
 import edu.stanford.bmir.protege.web.shared.dispatch.Result;
+import edu.stanford.bmir.protege.web.shared.project.ProjectId;
+
+import javax.annotation.Nullable;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -15,6 +20,9 @@ import static com.google.common.base.Preconditions.checkNotNull;
 @JsonTypeName("webprotege.history.GetHeadRevisionNumber")
 public class GetHeadRevisionNumberResult implements Result {
 
+    @Nullable
+    private ProjectId projectId;
+
     private RevisionNumber revisionNumber;
 
     /**
@@ -23,12 +31,25 @@ public class GetHeadRevisionNumberResult implements Result {
     private GetHeadRevisionNumberResult() {
     }
 
-    private GetHeadRevisionNumberResult(RevisionNumber revisionNumber) {
+    private GetHeadRevisionNumberResult(@Nullable ProjectId projectId, RevisionNumber revisionNumber) {
+        this.projectId = projectId;
         this.revisionNumber = checkNotNull(revisionNumber);
     }
 
     public static GetHeadRevisionNumberResult create(RevisionNumber revisionNumber) {
-        return new GetHeadRevisionNumberResult(revisionNumber);
+        return new GetHeadRevisionNumberResult(null, revisionNumber);
+    }
+
+    @JsonCreator
+    public static GetHeadRevisionNumberResult create(@JsonProperty("projectId") @Nullable ProjectId projectId,
+                                                     @JsonProperty("revisionNumber") RevisionNumber revisionNumber) {
+        return new GetHeadRevisionNumberResult(projectId, revisionNumber);
+    }
+
+    @Nullable
+    @JsonProperty("projectId")
+    public ProjectId getProjectId() {
+        return projectId;
     }
 
     public RevisionNumber getRevisionNumber() {

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/revision/GetRevisionSummariesAction.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/revision/GetRevisionSummariesAction.java
@@ -1,11 +1,15 @@
 package edu.stanford.bmir.protege.web.shared.revision;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.common.base.Objects;
 import edu.stanford.bmir.protege.web.shared.dispatch.ProjectAction;
+import edu.stanford.bmir.protege.web.shared.pagination.PageRequest;
 import edu.stanford.bmir.protege.web.shared.project.ProjectId;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -20,24 +24,41 @@ public class GetRevisionSummariesAction implements ProjectAction<GetRevisionSumm
 
     private ProjectId projectId;
 
+    @Nullable
+    private PageRequest pageRequest;
+
     /**
      * For serialization purposes only
      */
     private GetRevisionSummariesAction() {
     }
 
-    private GetRevisionSummariesAction(ProjectId projectId) {
+    private GetRevisionSummariesAction(ProjectId projectId, @Nullable PageRequest pageRequest) {
         this.projectId = checkNotNull(projectId);
+        this.pageRequest = pageRequest;
     }
 
     public static GetRevisionSummariesAction create(ProjectId projectId) {
-        return new GetRevisionSummariesAction(projectId);
+        return new GetRevisionSummariesAction(projectId, null);
+    }
+
+    @JsonCreator
+    public static GetRevisionSummariesAction create(@JsonProperty("projectId") ProjectId projectId,
+                                                    @JsonProperty("pageRequest") @Nullable PageRequest pageRequest) {
+        return new GetRevisionSummariesAction(projectId, pageRequest);
     }
 
     @Nonnull
     @Override
+    @JsonProperty("projectId")
     public ProjectId getProjectId() {
         return projectId;
+    }
+
+    @Nullable
+    @JsonProperty("pageRequest")
+    public PageRequest getPageRequest() {
+        return pageRequest;
     }
 
     @Override

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/search/SetSearchSettingsAction.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/search/SetSearchSettingsAction.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.auto.value.AutoValue;
 import com.google.common.annotations.GwtCompatible;
+import com.google.common.annotations.GwtIncompatible;
 import com.google.common.collect.ImmutableList;
 import edu.stanford.bmir.protege.web.shared.annotations.GwtSerializationConstructor;
 import edu.stanford.bmir.protege.web.shared.dispatch.ProjectAction;
@@ -12,9 +13,10 @@ import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
 import edu.stanford.bmir.protege.web.shared.project.ProjectId;
 
 import javax.annotation.Nonnull;
-import java.util.UUID;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.UUID;
 
 /**
  * Matthew Horridge
@@ -26,6 +28,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 @JsonTypeName("webprotege.search.SetSearchSettings")
 public abstract class SetSearchSettingsAction implements ProjectAction<SetSearchSettingsResult> {
 
+    @GwtIncompatible
     public static SetSearchSettingsAction create(@Nonnull ProjectId projectId,
                                                  @Nonnull ImmutableList<EntitySearchFilter> from,
                                                  @Nonnull ImmutableList<EntitySearchFilter> to) {

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/search/SetSearchSettingsAction.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/search/SetSearchSettingsAction.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.auto.value.AutoValue;
 import com.google.common.annotations.GwtCompatible;
-import com.google.common.annotations.GwtIncompatible;
 import com.google.common.collect.ImmutableList;
 import edu.stanford.bmir.protege.web.shared.annotations.GwtSerializationConstructor;
 import edu.stanford.bmir.protege.web.shared.dispatch.ProjectAction;
@@ -16,7 +15,6 @@ import javax.annotation.Nonnull;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import java.util.UUID;
 
 /**
  * Matthew Horridge
@@ -28,12 +26,6 @@ import java.util.UUID;
 @JsonTypeName("webprotege.search.SetSearchSettings")
 public abstract class SetSearchSettingsAction implements ProjectAction<SetSearchSettingsResult> {
 
-    @GwtIncompatible
-    public static SetSearchSettingsAction create(@Nonnull ProjectId projectId,
-                                                 @Nonnull ImmutableList<EntitySearchFilter> from,
-                                                 @Nonnull ImmutableList<EntitySearchFilter> to) {
-        return create(ChangeRequestId.get(UUID.randomUUID().toString()), projectId, from, to);
-    }
 
     @JsonCreator
     public static SetSearchSettingsAction create(@JsonProperty("changeRequestId") @Nonnull ChangeRequestId changeRequestId,

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/search/SetSearchSettingsAction.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/search/SetSearchSettingsAction.java
@@ -8,9 +8,11 @@ import com.google.common.annotations.GwtCompatible;
 import com.google.common.collect.ImmutableList;
 import edu.stanford.bmir.protege.web.shared.annotations.GwtSerializationConstructor;
 import edu.stanford.bmir.protege.web.shared.dispatch.ProjectAction;
+import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
 import edu.stanford.bmir.protege.web.shared.project.ProjectId;
 
 import javax.annotation.Nonnull;
+import java.util.UUID;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -24,12 +26,23 @@ import static com.google.common.base.Preconditions.checkNotNull;
 @JsonTypeName("webprotege.search.SetSearchSettings")
 public abstract class SetSearchSettingsAction implements ProjectAction<SetSearchSettingsResult> {
 
+    public static SetSearchSettingsAction create(@Nonnull ProjectId projectId,
+                                                 @Nonnull ImmutableList<EntitySearchFilter> from,
+                                                 @Nonnull ImmutableList<EntitySearchFilter> to) {
+        return create(ChangeRequestId.get(UUID.randomUUID().toString()), projectId, from, to);
+    }
+
     @JsonCreator
-    public static SetSearchSettingsAction create(@JsonProperty("projectId") @Nonnull ProjectId projectId,
+    public static SetSearchSettingsAction create(@JsonProperty("changeRequestId") @Nonnull ChangeRequestId changeRequestId,
+                                                 @JsonProperty("projectId") @Nonnull ProjectId projectId,
                                                  @JsonProperty("from") @Nonnull ImmutableList<EntitySearchFilter> from,
                                                  @JsonProperty("to") @Nonnull ImmutableList<EntitySearchFilter> to) {
-        return new AutoValue_SetSearchSettingsAction(projectId, from, to);
+        return new AutoValue_SetSearchSettingsAction(changeRequestId, projectId, from, to);
     }
+
+    @Nonnull
+    @JsonProperty("changeRequestId")
+    public abstract ChangeRequestId getChangeRequestId();
 
     @Nonnull
     @Override

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/sharing/GetProjectSharingSettingsResult.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/sharing/GetProjectSharingSettingsResult.java
@@ -1,5 +1,7 @@
 package edu.stanford.bmir.protege.web.shared.sharing;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.common.base.Objects;
 import edu.stanford.bmir.protege.web.shared.dispatch.Result;
@@ -25,10 +27,12 @@ public class GetProjectSharingSettingsResult implements Result {
         this.projectSharingSettings = checkNotNull(projectSharingSettings);
     }
 
-    public static GetProjectSharingSettingsResult create(ProjectSharingSettings projectSharingSettings) {
+    @JsonCreator
+    public static GetProjectSharingSettingsResult create(@JsonProperty("settings") ProjectSharingSettings projectSharingSettings) {
         return new GetProjectSharingSettingsResult(projectSharingSettings);
     }
 
+    @JsonProperty("settings")
     public ProjectSharingSettings getProjectSharingSettings() {
         return projectSharingSettings;
     }

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/tag/AddProjectTagAction.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/tag/AddProjectTagAction.java
@@ -9,9 +9,11 @@ import com.google.common.base.Objects;
 import edu.stanford.bmir.protege.web.shared.annotations.GwtSerializationConstructor;
 import edu.stanford.bmir.protege.web.shared.color.Color;
 import edu.stanford.bmir.protege.web.shared.dispatch.ProjectAction;
+import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
 import edu.stanford.bmir.protege.web.shared.project.ProjectId;
 
 import javax.annotation.Nonnull;
+import java.util.UUID;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -34,18 +36,33 @@ public abstract class AddProjectTagAction implements ProjectAction<AddProjectTag
      * @param color The color for the tag (foreground).
      * @param backgroundColor The background-color for the tag
      */
+    @Nonnull
+    public static AddProjectTagAction create(@Nonnull ProjectId projectId,
+                                             @Nonnull String label,
+                                             @Nonnull String description,
+                                             @Nonnull Color color,
+                                             @Nonnull Color backgroundColor) {
+        return create(ChangeRequestId.get(UUID.randomUUID().toString()), projectId, label, description, color, backgroundColor);
+    }
+
     @JsonCreator
     @Nonnull
-    public static AddProjectTagAction create(@JsonProperty("projectId") @Nonnull ProjectId projectId,
-                                                    @JsonProperty("label") @Nonnull String label,
-                                                    @JsonProperty("description") @Nonnull String description,
-                                                    @JsonProperty("color") @Nonnull Color color,
-                                                    @JsonProperty("backgroundColor") @Nonnull Color backgroundColor) {
-        return new AutoValue_AddProjectTagAction(projectId,
+    public static AddProjectTagAction create(@JsonProperty("changeRequestId") @Nonnull ChangeRequestId changeRequestId,
+                                             @JsonProperty("projectId") @Nonnull ProjectId projectId,
+                                             @JsonProperty("label") @Nonnull String label,
+                                             @JsonProperty("description") @Nonnull String description,
+                                             @JsonProperty("color") @Nonnull Color color,
+                                             @JsonProperty("backgroundColor") @Nonnull Color backgroundColor) {
+        return new AutoValue_AddProjectTagAction(changeRequestId,
+                                                 projectId,
                                                  label,
                                                  description,
-                                       color, backgroundColor);
+                                                 color, backgroundColor);
     }
+
+    @Nonnull
+    @JsonProperty("changeRequestId")
+    public abstract ChangeRequestId getChangeRequestId();
 
     @Nonnull
     @Override

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/tag/AddProjectTagAction.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/tag/AddProjectTagAction.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.auto.value.AutoValue;
 import com.google.common.annotations.GwtCompatible;
+import com.google.common.annotations.GwtIncompatible;
 import com.google.common.base.Objects;
 import edu.stanford.bmir.protege.web.shared.annotations.GwtSerializationConstructor;
 import edu.stanford.bmir.protege.web.shared.color.Color;
@@ -13,10 +14,11 @@ import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
 import edu.stanford.bmir.protege.web.shared.project.ProjectId;
 
 import javax.annotation.Nonnull;
-import java.util.UUID;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.UUID;
 
 /**
  * Matthew Horridge
@@ -36,6 +38,7 @@ public abstract class AddProjectTagAction implements ProjectAction<AddProjectTag
      * @param color The color for the tag (foreground).
      * @param backgroundColor The background-color for the tag
      */
+    @GwtIncompatible
     @Nonnull
     public static AddProjectTagAction create(@Nonnull ProjectId projectId,
                                              @Nonnull String label,

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/tag/AddProjectTagAction.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/tag/AddProjectTagAction.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.auto.value.AutoValue;
 import com.google.common.annotations.GwtCompatible;
-import com.google.common.annotations.GwtIncompatible;
 import com.google.common.base.Objects;
 import edu.stanford.bmir.protege.web.shared.annotations.GwtSerializationConstructor;
 import edu.stanford.bmir.protege.web.shared.color.Color;
@@ -18,7 +17,6 @@ import javax.annotation.Nonnull;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import java.util.UUID;
 
 /**
  * Matthew Horridge
@@ -38,15 +36,6 @@ public abstract class AddProjectTagAction implements ProjectAction<AddProjectTag
      * @param color The color for the tag (foreground).
      * @param backgroundColor The background-color for the tag
      */
-    @GwtIncompatible
-    @Nonnull
-    public static AddProjectTagAction create(@Nonnull ProjectId projectId,
-                                             @Nonnull String label,
-                                             @Nonnull String description,
-                                             @Nonnull Color color,
-                                             @Nonnull Color backgroundColor) {
-        return create(ChangeRequestId.get(UUID.randomUUID().toString()), projectId, label, description, color, backgroundColor);
-    }
 
     @JsonCreator
     @Nonnull

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/tag/EntityTagsChangedEvent.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/tag/EntityTagsChangedEvent.java
@@ -1,5 +1,8 @@
 package edu.stanford.bmir.protege.web.shared.tag;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableSet;
@@ -26,6 +29,8 @@ public class EntityTagsChangedEvent extends ProjectEvent<EntityTagsChangedHandle
     public static final transient Event.Type<EntityTagsChangedHandler> ON_ENTITY_TAGS_CHANGED = new Event.Type<>();
 
 
+    private String eventId;
+
     private OWLEntity entity;
 
     private ImmutableSet<Tag> tags;
@@ -38,8 +43,24 @@ public class EntityTagsChangedEvent extends ProjectEvent<EntityTagsChangedHandle
         this.tags = ImmutableSet.copyOf(checkNotNull(tags));
     }
 
+    @JsonCreator
+    public EntityTagsChangedEvent(@JsonProperty("eventId") String eventId,
+                                  @JsonProperty("projectId") @Nonnull ProjectId projectId,
+                                  @JsonProperty("entity") @Nonnull OWLEntity entity,
+                                  @JsonProperty("tags") @Nonnull Collection<Tag> tags) {
+        super(checkNotNull(projectId));
+        this.eventId = eventId;
+        this.entity = checkNotNull(entity);
+        this.tags = ImmutableSet.copyOf(checkNotNull(tags));
+    }
+
     @GwtSerializationConstructor
     private EntityTagsChangedEvent() {
+    }
+
+    @JsonProperty("eventId")
+    public String getEventId() {
+        return eventId;
     }
 
     @Nonnull
@@ -52,6 +73,7 @@ public class EntityTagsChangedEvent extends ProjectEvent<EntityTagsChangedHandle
         return tags;
     }
 
+    @JsonIgnore
     @Override
     public Event.Type<EntityTagsChangedHandler> getAssociatedType() {
         return ON_ENTITY_TAGS_CHANGED;

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/tag/EntityTagsChangedEvent.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/tag/EntityTagsChangedEvent.java
@@ -17,6 +17,7 @@ import java.util.Collection;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkNotNull;
+import edu.stanford.bmir.protege.web.shared.event.EventId;
 
 /**
  * Matthew Horridge
@@ -29,22 +30,14 @@ public class EntityTagsChangedEvent extends ProjectEvent<EntityTagsChangedHandle
     public static final transient Event.Type<EntityTagsChangedHandler> ON_ENTITY_TAGS_CHANGED = new Event.Type<>();
 
 
-    private String eventId;
+    private EventId eventId;
 
     private OWLEntity entity;
 
     private ImmutableSet<Tag> tags;
 
-    public EntityTagsChangedEvent(@Nonnull ProjectId projectId,
-                                  @Nonnull OWLEntity entity,
-                                  @Nonnull Collection<Tag> tags) {
-        super(checkNotNull(projectId));
-        this.entity = checkNotNull(entity);
-        this.tags = ImmutableSet.copyOf(checkNotNull(tags));
-    }
-
     @JsonCreator
-    public EntityTagsChangedEvent(@JsonProperty("eventId") String eventId,
+    public EntityTagsChangedEvent(@JsonProperty("eventId") EventId eventId,
                                   @JsonProperty("projectId") @Nonnull ProjectId projectId,
                                   @JsonProperty("entity") @Nonnull OWLEntity entity,
                                   @JsonProperty("tags") @Nonnull Collection<Tag> tags) {
@@ -59,7 +52,7 @@ public class EntityTagsChangedEvent extends ProjectEvent<EntityTagsChangedHandle
     }
 
     @JsonProperty("eventId")
-    public String getEventId() {
+    public EventId getEventId() {
         return eventId;
     }
 

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/tag/ProjectTagsChangedEvent.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/tag/ProjectTagsChangedEvent.java
@@ -1,5 +1,8 @@
 package edu.stanford.bmir.protege.web.shared.tag;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableList;
@@ -26,6 +29,8 @@ public class ProjectTagsChangedEvent extends ProjectEvent<ProjectTagsChangedHand
     public static final transient Event.Type<ProjectTagsChangedHandler> ON_PROJECT_TAGS_CHANGED = new Event.Type<>();
 
 
+    private String eventId;
+
     private Collection<Tag> projectTags;
 
     @Inject
@@ -35,8 +40,22 @@ public class ProjectTagsChangedEvent extends ProjectEvent<ProjectTagsChangedHand
         this.projectTags = ImmutableList.copyOf(checkNotNull(projectTags));
     }
 
+    @JsonCreator
+    public ProjectTagsChangedEvent(@JsonProperty("eventId") String eventId,
+                                   @JsonProperty("projectId") @Nonnull ProjectId source,
+                                   @JsonProperty("projectTags") @Nonnull Collection<Tag> projectTags) {
+        super(source);
+        this.eventId = eventId;
+        this.projectTags = ImmutableList.copyOf(checkNotNull(projectTags));
+    }
+
     @GwtSerializationConstructor
     private ProjectTagsChangedEvent() {
+    }
+
+    @JsonProperty("eventId")
+    public String getEventId() {
+        return eventId;
     }
 
     /**
@@ -47,6 +66,7 @@ public class ProjectTagsChangedEvent extends ProjectEvent<ProjectTagsChangedHand
         return projectTags;
     }
 
+    @JsonIgnore
     @Override
     public Event.Type<ProjectTagsChangedHandler> getAssociatedType() {
         return ON_PROJECT_TAGS_CHANGED;

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/tag/ProjectTagsChangedEvent.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/tag/ProjectTagsChangedEvent.java
@@ -17,6 +17,7 @@ import java.util.Collection;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkNotNull;
+import edu.stanford.bmir.protege.web.shared.event.EventId;
 
 /**
  * Matthew Horridge
@@ -29,19 +30,12 @@ public class ProjectTagsChangedEvent extends ProjectEvent<ProjectTagsChangedHand
     public static final transient Event.Type<ProjectTagsChangedHandler> ON_PROJECT_TAGS_CHANGED = new Event.Type<>();
 
 
-    private String eventId;
+    private EventId eventId;
 
     private Collection<Tag> projectTags;
 
-    @Inject
-    public ProjectTagsChangedEvent(@Nonnull ProjectId source,
-                                   @Nonnull Collection<Tag> projectTags) {
-        super(source);
-        this.projectTags = ImmutableList.copyOf(checkNotNull(projectTags));
-    }
-
     @JsonCreator
-    public ProjectTagsChangedEvent(@JsonProperty("eventId") String eventId,
+    public ProjectTagsChangedEvent(@JsonProperty("eventId") EventId eventId,
                                    @JsonProperty("projectId") @Nonnull ProjectId source,
                                    @JsonProperty("projectTags") @Nonnull Collection<Tag> projectTags) {
         super(source);
@@ -54,7 +48,7 @@ public class ProjectTagsChangedEvent extends ProjectEvent<ProjectTagsChangedHand
     }
 
     @JsonProperty("eventId")
-    public String getEventId() {
+    public EventId getEventId() {
         return eventId;
     }
 

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/tag/SetProjectTagsAction.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/tag/SetProjectTagsAction.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.auto.value.AutoValue;
 import com.google.common.annotations.GwtCompatible;
-import com.google.common.annotations.GwtIncompatible;
 import com.google.common.base.Objects;
 import edu.stanford.bmir.protege.web.shared.annotations.GwtSerializationConstructor;
 import edu.stanford.bmir.protege.web.shared.dispatch.ProjectAction;
@@ -15,7 +14,6 @@ import edu.stanford.bmir.protege.web.shared.project.ProjectId;
 import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.UUID;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -30,11 +28,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 @JsonTypeName("webprotege.tags.SetProjectTags")
 public abstract class SetProjectTagsAction implements ProjectAction<SetProjectTagsResult> {
 
-    @GwtIncompatible
-    public static SetProjectTagsAction create(@Nonnull ProjectId projectId,
-                                              @Nonnull List<TagData> tagData) {
-        return create(ChangeRequestId.get(UUID.randomUUID().toString()), projectId, tagData);
-    }
 
     @JsonCreator
     public static SetProjectTagsAction create(@JsonProperty("changeRequestId") @Nonnull ChangeRequestId changeRequestId,

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/tag/SetProjectTagsAction.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/tag/SetProjectTagsAction.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.auto.value.AutoValue;
 import com.google.common.annotations.GwtCompatible;
+import com.google.common.annotations.GwtIncompatible;
 import com.google.common.base.Objects;
 import edu.stanford.bmir.protege.web.shared.annotations.GwtSerializationConstructor;
 import edu.stanford.bmir.protege.web.shared.dispatch.ProjectAction;
@@ -29,6 +30,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 @JsonTypeName("webprotege.tags.SetProjectTags")
 public abstract class SetProjectTagsAction implements ProjectAction<SetProjectTagsResult> {
 
+    @GwtIncompatible
     public static SetProjectTagsAction create(@Nonnull ProjectId projectId,
                                               @Nonnull List<TagData> tagData) {
         return create(ChangeRequestId.get(UUID.randomUUID().toString()), projectId, tagData);

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/tag/SetProjectTagsAction.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/tag/SetProjectTagsAction.java
@@ -8,11 +8,13 @@ import com.google.common.annotations.GwtCompatible;
 import com.google.common.base.Objects;
 import edu.stanford.bmir.protege.web.shared.annotations.GwtSerializationConstructor;
 import edu.stanford.bmir.protege.web.shared.dispatch.ProjectAction;
+import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
 import edu.stanford.bmir.protege.web.shared.project.ProjectId;
 
 import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -27,11 +29,21 @@ import static com.google.common.base.Preconditions.checkNotNull;
 @JsonTypeName("webprotege.tags.SetProjectTags")
 public abstract class SetProjectTagsAction implements ProjectAction<SetProjectTagsResult> {
 
-    @JsonCreator
-    public static SetProjectTagsAction create(@JsonProperty("projectId") @Nonnull ProjectId projectId,
-                                              @JsonProperty("tagData") @Nonnull List<TagData> tagData) {
-        return new AutoValue_SetProjectTagsAction(projectId, tagData);
+    public static SetProjectTagsAction create(@Nonnull ProjectId projectId,
+                                              @Nonnull List<TagData> tagData) {
+        return create(ChangeRequestId.get(UUID.randomUUID().toString()), projectId, tagData);
     }
+
+    @JsonCreator
+    public static SetProjectTagsAction create(@JsonProperty("changeRequestId") @Nonnull ChangeRequestId changeRequestId,
+                                              @JsonProperty("projectId") @Nonnull ProjectId projectId,
+                                              @JsonProperty("tagData") @Nonnull List<TagData> tagData) {
+        return new AutoValue_SetProjectTagsAction(changeRequestId, projectId, tagData);
+    }
+
+    @Nonnull
+    @JsonProperty("changeRequestId")
+    public abstract ChangeRequestId getChangeRequestId();
 
     @Nonnull
     @Override

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/tag/UpdateEntityTagsAction.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/tag/UpdateEntityTagsAction.java
@@ -3,7 +3,6 @@ package edu.stanford.bmir.protege.web.shared.tag;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import com.google.common.annotations.GwtIncompatible;
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableSet;
 import edu.stanford.bmir.protege.web.shared.annotations.GwtSerializationConstructor;
@@ -14,7 +13,6 @@ import org.semanticweb.owlapi.model.OWLEntity;
 
 import javax.annotation.Nonnull;
 import java.util.Set;
-import java.util.UUID;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -54,13 +52,6 @@ public class UpdateEntityTagsAction implements ProjectAction<UpdateEntityTagsRes
     private UpdateEntityTagsAction() {
     }
 
-    @GwtIncompatible
-    public static UpdateEntityTagsAction create(@Nonnull ProjectId projectId,
-                                                OWLEntity entity,
-                                                @Nonnull Set<TagId> fromTagIds,
-                                                @Nonnull Set<TagId> toTagIds) {
-        return new UpdateEntityTagsAction(ChangeRequestId.get(UUID.randomUUID().toString()), projectId, entity, fromTagIds, toTagIds);
-    }
 
     public static UpdateEntityTagsAction create(@Nonnull ChangeRequestId changeRequestId,
                                                 @Nonnull ProjectId projectId,

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/tag/UpdateEntityTagsAction.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/tag/UpdateEntityTagsAction.java
@@ -3,6 +3,7 @@ package edu.stanford.bmir.protege.web.shared.tag;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.google.common.annotations.GwtIncompatible;
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableSet;
 import edu.stanford.bmir.protege.web.shared.annotations.GwtSerializationConstructor;
@@ -53,11 +54,20 @@ public class UpdateEntityTagsAction implements ProjectAction<UpdateEntityTagsRes
     private UpdateEntityTagsAction() {
     }
 
+    @GwtIncompatible
     public static UpdateEntityTagsAction create(@Nonnull ProjectId projectId,
                                                 OWLEntity entity,
                                                 @Nonnull Set<TagId> fromTagIds,
                                                 @Nonnull Set<TagId> toTagIds) {
         return new UpdateEntityTagsAction(ChangeRequestId.get(UUID.randomUUID().toString()), projectId, entity, fromTagIds, toTagIds);
+    }
+
+    public static UpdateEntityTagsAction create(@Nonnull ChangeRequestId changeRequestId,
+                                                @Nonnull ProjectId projectId,
+                                                OWLEntity entity,
+                                                @Nonnull Set<TagId> fromTagIds,
+                                                @Nonnull Set<TagId> toTagIds) {
+        return new UpdateEntityTagsAction(changeRequestId, projectId, entity, fromTagIds, toTagIds);
     }
 
     @Nonnull

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/tag/UpdateEntityTagsAction.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/tag/UpdateEntityTagsAction.java
@@ -1,15 +1,19 @@
 package edu.stanford.bmir.protege.web.shared.tag;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableSet;
 import edu.stanford.bmir.protege.web.shared.annotations.GwtSerializationConstructor;
 import edu.stanford.bmir.protege.web.shared.dispatch.ProjectAction;
+import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
 import edu.stanford.bmir.protege.web.shared.project.ProjectId;
 import org.semanticweb.owlapi.model.OWLEntity;
 
 import javax.annotation.Nonnull;
 import java.util.Set;
+import java.util.UUID;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -22,6 +26,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
 @JsonTypeName("webprotege.tags.UpdateEntityTags")
 public class UpdateEntityTagsAction implements ProjectAction<UpdateEntityTagsResult> {
 
+    private ChangeRequestId changeRequestId;
+
     private ProjectId projectId;
 
     private OWLEntity entity;
@@ -30,10 +36,13 @@ public class UpdateEntityTagsAction implements ProjectAction<UpdateEntityTagsRes
 
     private Set<TagId> toTagIds;
 
-    private UpdateEntityTagsAction(@Nonnull ProjectId projectId,
-                                   OWLEntity entity,
-                                   @Nonnull Set<TagId> fromTagIds,
-                                   @Nonnull Set<TagId> toTagIds) {
+    @JsonCreator
+    private UpdateEntityTagsAction(@JsonProperty("changeRequestId") @Nonnull ChangeRequestId changeRequestId,
+                                   @JsonProperty("projectId") @Nonnull ProjectId projectId,
+                                   @JsonProperty("entity") OWLEntity entity,
+                                   @JsonProperty("fromTagIds") @Nonnull Set<TagId> fromTagIds,
+                                   @JsonProperty("toTagIds") @Nonnull Set<TagId> toTagIds) {
+        this.changeRequestId = checkNotNull(changeRequestId);
         this.projectId = checkNotNull(projectId);
         this.entity = checkNotNull(entity);
         this.fromTagIds = ImmutableSet.copyOf(fromTagIds);
@@ -48,7 +57,13 @@ public class UpdateEntityTagsAction implements ProjectAction<UpdateEntityTagsRes
                                                 OWLEntity entity,
                                                 @Nonnull Set<TagId> fromTagIds,
                                                 @Nonnull Set<TagId> toTagIds) {
-        return new UpdateEntityTagsAction(projectId, entity, fromTagIds, toTagIds);
+        return new UpdateEntityTagsAction(ChangeRequestId.get(UUID.randomUUID().toString()), projectId, entity, fromTagIds, toTagIds);
+    }
+
+    @Nonnull
+    @JsonProperty("changeRequestId")
+    public ChangeRequestId getChangeRequestId() {
+        return changeRequestId;
     }
 
     @Nonnull

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/usage/GetUsageAction.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/usage/GetUsageAction.java
@@ -8,6 +8,7 @@ import com.google.common.annotations.GwtCompatible;
 import edu.stanford.bmir.protege.web.shared.annotations.GwtSerializationConstructor;
 import edu.stanford.bmir.protege.web.shared.dispatch.AbstractHasProjectIdAndSubject;
 import edu.stanford.bmir.protege.web.shared.dispatch.ProjectAction;
+import edu.stanford.bmir.protege.web.shared.pagination.PageRequest;
 import edu.stanford.bmir.protege.web.shared.project.ProjectId;
 import org.semanticweb.owlapi.model.OWLEntity;
 
@@ -29,20 +30,21 @@ public abstract class GetUsageAction implements ProjectAction<GetUsageResult> {
 
     public static GetUsageAction create(OWLEntity subject,
                                         ProjectId projectId) {
-        return new AutoValue_GetUsageAction(projectId, subject, null);
+        return new AutoValue_GetUsageAction(projectId, subject, null, null);
     }
 
     public static GetUsageAction create(OWLEntity subject,
                                         ProjectId projectId,
                                         Optional<UsageFilter> usageFilter) {
-        return new AutoValue_GetUsageAction(projectId, subject, usageFilter.orElse(null));
+        return new AutoValue_GetUsageAction(projectId, subject, usageFilter.orElse(null), null);
     }
 
     @JsonCreator
     public static GetUsageAction create(@JsonProperty("subject") OWLEntity subject,
                                         @JsonProperty("projectId") ProjectId projectId,
-                                        @JsonProperty("usageFilter") @Nullable UsageFilter usageFilter) {
-        return new AutoValue_GetUsageAction(projectId, subject, usageFilter);
+                                        @JsonProperty("usageFilter") @Nullable UsageFilter usageFilter,
+                                        @JsonProperty("pageRequest") @Nullable PageRequest pageRequest) {
+        return new AutoValue_GetUsageAction(projectId, subject, usageFilter, pageRequest);
     }
 
     @Override
@@ -56,6 +58,10 @@ public abstract class GetUsageAction implements ProjectAction<GetUsageResult> {
     public Optional<UsageFilter> getUsageFilter() {
         return Optional.ofNullable(getUsageFilterInternal());
     }
+
+    @Nullable
+    @JsonProperty("pageRequest")
+    public abstract PageRequest getPageRequest();
 
     public int getPageSize() {
         return DEFAULT_PAGE_SIZE;

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/viz/GetUserProjectEntityGraphCriteriaResult.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/viz/GetUserProjectEntityGraphCriteriaResult.java
@@ -18,7 +18,7 @@ import javax.annotation.Nonnull;
  */
 @AutoValue
 @GwtCompatible(serializable = true)
-@JsonTypeName("webprotege.graphs.GetProjectEntityGraphDefaultEdgeCriteria")
+@JsonTypeName("webprotege.graphs.GetUserProjectEntityGraphCriteria")
 public abstract class GetUserProjectEntityGraphCriteriaResult implements Result {
 
     @JsonCreator

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/viz/SetEntityGraphActiveFiltersAction.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/viz/SetEntityGraphActiveFiltersAction.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.auto.value.AutoValue;
 import com.google.common.annotations.GwtCompatible;
+import com.google.common.annotations.GwtIncompatible;
 import com.google.common.collect.ImmutableList;
 import edu.stanford.bmir.protege.web.shared.annotations.GwtSerializationConstructor;
 import edu.stanford.bmir.protege.web.shared.dispatch.ProjectAction;
@@ -12,9 +13,10 @@ import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
 import edu.stanford.bmir.protege.web.shared.project.ProjectId;
 
 import javax.annotation.Nonnull;
-import java.util.UUID;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.UUID;
 
 /**
  * Matthew Horridge
@@ -27,6 +29,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 public abstract class SetEntityGraphActiveFiltersAction implements ProjectAction<SetEntityGraphActiveFiltersResult> {
 
 
+    @GwtIncompatible
     public static SetEntityGraphActiveFiltersAction create(@Nonnull ProjectId projectId,
                                                            @Nonnull ImmutableList<FilterName> activeFilters) {
         return create(ChangeRequestId.get(UUID.randomUUID().toString()), projectId, activeFilters);

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/viz/SetEntityGraphActiveFiltersAction.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/viz/SetEntityGraphActiveFiltersAction.java
@@ -8,9 +8,11 @@ import com.google.common.annotations.GwtCompatible;
 import com.google.common.collect.ImmutableList;
 import edu.stanford.bmir.protege.web.shared.annotations.GwtSerializationConstructor;
 import edu.stanford.bmir.protege.web.shared.dispatch.ProjectAction;
+import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
 import edu.stanford.bmir.protege.web.shared.project.ProjectId;
 
 import javax.annotation.Nonnull;
+import java.util.UUID;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -25,11 +27,21 @@ import static com.google.common.base.Preconditions.checkNotNull;
 public abstract class SetEntityGraphActiveFiltersAction implements ProjectAction<SetEntityGraphActiveFiltersResult> {
 
 
-    @JsonCreator
-    public static SetEntityGraphActiveFiltersAction create(@JsonProperty("projectId") @Nonnull ProjectId projectId,
-                                                           @JsonProperty("activeFilters") @Nonnull ImmutableList<FilterName> activeFilters) {
-        return new AutoValue_SetEntityGraphActiveFiltersAction(projectId, activeFilters);
+    public static SetEntityGraphActiveFiltersAction create(@Nonnull ProjectId projectId,
+                                                           @Nonnull ImmutableList<FilterName> activeFilters) {
+        return create(ChangeRequestId.get(UUID.randomUUID().toString()), projectId, activeFilters);
     }
+
+    @JsonCreator
+    public static SetEntityGraphActiveFiltersAction create(@JsonProperty("changeRequestId") @Nonnull ChangeRequestId changeRequestId,
+                                                           @JsonProperty("projectId") @Nonnull ProjectId projectId,
+                                                           @JsonProperty("activeFilters") @Nonnull ImmutableList<FilterName> activeFilters) {
+        return new AutoValue_SetEntityGraphActiveFiltersAction(changeRequestId, projectId, activeFilters);
+    }
+
+    @Nonnull
+    @JsonProperty("changeRequestId")
+    public abstract ChangeRequestId getChangeRequestId();
 
     @Nonnull
     @Override

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/viz/SetEntityGraphActiveFiltersAction.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/viz/SetEntityGraphActiveFiltersAction.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.auto.value.AutoValue;
 import com.google.common.annotations.GwtCompatible;
-import com.google.common.annotations.GwtIncompatible;
 import com.google.common.collect.ImmutableList;
 import edu.stanford.bmir.protege.web.shared.annotations.GwtSerializationConstructor;
 import edu.stanford.bmir.protege.web.shared.dispatch.ProjectAction;
@@ -16,7 +15,6 @@ import javax.annotation.Nonnull;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import java.util.UUID;
 
 /**
  * Matthew Horridge
@@ -29,11 +27,6 @@ import java.util.UUID;
 public abstract class SetEntityGraphActiveFiltersAction implements ProjectAction<SetEntityGraphActiveFiltersResult> {
 
 
-    @GwtIncompatible
-    public static SetEntityGraphActiveFiltersAction create(@Nonnull ProjectId projectId,
-                                                           @Nonnull ImmutableList<FilterName> activeFilters) {
-        return create(ChangeRequestId.get(UUID.randomUUID().toString()), projectId, activeFilters);
-    }
 
     @JsonCreator
     public static SetEntityGraphActiveFiltersAction create(@JsonProperty("changeRequestId") @Nonnull ChangeRequestId changeRequestId,

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/viz/SetUserProjectEntityGraphSettingsAction.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/viz/SetUserProjectEntityGraphSettingsAction.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.auto.value.AutoValue;
 import com.google.common.annotations.GwtCompatible;
-import com.google.common.annotations.GwtIncompatible;
 import edu.stanford.bmir.protege.web.shared.annotations.GwtSerializationConstructor;
 import edu.stanford.bmir.protege.web.shared.dispatch.ProjectAction;
 import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
@@ -15,7 +14,6 @@ import edu.stanford.bmir.protege.web.shared.user.UserId;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Optional;
-import java.util.UUID;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -29,12 +27,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 @JsonTypeName("webprotege.graphs.SetUserProjectEntityGraphSettings")
 public abstract class SetUserProjectEntityGraphSettingsAction implements ProjectAction<SetUserProjectEntityGraphSettingsResult> {
 
-    @GwtIncompatible
-    public static SetUserProjectEntityGraphSettingsAction create(@Nonnull ProjectId projectId,
-                                                                 @Nullable UserId userId,
-                                                                 @Nonnull EntityGraphSettings settings) {
-        return create(ChangeRequestId.get(UUID.randomUUID().toString()), projectId, userId, settings);
-    }
 
     @JsonCreator
     public static SetUserProjectEntityGraphSettingsAction create(@JsonProperty("changeRequestId") @Nonnull ChangeRequestId changeRequestId,

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/viz/SetUserProjectEntityGraphSettingsAction.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/viz/SetUserProjectEntityGraphSettingsAction.java
@@ -7,12 +7,14 @@ import com.google.auto.value.AutoValue;
 import com.google.common.annotations.GwtCompatible;
 import edu.stanford.bmir.protege.web.shared.annotations.GwtSerializationConstructor;
 import edu.stanford.bmir.protege.web.shared.dispatch.ProjectAction;
+import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
 import edu.stanford.bmir.protege.web.shared.project.ProjectId;
 import edu.stanford.bmir.protege.web.shared.user.UserId;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Optional;
+import java.util.UUID;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -26,12 +28,23 @@ import static com.google.common.base.Preconditions.checkNotNull;
 @JsonTypeName("webprotege.graphs.SetUserProjectEntityGraphSettings")
 public abstract class SetUserProjectEntityGraphSettingsAction implements ProjectAction<SetUserProjectEntityGraphSettingsResult> {
 
+    public static SetUserProjectEntityGraphSettingsAction create(@Nonnull ProjectId projectId,
+                                                                 @Nullable UserId userId,
+                                                                 @Nonnull EntityGraphSettings settings) {
+        return create(ChangeRequestId.get(UUID.randomUUID().toString()), projectId, userId, settings);
+    }
+
     @JsonCreator
-    public static SetUserProjectEntityGraphSettingsAction create(@JsonProperty("projectId") @Nonnull ProjectId projectId,
+    public static SetUserProjectEntityGraphSettingsAction create(@JsonProperty("changeRequestId") @Nonnull ChangeRequestId changeRequestId,
+                                                                 @JsonProperty("projectId") @Nonnull ProjectId projectId,
                                                                  @JsonProperty("userId") @Nullable UserId userId,
                                                                  @JsonProperty("settings") @Nonnull EntityGraphSettings settings) {
-        return new AutoValue_SetUserProjectEntityGraphSettingsAction(projectId, settings, userId);
+        return new AutoValue_SetUserProjectEntityGraphSettingsAction(changeRequestId, projectId, settings, userId);
     }
+
+    @Nonnull
+    @JsonProperty("changeRequestId")
+    public abstract ChangeRequestId getChangeRequestId();
 
     @Nonnull
     @Override

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/viz/SetUserProjectEntityGraphSettingsAction.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/viz/SetUserProjectEntityGraphSettingsAction.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.auto.value.AutoValue;
 import com.google.common.annotations.GwtCompatible;
+import com.google.common.annotations.GwtIncompatible;
 import edu.stanford.bmir.protege.web.shared.annotations.GwtSerializationConstructor;
 import edu.stanford.bmir.protege.web.shared.dispatch.ProjectAction;
 import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
@@ -28,6 +29,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 @JsonTypeName("webprotege.graphs.SetUserProjectEntityGraphSettings")
 public abstract class SetUserProjectEntityGraphSettingsAction implements ProjectAction<SetUserProjectEntityGraphSettingsResult> {
 
+    @GwtIncompatible
     public static SetUserProjectEntityGraphSettingsAction create(@Nonnull ProjectId projectId,
                                                                  @Nullable UserId userId,
                                                                  @Nonnull EntityGraphSettings settings) {

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/watches/WatchAddedEvent.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/watches/WatchAddedEvent.java
@@ -1,5 +1,8 @@
 package edu.stanford.bmir.protege.web.shared.watches;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.web.bindery.event.shared.Event;
 import edu.stanford.bmir.protege.web.shared.event.ProjectEvent;
@@ -21,6 +24,8 @@ public class WatchAddedEvent extends ProjectEvent<WatchAddedHandler> {
 
     public static final transient Event.Type<WatchAddedHandler> ON_WATCH_ADDED = new Event.Type<>();
 
+    private String eventId;
+
     private Watch watch;
 
     /**
@@ -39,15 +44,31 @@ public class WatchAddedEvent extends ProjectEvent<WatchAddedHandler> {
         this.watch = watch;
     }
 
+    @JsonCreator
+    public WatchAddedEvent(@JsonProperty("eventId") String eventId,
+                           @JsonProperty("projectId") ProjectId source,
+                           @JsonProperty("watch") Watch watch) {
+        super(source);
+        this.eventId = eventId;
+        this.watch = watch;
+    }
+
+    @JsonProperty("eventId")
+    public String getEventId() {
+        return eventId;
+    }
+
     public Watch getWatch() {
         return watch;
     }
 
+    @JsonIgnore
     public UserId getUserId() {
         return watch.getUserId();
     }
 
 
+    @JsonIgnore
     @Override
     public Event.Type<WatchAddedHandler> getAssociatedType() {
         return ON_WATCH_ADDED;

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/watches/WatchAddedEvent.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/watches/WatchAddedEvent.java
@@ -12,6 +12,7 @@ import edu.stanford.bmir.protege.web.shared.user.UserId;
 import java.util.Objects;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
+import edu.stanford.bmir.protege.web.shared.event.EventId;
 
 /**
  * Author: Matthew Horridge<br>
@@ -24,7 +25,7 @@ public class WatchAddedEvent extends ProjectEvent<WatchAddedHandler> {
 
     public static final transient Event.Type<WatchAddedHandler> ON_WATCH_ADDED = new Event.Type<>();
 
-    private String eventId;
+    private EventId eventId;
 
     private Watch watch;
 
@@ -34,18 +35,8 @@ public class WatchAddedEvent extends ProjectEvent<WatchAddedHandler> {
     private WatchAddedEvent() {
     }
 
-    /**
-     * Creates a {@link WatchAddedEvent}.
-     * @param source The id of the project that the watch was added to.  Not {@code null}.
-     * @param watch The watch that was added.  Not {@code null}.
-     */
-    public WatchAddedEvent(ProjectId source, Watch watch) {
-        super(source);
-        this.watch = watch;
-    }
-
     @JsonCreator
-    public WatchAddedEvent(@JsonProperty("eventId") String eventId,
+    public WatchAddedEvent(@JsonProperty("eventId") EventId eventId,
                            @JsonProperty("projectId") ProjectId source,
                            @JsonProperty("watch") Watch watch) {
         super(source);
@@ -54,7 +45,7 @@ public class WatchAddedEvent extends ProjectEvent<WatchAddedHandler> {
     }
 
     @JsonProperty("eventId")
-    public String getEventId() {
+    public EventId getEventId() {
         return eventId;
     }
 

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/watches/WatchRemovedEvent.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/watches/WatchRemovedEvent.java
@@ -12,6 +12,7 @@ import edu.stanford.bmir.protege.web.shared.project.ProjectId;
 import edu.stanford.bmir.protege.web.shared.user.UserId;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
+import edu.stanford.bmir.protege.web.shared.event.EventId;
 
 /**
  * Author: Matthew Horridge<br>
@@ -24,17 +25,12 @@ public class WatchRemovedEvent extends ProjectEvent<WatchRemovedHandler> impleme
 
     public transient static final Event.Type<WatchRemovedHandler> ON_WATCH_REMOVED = new Event.Type<WatchRemovedHandler>();
 
-    private String eventId;
+    private EventId eventId;
 
     private Watch watch;
 
-    public WatchRemovedEvent(ProjectId source, Watch watch) {
-        super(source);
-        this.watch = watch;
-    }
-
     @JsonCreator
-    public WatchRemovedEvent(@JsonProperty("eventId") String eventId,
+    public WatchRemovedEvent(@JsonProperty("eventId") EventId eventId,
                              @JsonProperty("projectId") ProjectId source,
                              @JsonProperty("watch") Watch watch) {
         super(source);
@@ -46,7 +42,7 @@ public class WatchRemovedEvent extends ProjectEvent<WatchRemovedHandler> impleme
     }
 
     @JsonProperty("eventId")
-    public String getEventId() {
+    public EventId getEventId() {
         return eventId;
     }
 

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/watches/WatchRemovedEvent.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/watches/WatchRemovedEvent.java
@@ -1,5 +1,8 @@
 package edu.stanford.bmir.protege.web.shared.watches;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.common.base.Objects;
 import com.google.web.bindery.event.shared.Event;
@@ -21,6 +24,8 @@ public class WatchRemovedEvent extends ProjectEvent<WatchRemovedHandler> impleme
 
     public transient static final Event.Type<WatchRemovedHandler> ON_WATCH_REMOVED = new Event.Type<WatchRemovedHandler>();
 
+    private String eventId;
+
     private Watch watch;
 
     public WatchRemovedEvent(ProjectId source, Watch watch) {
@@ -28,9 +33,24 @@ public class WatchRemovedEvent extends ProjectEvent<WatchRemovedHandler> impleme
         this.watch = watch;
     }
 
+    @JsonCreator
+    public WatchRemovedEvent(@JsonProperty("eventId") String eventId,
+                             @JsonProperty("projectId") ProjectId source,
+                             @JsonProperty("watch") Watch watch) {
+        super(source);
+        this.eventId = eventId;
+        this.watch = watch;
+    }
+
     private WatchRemovedEvent() {
     }
 
+    @JsonProperty("eventId")
+    public String getEventId() {
+        return eventId;
+    }
+
+    @JsonIgnore
     @Override
     public Event.Type<WatchRemovedHandler> getAssociatedType() {
         return ON_WATCH_REMOVED;
@@ -45,6 +65,7 @@ public class WatchRemovedEvent extends ProjectEvent<WatchRemovedHandler> impleme
         return watch;
     }
 
+    @JsonIgnore
     public UserId getUserId() {
         return watch.getUserId();
     }

--- a/webprotege-gwt-ui-shared/src/test/java/edu/stanford/bmir/protege/web/shared/change/RevertRevisionAction_TestCase.java
+++ b/webprotege-gwt-ui-shared/src/test/java/edu/stanford/bmir/protege/web/shared/change/RevertRevisionAction_TestCase.java
@@ -1,6 +1,7 @@
 
 package edu.stanford.bmir.protege.web.shared.change;
 
+import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
 import edu.stanford.bmir.protege.web.shared.project.ProjectId;
 import edu.stanford.bmir.protege.web.shared.revision.RevisionNumber;
 import org.hamcrest.MatcherAssert;
@@ -26,12 +27,12 @@ public class RevertRevisionAction_TestCase {
     public void setUp()
         throws Exception
     {
-        revertRevisionAction = RevertRevisionAction.create(projectId, revisionNumber);
+        revertRevisionAction = RevertRevisionAction.create(ChangeRequestId.generate(), projectId, revisionNumber);
     }
 
     @Test(expected = java.lang.NullPointerException.class)
     public void shouldThrowNullPointerExceptionIf_projectId_IsNull() {
-        RevertRevisionAction.create(null, revisionNumber);
+        RevertRevisionAction.create(ChangeRequestId.generate(), null, revisionNumber);
     }
 
     @Test
@@ -41,7 +42,7 @@ public class RevertRevisionAction_TestCase {
 
     @Test(expected = java.lang.NullPointerException.class)
     public void shouldThrowNullPointerExceptionIf_revisionNumber_IsNull() {
-        RevertRevisionAction.create(projectId, null);
+        RevertRevisionAction.create(ChangeRequestId.generate(), projectId, null);
     }
 
     @Test
@@ -61,22 +62,22 @@ public class RevertRevisionAction_TestCase {
 
     @Test
     public void shouldBeEqualToOther() {
-        MatcherAssert.assertThat(revertRevisionAction, Matchers.is(RevertRevisionAction.create(projectId, revisionNumber)));
+        MatcherAssert.assertThat(revertRevisionAction, Matchers.is(RevertRevisionAction.create(ChangeRequestId.generate(), projectId, revisionNumber)));
     }
 
     @Test
     public void shouldNotBeEqualToOtherThatHasDifferent_projectId() {
-        MatcherAssert.assertThat(revertRevisionAction, Matchers.is(Matchers.not(RevertRevisionAction.create(Mockito.mock(ProjectId.class), revisionNumber))));
+        MatcherAssert.assertThat(revertRevisionAction, Matchers.is(Matchers.not(RevertRevisionAction.create(ChangeRequestId.generate(), Mockito.mock(ProjectId.class), revisionNumber))));
     }
 
     @Test
     public void shouldNotBeEqualToOtherThatHasDifferent_revisionNumber() {
-        MatcherAssert.assertThat(revertRevisionAction, Matchers.is(Matchers.not(RevertRevisionAction.create(projectId, Mockito.mock(RevisionNumber.class)))));
+        MatcherAssert.assertThat(revertRevisionAction, Matchers.is(Matchers.not(RevertRevisionAction.create(ChangeRequestId.generate(), projectId, Mockito.mock(RevisionNumber.class)))));
     }
 
     @Test
     public void shouldBeEqualToOtherHashCode() {
-        MatcherAssert.assertThat(revertRevisionAction.hashCode(), Matchers.is(RevertRevisionAction.create(projectId, revisionNumber)
+        MatcherAssert.assertThat(revertRevisionAction.hashCode(), Matchers.is(RevertRevisionAction.create(ChangeRequestId.generate(), projectId, revisionNumber)
                                                                                                   .hashCode()));
     }
 

--- a/webprotege-gwt-ui-shared/src/test/java/edu/stanford/bmir/protege/web/shared/entity/MergeEntitiesAction_TestCase.java
+++ b/webprotege-gwt-ui-shared/src/test/java/edu/stanford/bmir/protege/web/shared/entity/MergeEntitiesAction_TestCase.java
@@ -2,6 +2,7 @@
 package edu.stanford.bmir.protege.web.shared.entity;
 
 import com.google.common.collect.ImmutableSet;
+import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
 import edu.stanford.bmir.protege.web.shared.project.ProjectId;
 import org.junit.Before;
 import org.junit.Test;
@@ -33,13 +34,13 @@ public class MergeEntitiesAction_TestCase {
 
     @Before
     public void setUp() {
-        action = MergeEntitiesAction.create(projectId, sourceEntities, targetEntity, treatment, commitMessage);
+        action = MergeEntitiesAction.create(ChangeRequestId.generate(), projectId, sourceEntities, targetEntity, treatment, commitMessage);
     }
 
     @SuppressWarnings("ConstantConditions")
     @Test(expected = NullPointerException.class)
     public void shouldThrowNullPointerExceptionIf_projectId_IsNull() {
-        MergeEntitiesAction.create(null, sourceEntities, targetEntity, treatment, commitMessage);
+        MergeEntitiesAction.create(ChangeRequestId.generate(), null, sourceEntities, targetEntity, treatment, commitMessage);
     }
 
     @Test
@@ -50,7 +51,7 @@ public class MergeEntitiesAction_TestCase {
     @SuppressWarnings("ConstantConditions")
     @Test(expected = NullPointerException.class)
     public void shouldThrowNullPointerExceptionIf_sourceEntity_IsNull() {
-        MergeEntitiesAction.create(projectId, null, targetEntity, treatment, commitMessage);
+        MergeEntitiesAction.create(ChangeRequestId.generate(), projectId, null, targetEntity, treatment, commitMessage);
     }
 
     @Test
@@ -61,7 +62,7 @@ public class MergeEntitiesAction_TestCase {
     @SuppressWarnings("ConstantConditions")
     @Test(expected = NullPointerException.class)
     public void shouldThrowNullPointerExceptionIf_targetEntity_IsNull() {
-        MergeEntitiesAction.create(projectId, sourceEntities, null, treatment, commitMessage);
+        MergeEntitiesAction.create(ChangeRequestId.generate(), projectId, sourceEntities, null, treatment, commitMessage);
     }
 
     @Test
@@ -72,7 +73,7 @@ public class MergeEntitiesAction_TestCase {
     @SuppressWarnings("ConstantConditions")
     @Test(expected = NullPointerException.class)
     public void shouldThrowNullPointerExceptionIf_treatment_IsNull() {
-        MergeEntitiesAction.create(projectId, sourceEntities, targetEntity, null, commitMessage);
+        MergeEntitiesAction.create(ChangeRequestId.generate(), projectId, sourceEntities, targetEntity, null, commitMessage);
     }
 
     @Test
@@ -93,43 +94,38 @@ public class MergeEntitiesAction_TestCase {
 
     @Test
     public void shouldBeEqualToOther() {
-        assertThat(action, is(MergeEntitiesAction.create(projectId, sourceEntities, targetEntity, treatment, commitMessage)));
+        assertThat(action, is(MergeEntitiesAction.create(ChangeRequestId.generate(), projectId, sourceEntities, targetEntity, treatment, commitMessage)));
     }
 
     @Test
     public void shouldNotBeEqualToOtherThatHasDifferent_projectId() {
-        assertThat(action, is(not(MergeEntitiesAction.create(mock(ProjectId.class), sourceEntities, targetEntity, treatment, commitMessage))));
+        assertThat(action, is(not(MergeEntitiesAction.create(ChangeRequestId.generate(), mock(ProjectId.class), sourceEntities, targetEntity, treatment, commitMessage))));
     }
 
     @Test
     public void shouldNotBeEqualToOtherThatHasDifferent_sourceEntity() {
-        assertThat(action, is(not(MergeEntitiesAction.create(projectId, ImmutableSet.of(mock(OWLEntity.class)), targetEntity, treatment, commitMessage))));
+        assertThat(action, is(not(MergeEntitiesAction.create(ChangeRequestId.generate(), projectId, ImmutableSet.of(mock(OWLEntity.class)), targetEntity, treatment, commitMessage))));
     }
 
     @Test
     public void shouldNotBeEqualToOtherThatHasDifferent_targetEntity() {
-        assertThat(action, is(not(MergeEntitiesAction.create(projectId, sourceEntities, mock(OWLEntity.class), treatment, commitMessage))));
+        assertThat(action, is(not(MergeEntitiesAction.create(ChangeRequestId.generate(), projectId, sourceEntities, mock(OWLEntity.class), treatment, commitMessage))));
     }
 
     @Test
     public void shouldNotBeEqualToOtherThatHasDifferent_treatment() {
-        assertThat(action, is(not(MergeEntitiesAction.create(projectId, sourceEntities, targetEntity, MergedEntityTreatment.DEPRECATE_MERGED_ENTITY, commitMessage))));
+        assertThat(action, is(not(MergeEntitiesAction.create(ChangeRequestId.generate(), projectId, sourceEntities, targetEntity, MergedEntityTreatment.DEPRECATE_MERGED_ENTITY, commitMessage))));
     }
 
     @Test
     public void shouldBeEqualToOtherHashCode() {
-        assertThat(action.hashCode(), is(MergeEntitiesAction.create(projectId, sourceEntities, targetEntity, treatment, commitMessage)
+        assertThat(action.hashCode(), is(MergeEntitiesAction.create(ChangeRequestId.generate(), projectId, sourceEntities, targetEntity, treatment, commitMessage)
                                                             .hashCode()));
     }
 
     @Test
     public void shouldImplementToString() {
         assertThat(action.toString(), startsWith("MergeEntitiesAction"));
-    }
-
-    @Test
-    public void should_createMergeEntitiesAction() {
-        assertThat(MergeEntitiesAction.mergeEntities(projectId, sourceEntities, targetEntity, treatment, commitMessage), is(action));
     }
 
 }

--- a/webprotege-gwt-ui-shared/src/test/java/edu/stanford/bmir/protege/web/shared/event/PermissionsChangedEvent_TestCase.java
+++ b/webprotege-gwt-ui-shared/src/test/java/edu/stanford/bmir/protege/web/shared/event/PermissionsChangedEvent_TestCase.java
@@ -1,6 +1,7 @@
 
 package edu.stanford.bmir.protege.web.shared.event;
 
+import edu.stanford.bmir.protege.web.shared.event.EventId;
 import edu.stanford.bmir.protege.web.shared.permissions.PermissionsChangedEvent;
 import edu.stanford.bmir.protege.web.shared.project.ProjectId;
 import org.junit.Before;
@@ -23,13 +24,13 @@ public class PermissionsChangedEvent_TestCase {
 
     @Before
     public void setUp() {
-        permissionsChangedEvent = new PermissionsChangedEvent(source);
+        permissionsChangedEvent = new PermissionsChangedEvent(EventId.generate(), source);
     }
 
     @SuppressWarnings("ConstantConditions")
     @Test(expected = NullPointerException.class)
     public void shouldThrowNullPointerExceptionIf_source_IsNull() {
-        new PermissionsChangedEvent(null);
+        new PermissionsChangedEvent(EventId.generate(), null);
     }
 
     @Test
@@ -50,17 +51,17 @@ public class PermissionsChangedEvent_TestCase {
 
     @Test
     public void shouldBeEqualToOther() {
-        assertThat(permissionsChangedEvent, is(new PermissionsChangedEvent(source)));
+        assertThat(permissionsChangedEvent, is(new PermissionsChangedEvent(EventId.generate(), source)));
     }
 
     @Test
     public void shouldNotBeEqualToOtherThatHasDifferent_source() {
-        assertThat(permissionsChangedEvent, is(not(new PermissionsChangedEvent(mock(ProjectId.class)))));
+        assertThat(permissionsChangedEvent, is(not(new PermissionsChangedEvent(EventId.generate(), mock(ProjectId.class)))));
     }
 
     @Test
     public void shouldBeEqualToOtherHashCode() {
-        assertThat(permissionsChangedEvent.hashCode(), is(new PermissionsChangedEvent(source).hashCode()));
+        assertThat(permissionsChangedEvent.hashCode(), is(new PermissionsChangedEvent(EventId.generate(), source).hashCode()));
     }
 
     @Test

--- a/webprotege-gwt-ui-shared/src/test/java/edu/stanford/bmir/protege/web/shared/project/SetProjectPrefixDeclarationsAction_TestCase.java
+++ b/webprotege-gwt-ui-shared/src/test/java/edu/stanford/bmir/protege/web/shared/project/SetProjectPrefixDeclarationsAction_TestCase.java
@@ -1,6 +1,7 @@
 
 package edu.stanford.bmir.protege.web.shared.project;
 
+import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
 import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Test;
@@ -29,13 +30,13 @@ public class SetProjectPrefixDeclarationsAction_TestCase {
         projectId = ProjectId.get("12345678-1234-1234-1234-123456789abc");
         prefixDeclarations = new ArrayList<>();
         prefixDeclarations.add(mock(PrefixDeclaration.class));
-        action = SetProjectPrefixDeclarationsAction.create(projectId, prefixDeclarations);
+        action = SetProjectPrefixDeclarationsAction.create(ChangeRequestId.generate(), projectId, prefixDeclarations);
     }
 
     @SuppressWarnings("ConstantConditions")
     @Test(expected = NullPointerException.class)
     public void shouldThrowNullPointerExceptionIf_projectId_IsNull() {
-        SetProjectPrefixDeclarationsAction.create(null, prefixDeclarations);
+        SetProjectPrefixDeclarationsAction.create(ChangeRequestId.generate(), null, prefixDeclarations);
     }
 
     @Test
@@ -46,7 +47,7 @@ public class SetProjectPrefixDeclarationsAction_TestCase {
     @SuppressWarnings("ConstantConditions")
     @Test(expected = NullPointerException.class)
     public void shouldThrowNullPointerExceptionIf_prefixDeclarations_IsNull() {
-        SetProjectPrefixDeclarationsAction.create(projectId, null);
+        SetProjectPrefixDeclarationsAction.create(ChangeRequestId.generate(), projectId, null);
     }
 
     @Test
@@ -67,24 +68,24 @@ public class SetProjectPrefixDeclarationsAction_TestCase {
 
     @Test
     public void shouldBeEqualToOther() {
-        assertThat(action, is(SetProjectPrefixDeclarationsAction.create(projectId, prefixDeclarations)));
+        assertThat(action, is(SetProjectPrefixDeclarationsAction.create(ChangeRequestId.generate(), projectId, prefixDeclarations)));
     }
 
     @Test
     public void shouldNotBeEqualToOtherThatHasDifferent_projectId() {
-        assertThat(action, is(Matchers.not(SetProjectPrefixDeclarationsAction.create(mock(ProjectId.class), prefixDeclarations))));
+        assertThat(action, is(Matchers.not(SetProjectPrefixDeclarationsAction.create(ChangeRequestId.generate(), mock(ProjectId.class), prefixDeclarations))));
     }
 
     @Test
     public void shouldNotBeEqualToOtherThatHasDifferent_prefixDeclarations() {
         List<PrefixDeclaration> otherDecls = new ArrayList<>();
         otherDecls.add(mock(PrefixDeclaration.class));
-        assertThat(action, is(Matchers.not(SetProjectPrefixDeclarationsAction.create(projectId, otherDecls))));
+        assertThat(action, is(Matchers.not(SetProjectPrefixDeclarationsAction.create(ChangeRequestId.generate(), projectId, otherDecls))));
     }
 
     @Test
     public void shouldBeEqualToOtherHashCode() {
-        assertThat(action.hashCode(), is(SetProjectPrefixDeclarationsAction.create(projectId, prefixDeclarations).hashCode()));
+        assertThat(action.hashCode(), is(SetProjectPrefixDeclarationsAction.create(ChangeRequestId.generate(), projectId, prefixDeclarations).hashCode()));
     }
 
     @Test

--- a/webprotege-gwt-ui-shared/src/test/java/edu/stanford/bmir/protege/web/shared/projectsettings/SetProjectSettingsAction_TestCase.java
+++ b/webprotege-gwt-ui-shared/src/test/java/edu/stanford/bmir/protege/web/shared/projectsettings/SetProjectSettingsAction_TestCase.java
@@ -1,5 +1,6 @@
 package edu.stanford.bmir.protege.web.shared.projectsettings;
 
+import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
 import edu.stanford.bmir.protege.web.shared.project.ProjectId;
 import org.junit.Before;
 import org.junit.Test;
@@ -30,13 +31,13 @@ public class SetProjectSettingsAction_TestCase {
     @Before
     public void setUp() throws Exception {
         when(projectSettings.getProjectId()).thenReturn(projectId);
-        action = SetProjectSettingsAction.create(projectSettings);
+        action = SetProjectSettingsAction.create(ChangeRequestId.generate(), projectId, projectSettings);
     }
 
 
     @Test(expected = NullPointerException.class)
     public void shouldThrowNullPointerExceptionIf_ProjectSettings_IsNull() {
-        SetProjectSettingsAction.create(null);
+        SetProjectSettingsAction.create(ChangeRequestId.generate(), projectId, null);
     }
 
     @Test
@@ -56,13 +57,13 @@ public class SetProjectSettingsAction_TestCase {
 
     @Test
     public void shouldBeEqualToOther() {
-        SetProjectSettingsAction other = SetProjectSettingsAction.create(projectSettings);
+        SetProjectSettingsAction other = SetProjectSettingsAction.create(ChangeRequestId.generate(), projectId, projectSettings);
         assertThat(action, is(equalTo(other)));
     }
 
     @Test
     public void shouldHaveSameHashCode() {
-        SetProjectSettingsAction other = SetProjectSettingsAction.create(projectSettings);
+        SetProjectSettingsAction other = SetProjectSettingsAction.create(ChangeRequestId.generate(), projectId, projectSettings);
         assertThat(action.hashCode(), is(other.hashCode()));
     }
 }

--- a/webprotege-gwt-ui-shared/src/test/java/edu/stanford/bmir/protege/web/shared/tag/EntityTagsChangedEvent_TestCase.java
+++ b/webprotege-gwt-ui-shared/src/test/java/edu/stanford/bmir/protege/web/shared/tag/EntityTagsChangedEvent_TestCase.java
@@ -1,6 +1,7 @@
 
 package edu.stanford.bmir.protege.web.shared.tag;
 
+import edu.stanford.bmir.protege.web.shared.event.EventId;
 import edu.stanford.bmir.protege.web.shared.project.ProjectId;
 import org.junit.Before;
 import org.junit.Test;
@@ -33,13 +34,13 @@ public class EntityTagsChangedEvent_TestCase {
     @Before
     public void setUp() {
         tags = Collections.singleton(mock(Tag.class));
-        event = new EntityTagsChangedEvent(projectId, entity, tags);
+        event = new EntityTagsChangedEvent(EventId.generate(), projectId, entity, tags);
     }
 
     @SuppressWarnings("ConstantConditions")
     @Test(expected = NullPointerException.class)
     public void shouldThrowNullPointerExceptionIf_projectId_IsNull() {
-        new EntityTagsChangedEvent(null, entity, tags);
+        new EntityTagsChangedEvent(EventId.generate(), null, entity, tags);
     }
 
     @Test
@@ -50,7 +51,7 @@ public class EntityTagsChangedEvent_TestCase {
     @SuppressWarnings("ConstantConditions")
     @Test(expected = NullPointerException.class)
     public void shouldThrowNullPointerExceptionIf_entity_IsNull() {
-        new EntityTagsChangedEvent(projectId, null, tags);
+        new EntityTagsChangedEvent(EventId.generate(), projectId, null, tags);
     }
 
     @Test
@@ -61,7 +62,7 @@ public class EntityTagsChangedEvent_TestCase {
     @SuppressWarnings("ConstantConditions")
     @Test(expected = NullPointerException.class)
     public void shouldThrowNullPointerExceptionIf_tags_IsNull() {
-        new EntityTagsChangedEvent(projectId, entity, null);
+        new EntityTagsChangedEvent(EventId.generate(), projectId, entity, null);
     }
 
     @Test
@@ -82,27 +83,27 @@ public class EntityTagsChangedEvent_TestCase {
 
     @Test
     public void shouldBeEqualToOther() {
-        assertThat(event, is(new EntityTagsChangedEvent(projectId, entity, tags)));
+        assertThat(event, is(new EntityTagsChangedEvent(EventId.generate(), projectId, entity, tags)));
     }
 
     @Test
     public void shouldNotBeEqualToOtherThatHasDifferent_projectId() {
-        assertThat(event, is(not(new EntityTagsChangedEvent(mock(ProjectId.class), entity, tags))));
+        assertThat(event, is(not(new EntityTagsChangedEvent(EventId.generate(), mock(ProjectId.class), entity, tags))));
     }
 
     @Test
     public void shouldNotBeEqualToOtherThatHasDifferent_entity() {
-        assertThat(event, is(not(new EntityTagsChangedEvent(projectId, mock(OWLEntity.class), tags))));
+        assertThat(event, is(not(new EntityTagsChangedEvent(EventId.generate(), projectId, mock(OWLEntity.class), tags))));
     }
 
     @Test
     public void shouldNotBeEqualToOtherThatHasDifferent_tags() {
-        assertThat(event, is(not(new EntityTagsChangedEvent(projectId, entity, Collections.singleton(mock(Tag.class))))));
+        assertThat(event, is(not(new EntityTagsChangedEvent(EventId.generate(), projectId, entity, Collections.singleton(mock(Tag.class))))));
     }
 
     @Test
     public void shouldBeEqualToOtherHashCode() {
-        assertThat(event.hashCode(), is(new EntityTagsChangedEvent(projectId, entity, tags).hashCode()));
+        assertThat(event.hashCode(), is(new EntityTagsChangedEvent(EventId.generate(), projectId, entity, tags).hashCode()));
     }
 
     @Test

--- a/webprotege-gwt-ui-shared/src/test/java/edu/stanford/bmir/protege/web/shared/tag/UpdateEntityTagsAction_TestCase.java
+++ b/webprotege-gwt-ui-shared/src/test/java/edu/stanford/bmir/protege/web/shared/tag/UpdateEntityTagsAction_TestCase.java
@@ -1,6 +1,7 @@
 
 package edu.stanford.bmir.protege.web.shared.tag;
 
+import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
 import edu.stanford.bmir.protege.web.shared.project.ProjectId;
 import org.hamcrest.Matchers;
 import org.junit.Before;
@@ -38,13 +39,13 @@ public class UpdateEntityTagsAction_TestCase {
     public void setUp() {
         fromTagIds = Collections.singleton(mock(TagId.class));
         toTagIds = Collections.singleton(mock(TagId.class));
-        action = UpdateEntityTagsAction.create(projectId, entity, fromTagIds, toTagIds);
+        action = UpdateEntityTagsAction.create(ChangeRequestId.generate(), projectId, entity, fromTagIds, toTagIds);
     }
 
     @SuppressWarnings("ConstantConditions")
     @Test(expected = NullPointerException.class)
     public void shouldThrowNullPointerExceptionIf_projectId_IsNull() {
-        UpdateEntityTagsAction.create(null, entity, fromTagIds, toTagIds);
+        UpdateEntityTagsAction.create(ChangeRequestId.generate(), null, entity, fromTagIds, toTagIds);
     }
 
     @Test
@@ -55,7 +56,7 @@ public class UpdateEntityTagsAction_TestCase {
     @SuppressWarnings("ConstantConditions")
     @Test(expected = NullPointerException.class)
     public void shouldThrowNullPointerExceptionIf_entity_IsNull() {
-        UpdateEntityTagsAction.create(projectId, null, fromTagIds, toTagIds);
+        UpdateEntityTagsAction.create(ChangeRequestId.generate(), projectId, null, fromTagIds, toTagIds);
     }
 
     @Test
@@ -66,7 +67,7 @@ public class UpdateEntityTagsAction_TestCase {
     @SuppressWarnings("ConstantConditions")
     @Test(expected = NullPointerException.class)
     public void shouldThrowNullPointerExceptionIf_fromTagIds_IsNull() {
-        UpdateEntityTagsAction.create(projectId, entity, null, toTagIds);
+        UpdateEntityTagsAction.create(ChangeRequestId.generate(), projectId, entity, null, toTagIds);
     }
 
     @Test
@@ -77,7 +78,7 @@ public class UpdateEntityTagsAction_TestCase {
     @SuppressWarnings("ConstantConditions")
     @Test(expected = NullPointerException.class)
     public void shouldThrowNullPointerExceptionIf_toTagIds_IsNull() {
-        UpdateEntityTagsAction.create(projectId, entity, fromTagIds, null);
+        UpdateEntityTagsAction.create(ChangeRequestId.generate(), projectId, entity, fromTagIds, null);
     }
 
     @Test
@@ -98,32 +99,32 @@ public class UpdateEntityTagsAction_TestCase {
 
     @Test
     public void shouldBeEqualToOther() {
-        assertThat(action, is(UpdateEntityTagsAction.create(projectId, entity, fromTagIds, toTagIds)));
+        assertThat(action, is(UpdateEntityTagsAction.create(ChangeRequestId.generate(), projectId, entity, fromTagIds, toTagIds)));
     }
 
     @Test
     public void shouldNotBeEqualToOtherThatHasDifferent_projectId() {
-        assertThat(action, is(Matchers.not(UpdateEntityTagsAction.create(mock(ProjectId.class), entity, fromTagIds, toTagIds))));
+        assertThat(action, is(Matchers.not(UpdateEntityTagsAction.create(ChangeRequestId.generate(), mock(ProjectId.class), entity, fromTagIds, toTagIds))));
     }
 
     @Test
     public void shouldNotBeEqualToOtherThatHasDifferent_entity() {
-        assertThat(action, is(Matchers.not(UpdateEntityTagsAction.create(projectId, mock(OWLEntity.class), fromTagIds, toTagIds))));
+        assertThat(action, is(Matchers.not(UpdateEntityTagsAction.create(ChangeRequestId.generate(), projectId, mock(OWLEntity.class), fromTagIds, toTagIds))));
     }
 
     @Test
     public void shouldNotBeEqualToOtherThatHasDifferent_fromTagIds() {
-        assertThat(action, is(Matchers.not(UpdateEntityTagsAction.create(projectId, entity, Collections.singleton(mock(TagId.class)), toTagIds))));
+        assertThat(action, is(Matchers.not(UpdateEntityTagsAction.create(ChangeRequestId.generate(), projectId, entity, Collections.singleton(mock(TagId.class)), toTagIds))));
     }
 
     @Test
     public void shouldNotBeEqualToOtherThatHasDifferent_toTagIds() {
-        assertThat(action, is(Matchers.not(UpdateEntityTagsAction.create(projectId, entity, fromTagIds, Collections.singleton(mock(TagId.class))))));
+        assertThat(action, is(Matchers.not(UpdateEntityTagsAction.create(ChangeRequestId.generate(), projectId, entity, fromTagIds, Collections.singleton(mock(TagId.class))))));
     }
 
     @Test
     public void shouldBeEqualToOtherHashCode() {
-        assertThat(action.hashCode(), is(UpdateEntityTagsAction.create(projectId, entity, fromTagIds, toTagIds).hashCode()));
+        assertThat(action.hashCode(), is(UpdateEntityTagsAction.create(ChangeRequestId.generate(), projectId, entity, fromTagIds, toTagIds).hashCode()));
     }
 
     @Test


### PR DESCRIPTION
Client half of the coordinated PR pair for [webprotege-backend-api#53](https://github.com/protegeproject/webprotege-backend-api/issues/53). The companion PR in `webprotege-backend-api` pins the canonical names on the backend side; the two land together so the wire contract changes atomically.

## What this PR does

The GWT-UI and the backend services exchange typed messages over a Jackson-serialized bus. The wire contract for each message is the set of JSON field names on it. When the two sides disagree on those names, fields get silently dropped on deserialization and the backend falls back to defaults — often surfacing as the wrong outcome with no error.

This PR brings the client's wire DTOs back in sync with the backend across three buckets:

- **Surface `changeRequestId` on 24 client Actions.** The backend records always carried this field, but the client's `@JsonCreator` factories didn't accept it, so the bus silently dropped it on every call. Each affected Action now declares `changeRequestId` as a JSON property and exposes a matching getter. Touches Actions across the issues / tags / bulkop / perspectives / projects / search / graphs / discussions / change-history / merge surfaces.

- **Align 12 Events with the backend shape.** Two problems on the client side:
  - Events were missing an `eventId` field — the backend uses this to dedupe and order events on a topic, so without it, the backend couldn't track them reliably.
  - Events extend GWT's base `Event` class, which carries an internal `associatedType` field used for handler routing. Jackson was reflectively picking that up and shipping it on the wire, where the backend record had no such field.

  Fixed by adding the missing `eventId` (`@JsonProperty` first, in the position the backend record uses), and by pinning `@JsonIgnore` on the inherited `getAssociatedType()` so it stops appearing in JSON. A handful of events also had Java getters that were never part of the wire shape (e.g. `getRevisionNumber()`, `getTimestamp()`, `getUserId()` on `ProjectChangedEvent`) — those got `@JsonIgnore` too. 

  The client also gained a typed `EventId` wrapper (mirroring backend's `EventId` record): every event now carries `EventId eventId` instead of a bare `String`, matching the typed-ID convention used everywhere else on the client (`ProjectId`, `ChangeRequestId`, `FormId`, …). The wire shape is unchanged because `EventId` uses `@JsonValue` to serialize as the raw UUID string.

- **11 per-class structural reconciliations.** Each one was its own discrepancy with the backend record — field renames, missing nullable fields, or wrong `@JsonTypeName` values. Three flavours:
  - Field rename — e.g. `GetHierarchySiblingsResult`: `siblings` → `siblingsPage`.
  - Add missing field — e.g. `GetRevisionSummariesAction` gained a nullable `pageRequest` that backend already declared.
  - Fix wrong `@JsonTypeName` — e.g. `GetUserProjectEntityGraphCriteriaResult` had been claiming a sibling record's type-name (`webprotege.graphs.GetProjectEntityGraphDefaultEdgeCriteria`); corrected to match the backend record with the matching field shape.

  Backend is canonical per the issue; in-Java public method names are preserved wherever possible (e.g. `getProjectSettings()` stays put, just annotated with `@JsonProperty("settings")`) so call sites don't churn.

Surfacing `changeRequestId` on actions pulled `java.util.UUID` into the wire-DTO classes, which GWT 2.12 doesn't emulate. The PR also handles that fallout by following the codebase's existing `@GwtIncompatible` + `UuidV4Provider` pattern, and consolidates the repeated `ChangeRequestId.get(UUID.randomUUID().toString())` literal behind a single `ChangeRequestId.generate()` JVM-test helper that mirrors the existing `PerspectiveId.generate()` / `FormId.generate()` idiom.
