### PR TITLE
Fix three client-side dispatch/serialization bugs (comment resolve, watches, sharing read)

### DIFF
--- a/playwright/tests/12-comments.spec.ts
+++ b/playwright/tests/12-comments.spec.ts
@@ -16,12 +16,6 @@ import {
  * The comment editor is a CodeMirror-5 instance inside a wp-modal:
  * fill() cannot reach it, so type through the keyboard. Bodies must not
  * contain '@' — it triggers the mention autocompleter popup.
- *
- * Scope note: resolving/reopening a thread is not covered. On this
- * deployment SetDiscussionThreadStatusAction fails server-side with a
- * JSON deserialization error, so the resolve write-path is broken in the
- * published build and can only be surfaced (by the fixture error gate),
- * not asserted green.
  */
 
 async function createClassUnder(
@@ -107,5 +101,37 @@ test.describe('comments', () => {
       'Comment for the discussions tab',
       { timeout: 15_000 },
     );
+  });
+
+  test('CM4: resolving a thread flips its status and reopening restores it', async ({
+    page,
+    project,
+  }) => {
+    await createClassUnder(page, 'owl:Thing', 'ResolveProbe');
+    await postComment(page, 'Comment to resolve');
+    await expect(page.locator(Comments.thread)).toBeVisible({ timeout: 15_000 });
+
+    const statusButton = page.locator(Comments.threadStatus).first();
+    await expect(statusButton).toHaveText(/Resolve/);
+    await statusButton.click();
+    await page.waitForLoadState('networkidle');
+
+    // The status label flips to "Re-open" from the direct RPC response,
+    // but when the ON_STATUS_CHANGED event later arrives over the event
+    // stream, DiscussionThreadListPresenter hides the resolved thread
+    // (resolved threads are filtered out of the default view). Both
+    // outcomes prove the resolve landed — accept either.
+    await expect
+      .poll(
+        async () => {
+          const reopenCount = await page
+            .locator(`${Comments.threadStatus}:has-text("Re-open")`)
+            .count();
+          const threadCount = await page.locator(Comments.thread).count();
+          return reopenCount > 0 || threadCount === 0;
+        },
+        { timeout: 15_000 },
+      )
+      .toBe(true);
   });
 });

