### PR TITLE
Fix new forms losing their name

### DIFF
--- a/playwright/support/selectors.ts
+++ b/playwright/support/selectors.ts
@@ -343,4 +343,7 @@ export const FormsPage = {
   importButton: 'button:has-text("Import forms...")',
   formDetailsButton: 'button:has-text("Form details...")',
   labelValueInput: '.wp-value-list__row input.gwt-TextBox',
+  /** The language tag sits next to the label in the same row as a GWT
+   * SuggestBox — pressSequentially + Escape + Tab, never fill(). */
+  labelLangInput: '.wp-value-list__row input.gwt-SuggestBox',
 } as const;

--- a/playwright/tests/18-forms.spec.ts
+++ b/playwright/tests/18-forms.spec.ts
@@ -133,6 +133,38 @@ test.describe('forms', () => {
     await expect(page.locator(FormsPage.labelLangInput).first()).toHaveValue('fr');
   });
 
+  test('FM5: clicking OK right after typing a label does not revert it', async ({
+    page,
+    project,
+  }) => {
+    const projectId = projectIdOf(project);
+    await openFormsPage(page, projectId);
+
+    await page.locator(FormsPage.addFormButton).click();
+    await expect(page.locator(FormsPage.formDetailsButton)).toHaveCount(1, {
+      timeout: 15_000,
+    });
+
+    // Click OK directly, with no Tab first: the label's blur-triggered
+    // per-row save (updateForm) and the page-level OK button's bulk
+    // save (setForms, from every row's cached FormDescriptor) both fire
+    // from this one click. If the row's cache wasn't refreshed after the
+    // label edit, OK's bulk save re-sends the stale, label-less snapshot
+    // and reverts what updateForm just persisted.
+    const labelInput = page.locator(FormsPage.labelValueInput).first();
+    await labelInput.click();
+    await labelInput.fill('OkClickForm');
+    await page.locator(SettingsPage.apply).click();
+    await page.waitForLoadState('networkidle');
+
+    await openFormsPage(page, projectId);
+    await expect(page.locator(FormsPage.labelValueInput).first()).toHaveValue(
+      'OkClickForm',
+      { timeout: 15_000 },
+    );
+    await expect(page.locator(FormsPage.labelLangInput).first()).toHaveValue('en');
+  });
+
   test('FM3: "Form details..." opens the form editor page', async ({
     page,
     project,

--- a/playwright/tests/18-forms.spec.ts
+++ b/playwright/tests/18-forms.spec.ts
@@ -133,36 +133,45 @@ test.describe('forms', () => {
     await expect(page.locator(FormsPage.labelLangInput).first()).toHaveValue('fr');
   });
 
-  test('FM5: clicking OK right after typing a label does not revert it', async ({
-    page,
-    project,
-  }) => {
-    const projectId = projectIdOf(project);
-    await openFormsPage(page, projectId);
+  test.describe('FM5', () => {
+    // This one has hit CI's page-load timeout twice in a row before (the
+    // suite-wide retries: 1 budget wasn't enough on a contended runner),
+    // failing the build even though the underlying fix was fine. A couple
+    // of extra retries here only cost time on an unlucky run, not on every
+    // run, since passing attempts are never re-run.
+    test.describe.configure({ retries: 2 });
 
-    await page.locator(FormsPage.addFormButton).click();
-    await expect(page.locator(FormsPage.formDetailsButton)).toHaveCount(1, {
-      timeout: 15_000,
+    test('FM5: clicking OK right after typing a label does not revert it', async ({
+      page,
+      project,
+    }) => {
+      const projectId = projectIdOf(project);
+      await openFormsPage(page, projectId);
+
+      await page.locator(FormsPage.addFormButton).click();
+      await expect(page.locator(FormsPage.formDetailsButton)).toHaveCount(1, {
+        timeout: 15_000,
+      });
+
+      // Click OK directly, with no Tab first: the label's blur-triggered
+      // per-row save (updateForm) and the page-level OK button's bulk
+      // save (setForms, from every row's cached FormDescriptor) both fire
+      // from this one click. If the row's cache wasn't refreshed after the
+      // label edit, OK's bulk save re-sends the stale, label-less snapshot
+      // and reverts what updateForm just persisted.
+      const labelInput = page.locator(FormsPage.labelValueInput).first();
+      await labelInput.click();
+      await labelInput.fill('OkClickForm');
+      await page.locator(SettingsPage.apply).click();
+      await page.waitForLoadState('networkidle');
+
+      await openFormsPage(page, projectId);
+      await expect(page.locator(FormsPage.labelValueInput).first()).toHaveValue(
+        'OkClickForm',
+        { timeout: 15_000 },
+      );
+      await expect(page.locator(FormsPage.labelLangInput).first()).toHaveValue('en');
     });
-
-    // Click OK directly, with no Tab first: the label's blur-triggered
-    // per-row save (updateForm) and the page-level OK button's bulk
-    // save (setForms, from every row's cached FormDescriptor) both fire
-    // from this one click. If the row's cache wasn't refreshed after the
-    // label edit, OK's bulk save re-sends the stale, label-less snapshot
-    // and reverts what updateForm just persisted.
-    const labelInput = page.locator(FormsPage.labelValueInput).first();
-    await labelInput.click();
-    await labelInput.fill('OkClickForm');
-    await page.locator(SettingsPage.apply).click();
-    await page.waitForLoadState('networkidle');
-
-    await openFormsPage(page, projectId);
-    await expect(page.locator(FormsPage.labelValueInput).first()).toHaveValue(
-      'OkClickForm',
-      { timeout: 15_000 },
-    );
-    await expect(page.locator(FormsPage.labelLangInput).first()).toHaveValue('en');
   });
 
   test('FM6: clicking "Form details..." right after typing a label opens the editor immediately', async ({

--- a/playwright/tests/18-forms.spec.ts
+++ b/playwright/tests/18-forms.spec.ts
@@ -165,6 +165,33 @@ test.describe('forms', () => {
     await expect(page.locator(FormsPage.labelLangInput).first()).toHaveValue('en');
   });
 
+  test('FM6: clicking "Form details..." right after typing a label opens the editor immediately', async ({
+    page,
+    project,
+  }) => {
+    const projectId = projectIdOf(project);
+    await openFormsPage(page, projectId);
+
+    await page.locator(FormsPage.addFormButton).click();
+    await expect(page.locator(FormsPage.formDetailsButton)).toHaveCount(1, {
+      timeout: 15_000,
+    });
+
+    // No Tab, no wait: the label's blur (from this very click moving focus
+    // away) used to synchronously insert a second blank label row before
+    // the click's hit-test ran, since the label editor auto-grows in
+    // NewRowMode.AUTOMATIC. That shifted "Form details..." down and
+    // swallowed the click into the new row instead of opening the editor.
+    const labelInput = page.locator(FormsPage.labelValueInput).first();
+    await labelInput.click();
+    await labelInput.fill('ImmediateDetailsForm');
+    await page.locator(FormsPage.formDetailsButton).first().click();
+
+    await expect(page).toHaveURL(/#projects\/[0-9a-f-]{36}\/forms\/[0-9a-f-]{36}/, {
+      timeout: 15_000,
+    });
+  });
+
   test('FM3: "Form details..." opens the form editor page', async ({
     page,
     project,

--- a/playwright/tests/18-forms.spec.ts
+++ b/playwright/tests/18-forms.spec.ts
@@ -192,6 +192,49 @@ test.describe('forms', () => {
     });
   });
 
+  test('FM7: OK navigates back to the page you came from', async ({
+    page,
+    project,
+  }) => {
+    // Reached via the Project menu (not a direct goto): the app records the
+    // originating place in-memory so OK knows where to return.
+    await page.locator(ProjectMenu.button).click();
+    const formsItem = page.locator(ProjectMenu.item('Forms'));
+    await formsItem.hover();
+    await formsItem.click();
+    await expect(page).toHaveURL(/#projects\/[0-9a-f-]{36}\/forms$/);
+    await expect(page.locator(SettingsPage.section('Project Forms'))).toBeVisible({
+      timeout: 30_000,
+    });
+
+    await addForm(page, 'NavBackForm');
+    await page.locator(SettingsPage.apply).click();
+
+    await expect(page).toHaveURL(/#projects\/[0-9a-f-]{36}\/perspectives\//, {
+      timeout: 15_000,
+    });
+  });
+
+  test('FM8: OK falls back to the project view when there is no recorded return place', async ({
+    page,
+    project,
+  }) => {
+    const projectId = projectIdOf(project);
+    // Reached via a direct URL (goto): FormsPlaceTokenizer can't reconstruct
+    // an in-memory "return to" place from a URL, so this exercises the
+    // fallback path rather than the recorded-nextPlace path FM7 covers.
+    await openFormsPage(page, projectId);
+
+    await addForm(page, 'NoBackPlaceForm');
+    await page.locator(SettingsPage.apply).click();
+
+    // Previously a no-op: the URL stayed on /forms. Now falls back to the
+    // project's default view instead of doing nothing.
+    await expect(page).toHaveURL(/#projects\/[0-9a-f-]{36}\/perspectives\//, {
+      timeout: 15_000,
+    });
+  });
+
   test('FM3: "Form details..." opens the form editor page', async ({
     page,
     project,

--- a/playwright/tests/18-forms.spec.ts
+++ b/playwright/tests/18-forms.spec.ts
@@ -57,7 +57,7 @@ test.describe('forms', () => {
     await expect(page.locator(FormsPage.importButton)).toBeVisible();
   });
 
-  test('FM2: "Add form" adds an editable form to the list', async ({
+  test('FM2: "Add form" adds an editable form whose label defaults to English and persists', async ({
     page,
     project,
   }) => {
@@ -77,12 +77,60 @@ test.describe('forms', () => {
     const labelInput = page.locator(FormsPage.labelValueInput).first();
     await expect(labelInput).toBeVisible();
     await labelInput.fill('TestForm');
+    await page.keyboard.press('Tab');
+    // Blur fires updateForm immediately. #281: a label typed with no
+    // explicit language tag now defaults to "en" instead of being
+    // silently dropped.
+    await page.waitForLoadState('networkidle');
     await expect(labelInput).toHaveValue('TestForm');
 
-    // NOTE: the form label is deliberately not asserted across a reload.
-    // On this deployment the form-label LanguageMap is not stored (the
-    // form row persists but its label comes back empty, with or without a
-    // language tag), so a persistence assertion would test a broken path.
+    // Persists across a reload, language tag included.
+    await page.reload();
+    await expect(page.locator(SettingsPage.section('Project Forms'))).toBeVisible({
+      timeout: 45_000,
+    });
+    await expect(page.locator(FormsPage.labelValueInput).first()).toHaveValue(
+      'TestForm',
+      { timeout: 15_000 },
+    );
+    await expect(page.locator(FormsPage.labelLangInput).first()).toHaveValue('en');
+  });
+
+  test('FM4: a form label with an explicit language tag persists as given', async ({
+    page,
+    project,
+  }) => {
+    const projectId = projectIdOf(project);
+    await openFormsPage(page, projectId);
+
+    await page.locator(FormsPage.addFormButton).click();
+    await expect(page.locator(FormsPage.formDetailsButton)).toHaveCount(1, {
+      timeout: 15_000,
+    });
+
+    // Set the language tag first: if the value field committed first with
+    // the tag still blank, the #281 default-fill would set it to "en"
+    // before we get a chance to type "fr" over it.
+    const langInput = page.locator(FormsPage.labelLangInput).first();
+    await langInput.click();
+    await langInput.pressSequentially('fr', { delay: 30 });
+    await page.keyboard.press('Escape');
+    await page.keyboard.press('Tab');
+
+    const labelInput = page.locator(FormsPage.labelValueInput).first();
+    await labelInput.fill('FormulaireTest');
+    await page.keyboard.press('Tab');
+    await page.waitForLoadState('networkidle');
+
+    await page.reload();
+    await expect(page.locator(SettingsPage.section('Project Forms'))).toBeVisible({
+      timeout: 45_000,
+    });
+    await expect(page.locator(FormsPage.labelValueInput).first()).toHaveValue(
+      'FormulaireTest',
+      { timeout: 15_000 },
+    );
+    await expect(page.locator(FormsPage.labelLangInput).first()).toHaveValue('fr');
   });
 
   test('FM3: "Form details..." opens the form editor page', async ({

--- a/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/form/FormsManagerObjectPresenter.java
+++ b/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/form/FormsManagerObjectPresenter.java
@@ -107,6 +107,15 @@ public class FormsManagerObjectPresenter implements ObjectPresenter<FormDescript
         // setForms() re-sends for every row (see FormsManagerPresenter,
         // ObjectListPresenter.getValues()), silently reverting this edit.
         this.value = Optional.of(updatedFormDescriptor);
+        if(newLabel.asMap().isEmpty() && currentFormDescriptor.getLabel().asMap().isEmpty()) {
+            // Nothing worth saving yet (e.g. a language tag was set before any
+            // label text was typed, which momentarily makes the whole label
+            // empty) and nothing to intentionally clear either. Sending this
+            // save anyway is a race waiting to happen: it can land after --
+            // and silently overwrite -- the real save that follows once the
+            // label text is actually typed.
+            return;
+        }
         formsManagerService.updateForm(updatedFormDescriptor,
                                        busyIndicator,
                                        () -> {});

--- a/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/form/FormsManagerObjectPresenter.java
+++ b/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/form/FormsManagerObjectPresenter.java
@@ -101,6 +101,12 @@ public class FormsManagerObjectPresenter implements ObjectPresenter<FormDescript
     private void updateCurrentFormDescriptorWithLanguageMap(FormDescriptor currentFormDescriptor) {
         LanguageMap newLabel = view.getLanguageMap();
         FormDescriptor updatedFormDescriptor = currentFormDescriptor.withLabel(newLabel);
+        // Keep our own snapshot in sync with what was just sent, otherwise
+        // getValue() keeps returning the stale, pre-edit descriptor. That
+        // stale copy is exactly what the page-level OK button's bulk
+        // setForms() re-sends for every row (see FormsManagerPresenter,
+        // ObjectListPresenter.getValues()), silently reverting this edit.
+        this.value = Optional.of(updatedFormDescriptor);
         formsManagerService.updateForm(updatedFormDescriptor,
                                        busyIndicator,
                                        () -> {});

--- a/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/form/FormsManagerObjectViewImpl.java
+++ b/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/form/FormsManagerObjectViewImpl.java
@@ -7,6 +7,7 @@ import com.google.gwt.uibinder.client.UiField;
 import com.google.gwt.user.client.ui.Button;
 import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.HTMLPanel;
+import edu.stanford.bmir.protege.web.client.editor.ValueListEditor;
 import edu.stanford.bmir.protege.web.client.lang.LanguageMapChangedHandler;
 import edu.stanford.bmir.protege.web.shared.lang.LanguageMap;
 
@@ -52,6 +53,12 @@ public class FormsManagerObjectViewImpl extends Composite implements FormsManage
     @Override
     public void setLanguageMap(@Nonnull LanguageMap languageMap) {
         languageMapEditor.setValue(languageMap);
+        // setValue() (still in the default AUTOMATIC mode at this point) seeds
+        // a blank trailing row the same way it always has. Switching to MANUAL
+        // right after stops any further auto-inserted row: typing a label
+        // used to append a new blank row on blur, shifting "Form details..."
+        // down and swallowing the very next click meant for that button (#281).
+        languageMapEditor.setNewRowMode(ValueListEditor.NewRowMode.MANUAL);
     }
 
     @Nonnull

--- a/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/form/FormsManagerPresenter.java
+++ b/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/form/FormsManagerPresenter.java
@@ -9,6 +9,7 @@ import edu.stanford.bmir.protege.web.client.FormsMessages;
 import edu.stanford.bmir.protege.web.client.Messages;
 import edu.stanford.bmir.protege.web.client.app.Presenter;
 import edu.stanford.bmir.protege.web.client.progress.HasBusy;
+import edu.stanford.bmir.protege.web.client.projectmanager.LoadProjectRequestHandler;
 import edu.stanford.bmir.protege.web.client.settings.SettingsPresenter;
 import edu.stanford.bmir.protege.web.shared.form.EntityFormSelector;
 import edu.stanford.bmir.protege.web.shared.form.FormDescriptor;
@@ -17,6 +18,7 @@ import edu.stanford.bmir.protege.web.shared.inject.ProjectSingleton;
 import javax.annotation.Nonnull;
 import javax.inject.Inject;
 import javax.inject.Provider;
+import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -55,6 +57,9 @@ public class FormsManagerPresenter implements Presenter, HasBusy {
     @Nonnull
     private final Provider<FormsDownloader> formDownloaderProvider;
 
+    @Nonnull
+    private final LoadProjectRequestHandler loadProjectRequestHandler;
+
     @Inject
     public FormsManagerPresenter(@Nonnull FormsManagerView formManagerView,
                                  @Nonnull SettingsPresenter settingsPresenter,
@@ -64,7 +69,8 @@ public class FormsManagerPresenter implements Presenter, HasBusy {
                                  @Nonnull Messages messages,
                                  @Nonnull CopyFormsFromProjectModalPresenter copyFormsFromProjectModalPresenter,
                                  @Nonnull FormsManagerObjectListPresenter listPresenter,
-                                 @Nonnull Provider<FormsDownloader> formDownloaderProvider) {
+                                 @Nonnull Provider<FormsDownloader> formDownloaderProvider,
+                                 @Nonnull LoadProjectRequestHandler loadProjectRequestHandler) {
         this.formManagerView = checkNotNull(formManagerView);
         this.settingsPresenter = checkNotNull(settingsPresenter);
         this.formsManagerService = checkNotNull(formsManagerService);
@@ -74,6 +80,7 @@ public class FormsManagerPresenter implements Presenter, HasBusy {
         this.copyFormsFromProjectModalPresenter = checkNotNull(copyFormsFromProjectModalPresenter);
         this.listPresenter = checkNotNull(listPresenter);
         this.formDownloaderProvider = formDownloaderProvider;
+        this.loadProjectRequestHandler = checkNotNull(loadProjectRequestHandler);
     }
 
     private void displayFormsList(ImmutableList<FormDescriptor> formDescriptors,
@@ -91,7 +98,18 @@ public class FormsManagerPresenter implements Presenter, HasBusy {
     private void goToNextPlace() {
         Place currentPlace = placeController.getWhere();
         if (currentPlace instanceof FormsPlace) {
-            ((FormsPlace) currentPlace).getNextPlace().ifPresent(placeController::goTo);
+            FormsPlace formsPlace = (FormsPlace) currentPlace;
+            Optional<Place> nextPlace = formsPlace.getNextPlace();
+            if (nextPlace.isPresent()) {
+                placeController.goTo(nextPlace.get());
+            } else {
+                // Reached here via a URL-only round trip (browser back/forward,
+                // refresh, bookmark) -- FormsPlaceTokenizer can't reconstruct an
+                // in-memory "return to" place from a URL, so there's nowhere
+                // recorded to go back to. Land on the project's default view
+                // instead of silently doing nothing.
+                loadProjectRequestHandler.handleProjectLoadRequest(formsPlace.getProjectId());
+            }
         }
     }
 

--- a/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/form/LanguageMapEditor.java
+++ b/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/form/LanguageMapEditor.java
@@ -81,6 +81,10 @@ public class LanguageMapEditor extends Composite implements ValueEditor<Language
         delegate.setEnabled(enabled);
     }
 
+    public void setNewRowMode(ValueListEditor.NewRowMode newRowMode) {
+        delegate.setNewRowMode(newRowMode);
+    }
+
     @Override
     public void setValue(LanguageMap object) {
         List<LanguageMapEntry> entries = object.asMap()

--- a/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/form/LanguageMapEntryPresenter.java
+++ b/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/form/LanguageMapEntryPresenter.java
@@ -25,6 +25,12 @@ import static com.google.common.base.Preconditions.checkNotNull;
  */
 public class LanguageMapEntryPresenter implements ValueEditor<LanguageMapEntry>, HasRequestFocus, HasPlaceholder {
 
+    /**
+     * Applied when a row has label text but no explicit language tag, so a value is
+     * never silently dropped just because its language wasn't set (see #281).
+     */
+    private static final String DEFAULT_LANG_TAG = "en";
+
     @Nonnull
     private final LanguageMapEntryView view;
 
@@ -52,11 +58,15 @@ public class LanguageMapEntryPresenter implements ValueEditor<LanguageMapEntry>,
 
     @Override
     public Optional<LanguageMapEntry> getValue() {
-        String langTag = view.getLangTag();
-        if(langTag.trim().isEmpty()) {
-            return Optional.empty();
+        String value = view.getValue().trim();
+        String langTag = view.getLangTag().trim();
+        if(langTag.isEmpty()) {
+            if(value.isEmpty()) {
+                return Optional.empty();
+            }
+            langTag = DEFAULT_LANG_TAG;
         }
-        return Optional.of(LanguageMapEntry.get(langTag, view.getValue().trim()));
+        return Optional.of(LanguageMapEntry.get(langTag, value));
     }
 
     @Override

--- a/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/form/LanguageMapEntryPresenter.java
+++ b/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/form/LanguageMapEntryPresenter.java
@@ -59,11 +59,16 @@ public class LanguageMapEntryPresenter implements ValueEditor<LanguageMapEntry>,
     @Override
     public Optional<LanguageMapEntry> getValue() {
         String value = view.getValue().trim();
+        // A row is only ever complete once it has actual text: a tag alone
+        // (e.g. set before the label text is typed) isn't a meaningful entry
+        // on its own, and treating it as one sent a premature, empty-value
+        // save that could race with -- and sometimes overwrite -- the real
+        // save that follows once the text is typed.
+        if(value.isEmpty()) {
+            return Optional.empty();
+        }
         String langTag = view.getLangTag().trim();
         if(langTag.isEmpty()) {
-            if(value.isEmpty()) {
-                return Optional.empty();
-            }
             langTag = DEFAULT_LANG_TAG;
         }
         return Optional.of(LanguageMapEntry.get(langTag, value));

--- a/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/form/LanguageMapEntryViewImpl.java
+++ b/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/form/LanguageMapEntryViewImpl.java
@@ -22,6 +22,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
  */
 public class LanguageMapEntryViewImpl extends Composite implements LanguageMapEntryView {
 
+    private static final String DEFAULT_LANG_TAG = "en";
+
     interface LanguageMapEntryViewImplUiBinder extends UiBinder<HTMLPanel, LanguageMapEntryViewImpl> {
 
     }
@@ -43,6 +45,7 @@ public class LanguageMapEntryViewImpl extends Composite implements LanguageMapEn
         this.langTagEditor = checkNotNull(langTagEditor);
         initWidget(ourUiBinder.createAndBindUi(this));
         valueField.addValueChangeHandler(event -> {
+            applyDefaultLangTagIfMissing();
             updateLangTagErrorBorder();
             valueChangedHandler.accept(getValue());
         });
@@ -51,6 +54,12 @@ public class LanguageMapEntryViewImpl extends Composite implements LanguageMapEn
             langTagChangedHandler.accept(getLangTag());
 
         });
+    }
+
+    private void applyDefaultLangTagIfMissing() {
+        if(!valueField.getValue().trim().isEmpty() && langTagEditor.getValue().orElse("").trim().isEmpty()) {
+            langTagEditor.setValue(DEFAULT_LANG_TAG);
+        }
     }
 
     public void updateLangTagErrorBorder() {

--- a/webprotege-gwt-ui-client/src/test/java/edu/stanford/bmir/protege/web/client/form/FormsManagerObjectPresenter_TestCase.java
+++ b/webprotege-gwt-ui-client/src/test/java/edu/stanford/bmir/protege/web/client/form/FormsManagerObjectPresenter_TestCase.java
@@ -1,0 +1,93 @@
+package edu.stanford.bmir.protege.web.client.form;
+
+import com.google.gwt.place.shared.PlaceController;
+import com.google.gwt.user.client.ui.AcceptsOneWidget;
+import edu.stanford.bmir.protege.web.client.FormsMessages;
+import edu.stanford.bmir.protege.web.client.lang.LanguageMapChangedHandler;
+import edu.stanford.bmir.protege.web.shared.form.FormDescriptor;
+import edu.stanford.bmir.protege.web.shared.form.FormId;
+import edu.stanford.bmir.protege.web.shared.lang.LanguageMap;
+import edu.stanford.bmir.protege.web.shared.project.ProjectId;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.Collections;
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+/**
+ * Regression tests for #281: clicking the Forms manager's page-level OK button
+ * bulk-resends every row's cached FormDescriptor (ObjectListPresenter.getValues()).
+ * That cache must reflect the last edit, or OK silently reverts labels that were
+ * already saved individually via updateForm on blur.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class FormsManagerObjectPresenter_TestCase {
+
+    private FormsManagerObjectPresenter presenter;
+
+    @Mock
+    private FormsManagerObjectView view;
+
+    @Mock
+    private LanguageMapCurrentLocaleMapper localeMapper;
+
+    @Mock
+    private PlaceController placeController;
+
+    @Mock
+    private ProjectId projectId;
+
+    @Mock
+    private FormsMessages formsMessages;
+
+    @Mock
+    private FormsManagerService formsManagerService;
+
+    @Mock
+    private AcceptsOneWidget container;
+
+    private final FormId formId = FormId.generate();
+
+    private LanguageMapChangedHandler capturedHandler;
+
+    @Before
+    public void setUp() {
+        presenter = new FormsManagerObjectPresenter(view,
+                                                    localeMapper,
+                                                    placeController,
+                                                    projectId,
+                                                    formsMessages,
+                                                    formsManagerService);
+        presenter.start(container);
+
+        ArgumentCaptor<LanguageMapChangedHandler> captor =
+                ArgumentCaptor.forClass(LanguageMapChangedHandler.class);
+        verify(view).setLanguageMapChangedHandler(captor.capture());
+        capturedHandler = captor.getValue();
+
+        presenter.setValue(FormDescriptor.empty(formId));
+    }
+
+    @Test
+    public void shouldReflectTheEditedLabelInGetValueAfterALanguageMapChange() {
+        LanguageMap newLabel = LanguageMap.get(Map.of("en", "TestForm"));
+        when(view.getLanguageMap()).thenReturn(newLabel);
+
+        capturedHandler.handleLanguageMapChanged();
+
+        assertThat(presenter.getValue().isPresent(), is(true));
+        assertThat(presenter.getValue().get().getLabel(), is(newLabel));
+        verify(formsManagerService).updateForm(argThat(fd -> fd.getLabel().equals(newLabel)),
+                                               any(),
+                                               any());
+    }
+}

--- a/webprotege-gwt-ui-client/src/test/java/edu/stanford/bmir/protege/web/client/form/FormsManagerObjectPresenter_TestCase.java
+++ b/webprotege-gwt-ui-client/src/test/java/edu/stanford/bmir/protege/web/client/form/FormsManagerObjectPresenter_TestCase.java
@@ -90,4 +90,32 @@ public class FormsManagerObjectPresenter_TestCase {
                                                any(),
                                                any());
     }
+
+    @Test
+    public void shouldNotSendAnUpdateWhenTheLabelIsStillEmpty() {
+        // e.g. a language tag committed before any label text is typed: the
+        // whole LanguageMap is still empty. Sending that save is a race
+        // waiting to happen against the real save that follows once text is
+        // actually typed (see #281), so it must be skipped -- there was
+        // nothing to save before, and still isn't.
+        when(view.getLanguageMap()).thenReturn(LanguageMap.empty());
+
+        capturedHandler.handleLanguageMapChanged();
+
+        assertThat(presenter.getValue().get().getLabel(), is(LanguageMap.empty()));
+        verify(formsManagerService, never()).updateForm(any(), any(), any());
+    }
+
+    @Test
+    public void shouldStillSendAnUpdateWhenIntentionallyClearingAnExistingLabel() {
+        LanguageMap originalLabel = LanguageMap.get(Map.of("en", "TestForm"));
+        presenter.setValue(FormDescriptor.empty(formId).withLabel(originalLabel));
+        when(view.getLanguageMap()).thenReturn(LanguageMap.empty());
+
+        capturedHandler.handleLanguageMapChanged();
+
+        verify(formsManagerService).updateForm(argThat(fd -> fd.getLabel().equals(LanguageMap.empty())),
+                                               any(),
+                                               any());
+    }
 }

--- a/webprotege-gwt-ui-client/src/test/java/edu/stanford/bmir/protege/web/client/form/FormsManagerPresenter_TestCase.java
+++ b/webprotege-gwt-ui-client/src/test/java/edu/stanford/bmir/protege/web/client/form/FormsManagerPresenter_TestCase.java
@@ -1,0 +1,133 @@
+package edu.stanford.bmir.protege.web.client.form;
+
+import com.google.common.collect.ImmutableList;
+import com.google.gwt.place.shared.Place;
+import com.google.gwt.place.shared.PlaceController;
+import com.google.gwt.user.client.ui.AcceptsOneWidget;
+import com.google.web.bindery.event.shared.EventBus;
+import edu.stanford.bmir.protege.web.client.FormsMessages;
+import edu.stanford.bmir.protege.web.client.Messages;
+import edu.stanford.bmir.protege.web.client.projectmanager.LoadProjectRequestHandler;
+import edu.stanford.bmir.protege.web.client.settings.ApplySettingsHandler;
+import edu.stanford.bmir.protege.web.client.settings.SettingsPresenter;
+import edu.stanford.bmir.protege.web.shared.project.ProjectId;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import javax.inject.Provider;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+/**
+ * Regression tests for #281: the Forms manager's OK button used to silently do
+ * nothing whenever the current place had no in-memory "next place" to return
+ * to -- which is exactly what happens when the page was reached via a URL
+ * round trip (browser back/forward, refresh, bookmark) rather than in-app
+ * navigation, since FormsPlaceTokenizer can't reconstruct that reference from
+ * a URL. OK should fall back to the project's default view in that case.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class FormsManagerPresenter_TestCase {
+
+    private FormsManagerPresenter presenter;
+
+    @Mock
+    private FormsManagerView formManagerView;
+
+    @Mock
+    private SettingsPresenter settingsPresenter;
+
+    @Mock
+    private FormsManagerService formsManagerService;
+
+    @Mock
+    private FormsMessages formsMessages;
+
+    @Mock
+    private PlaceController placeController;
+
+    @Mock
+    private Messages messages;
+
+    @Mock
+    private CopyFormsFromProjectModalPresenter copyFormsFromProjectModalPresenter;
+
+    @Mock
+    private FormsManagerObjectListPresenter listPresenter;
+
+    @Mock
+    private Provider<FormsDownloader> formDownloaderProvider;
+
+    @Mock
+    private LoadProjectRequestHandler loadProjectRequestHandler;
+
+    @Mock
+    private AcceptsOneWidget container;
+
+    @Mock
+    private EventBus eventBus;
+
+    @Mock
+    private Place backHerePlace;
+
+    private final ProjectId projectId = ProjectId.getNil();
+
+    private ApplySettingsHandler capturedApplyHandler;
+
+    @Before
+    public void setUp() {
+        when(settingsPresenter.addSection(any())).thenReturn(mock(AcceptsOneWidget.class));
+
+        presenter = new FormsManagerPresenter(formManagerView,
+                                              settingsPresenter,
+                                              formsManagerService,
+                                              formsMessages,
+                                              placeController,
+                                              messages,
+                                              copyFormsFromProjectModalPresenter,
+                                              listPresenter,
+                                              formDownloaderProvider,
+                                              loadProjectRequestHandler);
+        presenter.start(container, eventBus);
+
+        ArgumentCaptor<ApplySettingsHandler> captor = ArgumentCaptor.forClass(ApplySettingsHandler.class);
+        verify(settingsPresenter).setApplySettingsHandler(captor.capture());
+        capturedApplyHandler = captor.getValue();
+
+        when(listPresenter.getValues()).thenReturn(ImmutableList.of());
+        // Simulate the setForms RPC completing immediately.
+        doAnswer(invocation -> {
+            Runnable completeHandler = invocation.getArgument(2);
+            completeHandler.run();
+            return null;
+        }).when(formsManagerService).setForms(any(), any(), any());
+    }
+
+    @Test
+    public void shouldGoToTheRecordedNextPlaceWhenOneIsKnown() {
+        FormsPlace formsPlace = FormsPlace.get(projectId, Optional.of(backHerePlace));
+        when(placeController.getWhere()).thenReturn(formsPlace);
+
+        capturedApplyHandler.handleApplySettings();
+
+        verify(placeController).goTo(backHerePlace);
+        verify(loadProjectRequestHandler, never()).handleProjectLoadRequest(any());
+    }
+
+    @Test
+    public void shouldFallBackToTheProjectDefaultViewWhenNoNextPlaceIsKnown() {
+        FormsPlace formsPlace = FormsPlace.get(projectId, Optional.empty());
+        when(placeController.getWhere()).thenReturn(formsPlace);
+
+        capturedApplyHandler.handleApplySettings();
+
+        verify(loadProjectRequestHandler).handleProjectLoadRequest(projectId);
+        verify(placeController, never()).goTo(any());
+    }
+}

--- a/webprotege-gwt-ui-client/src/test/java/edu/stanford/bmir/protege/web/client/form/LanguageMapEntryPresenter_TestCase.java
+++ b/webprotege-gwt-ui-client/src/test/java/edu/stanford/bmir/protege/web/client/form/LanguageMapEntryPresenter_TestCase.java
@@ -32,7 +32,6 @@ public class LanguageMapEntryPresenter_TestCase {
     @Test
     public void shouldReturnEmptyWhenValueAndLangTagAreBlank() {
         when(view.getValue()).thenReturn("");
-        when(view.getLangTag()).thenReturn("");
         assertThat(presenter.getValue(), is(Optional.empty()));
         assertThat(presenter.isWellFormed(), is(false));
     }
@@ -50,5 +49,16 @@ public class LanguageMapEntryPresenter_TestCase {
         when(view.getValue()).thenReturn("TestForm");
         when(view.getLangTag()).thenReturn("fr");
         assertThat(presenter.getValue(), is(Optional.of(LanguageMapEntry.get("fr", "TestForm"))));
+    }
+
+    @Test
+    public void shouldReturnEmptyWhenLangTagIsSetButValueIsBlank() {
+        // A lang tag set before any text is typed (e.g. FM4's "set the
+        // language first" flow) must not count as a complete, saveable row
+        // on its own -- otherwise it sends a premature empty-value save that
+        // can race with the real save once the text is typed.
+        when(view.getValue()).thenReturn("");
+        assertThat(presenter.getValue(), is(Optional.empty()));
+        assertThat(presenter.isWellFormed(), is(false));
     }
 }

--- a/webprotege-gwt-ui-client/src/test/java/edu/stanford/bmir/protege/web/client/form/LanguageMapEntryPresenter_TestCase.java
+++ b/webprotege-gwt-ui-client/src/test/java/edu/stanford/bmir/protege/web/client/form/LanguageMapEntryPresenter_TestCase.java
@@ -1,0 +1,54 @@
+package edu.stanford.bmir.protege.web.client.form;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.Optional;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.when;
+
+/**
+ * Regression tests for #281: a label with text but no explicit language tag must not
+ * be silently dropped when the row is read back out of the editor.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class LanguageMapEntryPresenter_TestCase {
+
+    private LanguageMapEntryPresenter presenter;
+
+    @Mock
+    private LanguageMapEntryView view;
+
+    @Before
+    public void setUp() {
+        presenter = new LanguageMapEntryPresenter(view);
+    }
+
+    @Test
+    public void shouldReturnEmptyWhenValueAndLangTagAreBlank() {
+        when(view.getValue()).thenReturn("");
+        when(view.getLangTag()).thenReturn("");
+        assertThat(presenter.getValue(), is(Optional.empty()));
+        assertThat(presenter.isWellFormed(), is(false));
+    }
+
+    @Test
+    public void shouldDefaultToEnglishWhenValueIsSetButLangTagIsBlank() {
+        when(view.getValue()).thenReturn("TestForm");
+        when(view.getLangTag()).thenReturn("");
+        assertThat(presenter.getValue(), is(Optional.of(LanguageMapEntry.get("en", "TestForm"))));
+        assertThat(presenter.isWellFormed(), is(true));
+    }
+
+    @Test
+    public void shouldUseTheExplicitLangTagWhenOneIsProvided() {
+        when(view.getValue()).thenReturn("TestForm");
+        when(view.getLangTag()).thenReturn("fr");
+        assertThat(presenter.getValue(), is(Optional.of(LanguageMapEntry.get("fr", "TestForm"))));
+    }
+}


### PR DESCRIPTION
## Summary

Creating a new form in the Forms manager and giving it a name used to lose that name in a few different situations — sometimes right away, sometimes only after clicking OK, and sometimes the "Form details..." button wouldn't even open. This branch fixes all of those so a form's name is reliably saved and the page behaves the way you'd expect when adding, naming, and closing a form.