### PR TITLE
fix(issues): conform discussion event @JsonTypeName to plural (fix silently-dropped events)

### DIFF
--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/issues/CommentPostedEvent.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/issues/CommentPostedEvent.java
@@ -20,7 +20,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * Stanford Center for Biomedical Informatics Research
  * 11 Oct 2016
  */
-@JsonTypeName("webprotege.events.discussion.CommentPosted")
+@JsonTypeName("webprotege.events.discussions.CommentPosted")
 public class CommentPostedEvent extends ProjectEvent<CommentPostedHandler> implements HasProjectId {
 
 

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/issues/DiscussionThreadCreatedEvent.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/issues/DiscussionThreadCreatedEvent.java
@@ -13,7 +13,7 @@ import java.util.Objects;
  * Stanford Center for Biomedical Informatics Research
  * 12 Oct 2016
  */
-@JsonTypeName("webprotege.events.discussion.DiscussionThreadCreated")
+@JsonTypeName("webprotege.events.discussions.DiscussionThreadCreated")
 public class DiscussionThreadCreatedEvent extends ProjectEvent<DiscussionThreadCreatedHandler> implements HasProjectId {
 
     public static final transient Event.Type<DiscussionThreadCreatedHandler> ON_DISCUSSION_THREAD_CREATED = new Event.Type<>();

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/issues/DiscussionThreadStatusChangedEvent.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/issues/DiscussionThreadStatusChangedEvent.java
@@ -20,7 +20,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * Stanford Center for Biomedical Informatics Research
  * 12 Oct 2016
  */
-@JsonTypeName("webprotege.events.discussion.DiscussionThreadStatusChanged")
+@JsonTypeName("webprotege.events.discussions.DiscussionThreadStatusChanged")
 public class DiscussionThreadStatusChangedEvent extends ProjectEvent<DiscussionThreadStatusChangedHandler> {
 
     public static final transient Event.Type<DiscussionThreadStatusChangedHandler> ON_STATUS_CHANGED = new Event.Type<>();


### PR DESCRIPTION
## Summary

Substantive fix for the NEAR_MISS `@JsonTypeName` drift described in protegeproject/webprotege-backend-api#54.

The client declared three discussion events with the **singular** `webprotege.events.discussion.*` discriminator, while the backend publishes them under the canonical **plural** `webprotege.events.discussions.*`. Because the JSON-RPC envelope routes messages by `@JsonTypeName`, these events never reached the deserializer — they were **silently dropped on the wire** (no error on either side).

## What changed

Renamed the discriminator on three events in `webprotege-gwt-ui-shared` (singular → plural):

| Event | Before | After |
| --- | --- | --- |
| `CommentPostedEvent` | `…events.discussion.CommentPosted` | `…events.discussions.CommentPosted` |
| `DiscussionThreadStatusChangedEvent` | `…events.discussion.DiscussionThreadStatusChanged` | `…events.discussions.DiscussionThreadStatusChanged` |
| `DiscussionThreadCreatedEvent` | `…events.discussion.DiscussionThreadCreated` | `…events.discussions.DiscussionThreadCreated` |

`CommentUpdatedEvent` was already plural. The whole discussion namespace now uses the plural form, matching the backend on both sides.

`DiscussionThreadCreated` is kept and conformed to plural (rather than deleted): the backend already emits the matching plural record, so that record stays canonical.

## Verification

- Conformance audit (`tools/audit_json_conformance.py`) now reports **`NEAR_MISS=0`** (was 2), no `discussion.` singulars remaining in the namespace.
- `EventsSerializationTestCase` → **23/23 pass**; each discussion event now round-trips through the polymorphic `WebProtegeEvent` base type emitting the plural `@type` (i.e. routing works end-to-end on the client — the smoke test from the issue's acceptance criteria).

## Related

- Backend guard tests pinning the canonical plural discriminators: protegeproject/webprotege-backend-api#62
- Field-set drift (`eventId`/`projectId` vs `associatedType`) is the separate MISMATCH bucket tracked in protegeproject/webprotege-backend-api#53 and is intentionally out of scope here.

Closes protegeproject/webprotege-backend-api#54