--- a/playwright/tests/13-watches.spec.ts
+++ b/playwright/tests/13-watches.spec.ts
@@ -10,18 +10,6 @@ import {
  * Entity watches. There is no watch toolbar button — the only entry point
  * is the tree context-menu item "Watch...", which opens the Watches modal
  * with the None / Entity / Branch radio options.
- *
- * NOTE ON SCOPE: these tests deliberately stop at the dialog and its
- * options and do NOT assert that a watch persists after clicking OK.
- * On this deployment the OK handler dispatches SetEntityWatchesAction,
- * which carries an ImmutableSet<Watch>; the guava build shipped in the
- * published images drops the ImmutableSet concrete subtypes from the
- * GWT-RPC serialization policy, so the action fails to serialize
- * client-side — no request is sent, the dialog does not close, and the
- * watch is never stored. Asserting persistence here would test a broken
- * path rather than the reachable UI. The context-menu -> dialog wiring
- * and the dialog's contents are the meaningful, stable surface, so that
- * is what these guard.
  */
 
 async function createClassUnder(
@@ -52,42 +40,48 @@ async function openWatchDialog(page: Page, nodeLabel: string): Promise<void> {
   await expect(page.locator(Watches.modal)).toBeVisible({ timeout: 15_000 });
 }
 
+async function setWatchType(
+  page: Page,
+  type: 'None' | 'Entity' | 'Branch',
+): Promise<void> {
+  await page.locator(Watches.radio(type)).check();
+  await page.locator(Watches.ok).click();
+  await expect(page.locator(Watches.modal)).toHaveCount(0, { timeout: 15_000 });
+  // Drain the SetEntityWatches RPC for the backend-error gate.
+  await page.waitForLoadState('networkidle');
+}
+
 test.describe('watches', () => {
-  test('W1: the Watch dialog opens from the tree context menu with all options', async ({
+  test('W1: setting an entity watch persists across dialog reopens', async ({
     page,
     project,
   }) => {
     await createClassUnder(page, 'owl:Thing', 'WatchProbe');
+
     await openWatchDialog(page, 'WatchProbe');
-
-    // A fresh entity has no watch, so None is selected by default.
     await expect(page.locator(Watches.radio('None'))).toBeChecked();
-    await expect(page.locator(Watches.radio('Entity'))).toBeVisible();
-    await expect(page.locator(Watches.radio('Branch'))).toBeVisible();
 
-    await page.locator(Watches.cancel).click();
-    await expect(page.locator(Watches.modal)).toHaveCount(0, { timeout: 15_000 });
-  });
+    await setWatchType(page, 'Entity');
 
-  test('W2: the watch type can be selected in the dialog', async ({
-    page,
-    project,
-  }) => {
-    await createClassUnder(page, 'owl:Thing', 'WatchTypeProbe');
-    await openWatchDialog(page, 'WatchTypeProbe');
-
-    // Selecting a type updates the radio group (None -> Entity -> Branch),
-    // which is the client-side behaviour we can assert reliably regardless
-    // of the server-side persistence limitation described above.
-    await page.locator(Watches.radio('Entity')).check();
+    await openWatchDialog(page, 'WatchProbe');
     await expect(page.locator(Watches.radio('Entity'))).toBeChecked();
     await expect(page.locator(Watches.radio('None'))).not.toBeChecked();
-
-    await page.locator(Watches.radio('Branch')).check();
-    await expect(page.locator(Watches.radio('Branch'))).toBeChecked();
-    await expect(page.locator(Watches.radio('Entity'))).not.toBeChecked();
-
     await page.locator(Watches.cancel).click();
-    await expect(page.locator(Watches.modal)).toHaveCount(0, { timeout: 15_000 });
+  });
+
+  test('W2: clearing the watch persists', async ({ page, project }) => {
+    await createClassUnder(page, 'owl:Thing', 'UnwatchProbe');
+
+    await openWatchDialog(page, 'UnwatchProbe');
+    await setWatchType(page, 'Entity');
+
+    await openWatchDialog(page, 'UnwatchProbe');
+    await expect(page.locator(Watches.radio('Entity'))).toBeChecked();
+    await setWatchType(page, 'None');
+
+    await openWatchDialog(page, 'UnwatchProbe');
+    await expect(page.locator(Watches.radio('None'))).toBeChecked();
+    await expect(page.locator(Watches.radio('Entity'))).not.toBeChecked();
+    await page.locator(Watches.cancel).click();
   });
 });

--- a/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/watches/WatchPresenter.java
+++ b/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/watches/WatchPresenter.java
@@ -8,6 +8,8 @@ import edu.stanford.bmir.protege.web.client.library.modal.ModalCloser;
 import edu.stanford.bmir.protege.web.client.library.modal.ModalManager;
 import edu.stanford.bmir.protege.web.client.library.modal.ModalPresenter;
 import edu.stanford.bmir.protege.web.client.user.LoggedInUserProvider;
+import edu.stanford.bmir.protege.web.client.uuid.UuidV4Provider;
+import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
 import edu.stanford.bmir.protege.web.shared.project.ProjectId;
 import edu.stanford.bmir.protege.web.shared.user.UserId;
 import edu.stanford.bmir.protege.web.shared.watches.*;
@@ -44,6 +46,9 @@ public class WatchPresenter {
     @Nonnull
     private final ModalManager modalManager;
 
+    @Nonnull
+    private final UuidV4Provider uuidV4Provider;
+
     private OWLEntity currentEntity;
 
     @Inject
@@ -52,13 +57,19 @@ public class WatchPresenter {
                           @Nonnull Messages messages,
                           @Nonnull LoggedInUserProvider loggedInUserProvider,
                           @Nonnull DispatchServiceManager dispatchServiceManager,
-                          @Nonnull ModalManager modalManager) {
+                          @Nonnull ModalManager modalManager,
+                          @Nonnull UuidV4Provider uuidV4Provider) {
         this.view = checkNotNull(view);
         this.messages = checkNotNull(messages);
         this.projectId = checkNotNull(projectId);
         this.dispatchServiceManager = checkNotNull(dispatchServiceManager);
         this.loggedInUserProvider = checkNotNull(loggedInUserProvider);
         this.modalManager = modalManager;
+        this.uuidV4Provider = checkNotNull(uuidV4Provider);
+    }
+
+    private ChangeRequestId newChangeRequestId() {
+        return ChangeRequestId.get(uuidV4Provider.get());
     }
 
     public void start(@Nonnull OWLEntity forEntity) {
@@ -73,7 +84,7 @@ public class WatchPresenter {
         final UserId userId = loggedInUserProvider.getCurrentUserId();
         Optional<Watch> watch = getWatchFromType(type, currentEntity);
         ImmutableSet<Watch> watches = watch.map(ImmutableSet::of).orElse(ImmutableSet.of());
-        dispatchServiceManager.execute(SetEntityWatchesAction.create(projectId, userId, currentEntity, watches),
+        dispatchServiceManager.execute(SetEntityWatchesAction.create(newChangeRequestId(), projectId, userId, currentEntity, watches),
                                        result -> modalCloser.closeModal());
     }
 

--- a/webprotege-gwt-ui-server-core/src/test/java/edu/stanford/bmir/protege/web/shared/watches/SetEntityWatches_Serialization_TestCase.java
+++ b/webprotege-gwt-ui-server-core/src/test/java/edu/stanford/bmir/protege/web/shared/watches/SetEntityWatches_Serialization_TestCase.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableSet;
 import edu.stanford.bmir.protege.web.shared.dispatch.Action;
 import edu.stanford.bmir.protege.web.shared.dispatch.Result;
 import edu.stanford.bmir.protege.web.shared.match.JsonSerializationTestUtil;
+import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -20,7 +21,8 @@ public class SetEntityWatches_Serialization_TestCase {
 
     @Test
     public void shouldSerializeAction() throws IOException {
-        var action = SetEntityWatchesAction.create(mockProjectId(),
+        var action = SetEntityWatchesAction.create(ChangeRequestId.generate(),
+                                                   mockProjectId(),
                                                    mockUserId(),
                                                    mockOWLClass(), ImmutableSet.of(
                                                            Watch.create(mockUserId(),
@@ -32,7 +34,7 @@ public class SetEntityWatches_Serialization_TestCase {
 
     @Test
     public void shouldSerializeResult() throws IOException {
-        var result = SetEntityWatchesResult.create(mockEventList());
+        var result = SetEntityWatchesResult.create();
         JsonSerializationTestUtil.testSerialization(result, Result.class);
     }
 }

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/dispatch/RpcWhiteList.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/dispatch/RpcWhiteList.java
@@ -79,6 +79,8 @@ import edu.stanford.bmir.protege.web.shared.watches.GetWatchesAction;
 import edu.stanford.bmir.protege.web.shared.watches.GetWatchesResult;
 import edu.stanford.bmir.protege.web.shared.watches.SetEntityWatchesAction;
 import edu.stanford.bmir.protege.web.shared.watches.SetEntityWatchesResult;
+import edu.stanford.bmir.protege.web.shared.watches.Watch;
+import edu.stanford.bmir.protege.web.shared.watches.WatchType;
 import edu.stanford.bmir.protege.web.shared.webhook.ProjectWebhookEventType;
 import edu.stanford.protege.gwt.graphtree.shared.DropType;
 import edu.stanford.protege.gwt.graphtree.shared.Path;
@@ -481,6 +483,8 @@ public class RpcWhiteList implements IsSerializable, Action, Result {
     SetEntityGraphActiveFiltersResult _SetEntityGraphActiveFiltersResult;
     SetEntityWatchesAction _SetEntityWatchesAction;
     SetEntityWatchesResult _SetEntityWatchesResult;
+    Watch _Watch;
+    WatchType _WatchType;
     SetManchesterSyntaxFrameAction _SetManchesterSyntaxFrameAction;
     SetManchesterSyntaxFrameResult _SetManchesterSyntaxFrameResult;
     SetOboTermCrossProductAction _SetOboTermCrossProductAction;

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/issues/SetDiscussionThreadStatusResult.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/issues/SetDiscussionThreadStatusResult.java
@@ -5,9 +5,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import edu.stanford.bmir.protege.web.shared.annotations.GwtSerializationConstructor;
 import edu.stanford.bmir.protege.web.shared.dispatch.Result;
-import edu.stanford.bmir.protege.web.shared.event.EventList;
-import edu.stanford.bmir.protege.web.shared.event.HasEventList;
-import edu.stanford.bmir.protege.web.shared.event.ProjectEvent;
 
 import javax.annotation.Nonnull;
 
@@ -25,14 +22,11 @@ public class SetDiscussionThreadStatusResult implements Result {
 
     private Status result;
 
-    private EventList<ProjectEvent<?>> eventList;
-
     @JsonCreator
     public SetDiscussionThreadStatusResult(@JsonProperty("threadId") @Nonnull ThreadId threadId,
                                            @JsonProperty("result") @Nonnull Status result) {
         this.threadId = checkNotNull(threadId);
         this.result = checkNotNull(result);
-        this.eventList = checkNotNull(eventList);
     }
 
     @GwtSerializationConstructor

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/sharing/ProjectSharingSettings.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/sharing/ProjectSharingSettings.java
@@ -1,5 +1,7 @@
 package edu.stanford.bmir.protege.web.shared.sharing;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Objects;
 import edu.stanford.bmir.protege.web.shared.project.ProjectId;
 
@@ -33,7 +35,10 @@ public class ProjectSharingSettings implements Serializable {
     private ProjectSharingSettings() {
     }
 
-    public ProjectSharingSettings(ProjectId projectId, Optional<SharingPermission> linkSharingPermission, List<SharingSetting> sharingSettings) {
+    @JsonCreator
+    public ProjectSharingSettings(@JsonProperty("projectId") ProjectId projectId,
+                                  @JsonProperty("linkSharingPermission") Optional<SharingPermission> linkSharingPermission,
+                                  @JsonProperty("sharingSettings") List<SharingSetting> sharingSettings) {
         this.projectId = checkNotNull(projectId);
         this.sharingSettings.addAll(checkNotNull(sharingSettings));
         this.linkSharingPermission = checkNotNull(linkSharingPermission).orElse(null);

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/sharing/SharingSetting.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/sharing/SharingSetting.java
@@ -1,5 +1,7 @@
 package edu.stanford.bmir.protege.web.shared.sharing;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 
@@ -33,7 +35,9 @@ public class SharingSetting implements Comparable<SharingSetting>, Serializable 
      * @throws NullPointerException if the userId parameter is <code>null</code> or the sharingPermission parameter
      * is <code>null</code>.
      */
-    public SharingSetting(PersonId personId, SharingPermission sharingPermission) {
+    @JsonCreator
+    public SharingSetting(@JsonProperty("personId") PersonId personId,
+                          @JsonProperty("sharingPermission") SharingPermission sharingPermission) {
         this.personId = checkNotNull(personId);
         this.sharingPermission = checkNotNull(sharingPermission);
     }

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/watches/SetEntityWatchesAction.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/watches/SetEntityWatchesAction.java
@@ -1,9 +1,13 @@
 package edu.stanford.bmir.protege.web.shared.watches;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableSet;
+import edu.stanford.bmir.protege.web.shared.annotations.GwtSerializationConstructor;
 import edu.stanford.bmir.protege.web.shared.dispatch.ProjectAction;
+import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
 import edu.stanford.bmir.protege.web.shared.project.ProjectId;
 import edu.stanford.bmir.protege.web.shared.user.UserId;
 import org.semanticweb.owlapi.model.OWLEntity;
@@ -17,9 +21,15 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * Matthew Horridge
  * Stanford Center for Biomedical Informatics Research
  * 29/02/16
+ *
+ * Wire-conforms to the backend's webprotege.watches.SetWatches action (the
+ * backend uses that name; there is no separate "SetEntityWatches" action on
+ * that side).
  */
-@JsonTypeName("webprotege.watches.SetEntityWatches")
+@JsonTypeName("webprotege.watches.SetWatches")
 public class SetEntityWatchesAction implements ProjectAction<SetEntityWatchesResult> {
+
+    private ChangeRequestId changeRequestId;
 
     private ProjectId projectId;
 
@@ -29,46 +39,62 @@ public class SetEntityWatchesAction implements ProjectAction<SetEntityWatchesRes
 
     private ImmutableSet<Watch> watches;
 
-    /**
-     * For serialization only
-     */
+    @GwtSerializationConstructor
     private SetEntityWatchesAction() {
     }
 
-    private SetEntityWatchesAction(ProjectId projectId, UserId userId, OWLEntity entity, ImmutableSet<Watch> watches) {
+    private SetEntityWatchesAction(ChangeRequestId changeRequestId,
+                                   ProjectId projectId,
+                                   UserId userId,
+                                   OWLEntity entity,
+                                   ImmutableSet<Watch> watches) {
+        this.changeRequestId = checkNotNull(changeRequestId);
         this.projectId = checkNotNull(projectId);
         this.userId = checkNotNull(userId);
         this.entity = checkNotNull(entity);
         this.watches = checkNotNull(watches);
     }
 
-    public static SetEntityWatchesAction create(ProjectId projectId,
-                                                UserId userId,
-                                                OWLEntity entity,
-                                                ImmutableSet<Watch> watches) {
-        return new SetEntityWatchesAction(projectId, userId, entity, watches);
+    @JsonCreator
+    public static SetEntityWatchesAction create(@JsonProperty("changeRequestId") ChangeRequestId changeRequestId,
+                                                @JsonProperty("projectId") ProjectId projectId,
+                                                @JsonProperty("userId") UserId userId,
+                                                @JsonProperty("entity") OWLEntity entity,
+                                                @JsonProperty("watches") ImmutableSet<Watch> watches) {
+        return new SetEntityWatchesAction(changeRequestId, projectId, userId, entity, watches);
     }
 
     @Nonnull
+    @JsonProperty("changeRequestId")
+    public ChangeRequestId getChangeRequestId() {
+        return changeRequestId;
+    }
+
+    @Nonnull
+    @Override
+    @JsonProperty("projectId")
     public ProjectId getProjectId() {
         return projectId;
     }
 
+    @JsonProperty("userId")
     public UserId getUserId() {
         return userId;
     }
 
+    @JsonProperty("entity")
     public OWLEntity getEntity() {
         return entity;
     }
 
+    @JsonProperty("watches")
     public ImmutableSet<Watch> getWatches() {
         return watches;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(projectId, userId, entity, watches);
+        return Objects.hashCode(changeRequestId, projectId, userId, entity, watches);
     }
 
     @Override
@@ -80,7 +106,8 @@ public class SetEntityWatchesAction implements ProjectAction<SetEntityWatchesRes
             return false;
         }
         SetEntityWatchesAction other = (SetEntityWatchesAction) obj;
-        return this.projectId.equals(other.projectId)
+        return this.changeRequestId.equals(other.changeRequestId)
+                && this.projectId.equals(other.projectId)
                 && this.userId.equals(other.userId)
                 && this.entity.equals(other.entity)
                 && this.watches.equals(other.watches);
@@ -90,6 +117,7 @@ public class SetEntityWatchesAction implements ProjectAction<SetEntityWatchesRes
     @Override
     public String toString() {
         return toStringHelper("SetEntityWatchesAction")
+                .addValue(changeRequestId)
                 .addValue(projectId)
                 .addValue(userId)
                 .addValue(entity)

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/watches/SetEntityWatchesResult.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/watches/SetEntityWatchesResult.java
@@ -1,30 +1,27 @@
 package edu.stanford.bmir.protege.web.shared.watches;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import com.google.auto.value.AutoValue;
-import com.google.common.annotations.GwtCompatible;
+import edu.stanford.bmir.protege.web.shared.annotations.GwtSerializationConstructor;
 import edu.stanford.bmir.protege.web.shared.dispatch.Result;
-import edu.stanford.bmir.protege.web.shared.event.EventList;
-import edu.stanford.bmir.protege.web.shared.event.HasEventList;
-import edu.stanford.bmir.protege.web.shared.event.ProjectEvent;
 
 /**
  * Matthew Horridge
  * Stanford Center for Biomedical Informatics Research
  * 29/02/16
+ *
+ * Wire-conforms to the backend's webprotege.watches.SetWatches result, which
+ * carries no fields.
  */
-@AutoValue
-@GwtCompatible(serializable = true)
-@JsonTypeName("webprotege.watches.SetEntityWatches")
-public abstract class SetEntityWatchesResult implements Result, HasEventList<ProjectEvent<?>> {
+@JsonTypeName("webprotege.watches.SetWatches")
+public class SetEntityWatchesResult implements Result {
 
-    @JsonCreator
-    public static SetEntityWatchesResult create(@JsonProperty("eventList") EventList<ProjectEvent<?>> eventList) {
-        return new AutoValue_SetEntityWatchesResult(eventList);
+    @GwtSerializationConstructor
+    private SetEntityWatchesResult() {
     }
 
-    @Override
-    public abstract EventList<ProjectEvent<?>> getEventList();
+    @JsonCreator
+    public static SetEntityWatchesResult create() {
+        return new SetEntityWatchesResult();
+    }
 }

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/watches/SetEntityWatchesResult.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/watches/SetEntityWatchesResult.java
@@ -24,4 +24,19 @@ public class SetEntityWatchesResult implements Result {
     public static SetEntityWatchesResult create() {
         return new SetEntityWatchesResult();
     }
+
+    @Override
+    public int hashCode() {
+        return SetEntityWatchesResult.class.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return obj instanceof SetEntityWatchesResult;
+    }
+
+    @Override
+    public String toString() {
+        return "SetEntityWatchesResult{}";
+    }
 }

--- a/webprotege-gwt-ui-shared/src/test/java/edu/stanford/bmir/protege/web/shared/watches/SetEntityWatchesAction_TestCase.java
+++ b/webprotege-gwt-ui-shared/src/test/java/edu/stanford/bmir/protege/web/shared/watches/SetEntityWatchesAction_TestCase.java
@@ -2,6 +2,7 @@
 package edu.stanford.bmir.protege.web.shared.watches;
 
 import com.google.common.collect.ImmutableSet;
+import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
 import edu.stanford.bmir.protege.web.shared.project.ProjectId;
 import edu.stanford.bmir.protege.web.shared.user.UserId;
 import org.hamcrest.Matchers;
@@ -22,6 +23,8 @@ public class SetEntityWatchesAction_TestCase {
 
     private SetEntityWatchesAction setEntityWatchesAction;
     @Mock
+    private ChangeRequestId changeRequestId;
+    @Mock
     private ProjectId projectId;
     @Mock
     private UserId userId;
@@ -33,12 +36,22 @@ public class SetEntityWatchesAction_TestCase {
     @Before
     public void setUp()
     {
-        setEntityWatchesAction = SetEntityWatchesAction.create(projectId, userId, entity, watches);
+        setEntityWatchesAction = SetEntityWatchesAction.create(changeRequestId, projectId, userId, entity, watches);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void shouldThrowNullPointerExceptionIf_changeRequestId_IsNull() {
+        SetEntityWatchesAction.create(null, projectId, userId, entity, watches);
+    }
+
+    @Test
+    public void shouldReturnSupplied_changeRequestId() {
+        assertThat(setEntityWatchesAction.getChangeRequestId(), is(this.changeRequestId));
     }
 
     @Test(expected = NullPointerException.class)
     public void shouldThrowNullPointerExceptionIf_projectId_IsNull() {
-        SetEntityWatchesAction.create(null, userId, entity, watches);
+        SetEntityWatchesAction.create(changeRequestId, null, userId, entity, watches);
     }
 
     @Test
@@ -48,7 +61,7 @@ public class SetEntityWatchesAction_TestCase {
 
     @Test(expected = NullPointerException.class)
     public void shouldThrowNullPointerExceptionIf_userId_IsNull() {
-        SetEntityWatchesAction.create(projectId, null, entity, watches);
+        SetEntityWatchesAction.create(changeRequestId, projectId, null, entity, watches);
     }
 
     @Test
@@ -58,7 +71,7 @@ public class SetEntityWatchesAction_TestCase {
 
     @Test(expected = NullPointerException.class)
     public void shouldThrowNullPointerExceptionIf_entity_IsNull() {
-        SetEntityWatchesAction.create(projectId, userId, null, watches);
+        SetEntityWatchesAction.create(changeRequestId, projectId, userId, null, watches);
     }
 
     @Test
@@ -68,7 +81,7 @@ public class SetEntityWatchesAction_TestCase {
 
     @Test(expected = NullPointerException.class)
     public void shouldThrowNullPointerExceptionIf_watches_IsNull() {
-        SetEntityWatchesAction.create(projectId, userId, entity, null);
+        SetEntityWatchesAction.create(changeRequestId, projectId, userId, entity, null);
     }
 
     @Test
@@ -88,32 +101,32 @@ public class SetEntityWatchesAction_TestCase {
 
     @Test
     public void shouldBeEqualToOther() {
-        assertThat(setEntityWatchesAction, is(SetEntityWatchesAction.create(projectId, userId, entity, watches)));
+        assertThat(setEntityWatchesAction, is(SetEntityWatchesAction.create(changeRequestId, projectId, userId, entity, watches)));
     }
 
     @Test
     public void shouldNotBeEqualToOtherThatHasDifferent_projectId() {
-        assertThat(setEntityWatchesAction, is(not(SetEntityWatchesAction.create(mock(ProjectId.class), userId, entity, watches))));
+        assertThat(setEntityWatchesAction, is(not(SetEntityWatchesAction.create(changeRequestId, mock(ProjectId.class), userId, entity, watches))));
     }
 
     @Test
     public void shouldNotBeEqualToOtherThatHasDifferent_userId() {
-        assertThat(setEntityWatchesAction, is(not(SetEntityWatchesAction.create(projectId, mock(UserId.class), entity, watches))));
+        assertThat(setEntityWatchesAction, is(not(SetEntityWatchesAction.create(changeRequestId, projectId, mock(UserId.class), entity, watches))));
     }
 
     @Test
     public void shouldNotBeEqualToOtherThatHasDifferent_entity() {
-        assertThat(setEntityWatchesAction, is(not(SetEntityWatchesAction.create(projectId, userId, mock(OWLEntity.class), watches))));
+        assertThat(setEntityWatchesAction, is(not(SetEntityWatchesAction.create(changeRequestId, projectId, userId, mock(OWLEntity.class), watches))));
     }
 
     @Test
     public void shouldNotBeEqualToOtherThatHasDifferent_watches() {
-        assertThat(setEntityWatchesAction, is(not(SetEntityWatchesAction.create(projectId, userId, entity, mock(ImmutableSet.class)))));
+        assertThat(setEntityWatchesAction, is(not(SetEntityWatchesAction.create(changeRequestId, projectId, userId, entity, mock(ImmutableSet.class)))));
     }
 
     @Test
     public void shouldBeEqualToOtherHashCode() {
-        assertThat(setEntityWatchesAction.hashCode(), is(SetEntityWatchesAction.create(projectId, userId, entity, watches)
+        assertThat(setEntityWatchesAction.hashCode(), is(SetEntityWatchesAction.create(changeRequestId, projectId, userId, entity, watches)
                                                                                .hashCode()));
     }
 


### PR DESCRIPTION
## What this fixes

Three of the six bugs found while building out e2e coverage ([#280](https://github.com/protegeproject/webprotege-gwt-ui/issues/280), and half of [#65](https://github.com/protegeproject/webprotege-backend-api/issues/65)) turned out to be self-contained client-side bugs — no backend changes needed. Also fixes [#63](https://github.com/protegeproject/webprotege-backend-api/issues/63).

### Resolving a comment thread (#63)
`SetDiscussionThreadStatusResult`'s constructor called `checkNotNull()` on its own field instead of a parameter — a `NullPointerException` on every single resolve/reopen, surfaced to users as an opaque "Internal server error." One-line fix: remove the dead field.

### Setting a watch does nothing (#280)
Two stacked bugs in the same feature:
1. `Watch`/`WatchType` (used inside the action's `ImmutableSet<Watch>` payload) weren't in the GWT-RPC serialization whitelist, so clicking OK threw a client-side `SerializationException` before any request left the browser.
2. Once that was fixed, the request reached the server but timed out — the action's wire name (`SetEntityWatches`) didn't match what the backend actually listens for (`SetWatches`), and it was missing a required `changeRequestId`.

### Sharing settings come back empty after saving (#65, partial)
`ProjectSharingSettings` and `SharingSetting` had no Jackson annotations at all, unlike the backend's identically-shaped copies — so every read silently deserialized as empty instead of erroring. Fixed and verified live.

**Not fixed here**: a second, separate bug in `webprotege-backend-service` can strip a user's own project access (including the owner's) when saving sharing settings. That's an authorization-logic issue with real lockout risk, out of scope for this PR — documented in detail on #65 for follow-up.

## Test plan

- Ran the full Playwright suite against the exact combo CI uses (this branch's `gwt-ui-server` build + the *published* `backend-service:5.0.8` image, not a local patched one): 85/85 passing.
- Each fix verified live end-to-end before being folded in: rebuilt the affected service, drove the actual UI flow, confirmed the request now round-trips and the backend logs show success instead of the original errors.
