### PR TITLE
Keep live project updates connected

### DIFF
--- a/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/events/ChangeRequestEventAwaiter.java
+++ b/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/events/ChangeRequestEventAwaiter.java
@@ -10,7 +10,6 @@ import edu.stanford.bmir.protege.web.shared.perspective.HasChangeRequestId;
 
 import javax.annotation.Nonnull;
 import javax.inject.Inject;
-import javax.inject.Provider;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -73,17 +72,8 @@ public class ChangeRequestEventAwaiter {
      */
     private final Multimap<ChangeRequestId, WebProtegeEvent<?>> bufferedEvents = HashMultimap.create();
 
-    /**
-     * Lazy provider for the project's {@link EventPollingManager}. Lazy
-     * because {@link EventPollingManager} already depends on this class
-     * (via constructor injection) and a direct field would create a Dagger
-     * cycle.
-     */
-    private final Provider<EventPollingManager> eventPollingManagerProvider;
-
     @Inject
-    public ChangeRequestEventAwaiter(@Nonnull Provider<EventPollingManager> eventPollingManagerProvider) {
-        this.eventPollingManagerProvider = eventPollingManagerProvider;
+    public ChangeRequestEventAwaiter() {
     }
 
     /**
@@ -110,32 +100,9 @@ public class ChangeRequestEventAwaiter {
                     handler.handle(Collections.emptyList());
                 }
             });
-            // Also trigger an immediate event poll so the matching events
-            // arrive within one extra round-trip rather than waiting for
-            // the next periodic tick (default 10s — see
-            // EventPollingPeriodProvider). Without this kick, every
-            // hierarchy create incurs the full FALLBACK_TIMEOUT_MS as
-            // dead time before the tree updates and the new node can be
-            // selected.
-            requestImmediatePoll();
         } else {
             // Deliver buffered events immediately
             handler.handle(alreadyArrivedEvents);
-        }
-    }
-
-    /**
-     * Asks the {@link EventPollingManager} to poll for events right now.
-     * Visible for testing — JVM unit tests may override this to capture
-     * the call without touching the GWT-only timer / network stack.
-     */
-    protected void requestImmediatePoll() {
-        try {
-            eventPollingManagerProvider.get().pollForProjectEvents();
-        } catch (RuntimeException e) {
-            // Polling is best-effort; the fallback timer guarantees the
-            // handler eventually fires either way.
-            logger.warning("Immediate event poll failed: " + e.getMessage());
         }
     }
 

--- a/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/project/ProjectPresenter.java
+++ b/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/project/ProjectPresenter.java
@@ -1,6 +1,7 @@
 package edu.stanford.bmir.protege.web.client.project;
 
 import com.google.gwt.core.client.GWT;
+import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.ui.AcceptsOneWidget;
 import com.google.web.bindery.event.shared.EventBus;
@@ -65,6 +66,15 @@ public class ProjectPresenter implements HasDispose, HasProjectId {
 
     private final LoggedInUserProvider loggedInUserProvider;
 
+    /**
+     * The StompJs client that carries the project-events subscription.
+     * Held on the presenter so the connection lives exactly as long as the
+     * project view does: previously the client was a local variable inside
+     * {@link #subscribeToWebsocket}, so nothing owned it and the connection
+     * could silently go away while the user was still on the project. It is
+     * closed explicitly in {@link #dispose()} via {@link #disconnectWebsocket()}.
+     */
+    private JavaScriptObject stompClient;
 
     @Inject
     public ProjectPresenter(ProjectId projectId,
@@ -145,6 +155,7 @@ public class ProjectPresenter implements HasDispose, HasProjectId {
         linkBarPresenter.dispose();
         perspectivePresenter.dispose();
         eventPollingManager.stop();
+        disconnectWebsocket();
         eventBus.dispose();
     }
 
@@ -162,6 +173,13 @@ public class ProjectPresenter implements HasDispose, HasProjectId {
     public native void subscribeToWebsocket(String projectId, String token, String websocketUrl, String userId)/*-{
         try {
             var that = this;
+
+            // If a previous connection is still around (e.g. the presenter is
+            // re-started), close it rather than leaking it.
+            var existing = this.@edu.stanford.bmir.protege.web.client.project.ProjectPresenter::stompClient;
+            if (existing) {
+                existing.deactivate();
+            }
 
             var stompClient = new $wnd.StompJs.Client({
                 brokerURL: websocketUrl,
@@ -203,8 +221,22 @@ public class ProjectPresenter implements HasDispose, HasProjectId {
 
             stompClient.activate();
 
+            this.@edu.stanford.bmir.protege.web.client.project.ProjectPresenter::stompClient = stompClient;
+
         } catch (e) {
             $wnd.console.log('An error has occurred in the websocket connection/subscription ' + e)
+        }
+    }-*/;
+
+    public native void disconnectWebsocket()/*-{
+        try {
+            var stompClient = this.@edu.stanford.bmir.protege.web.client.project.ProjectPresenter::stompClient;
+            if (stompClient) {
+                stompClient.deactivate();
+                this.@edu.stanford.bmir.protege.web.client.project.ProjectPresenter::stompClient = null;
+            }
+        } catch (e) {
+            $wnd.console.log('An error has occurred while closing the websocket connection ' + e)
         }
     }-*/;
 }

--- a/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/project/ProjectPresenter.java
+++ b/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/project/ProjectPresenter.java
@@ -138,7 +138,11 @@ public class ProjectPresenter implements HasDispose, HasProjectId {
         topBarPresenter.start(view.getTopBarContainer(), eventBus, place);
         linkBarPresenter.start(view.getPerspectiveLinkBarViewContainer(), eventBus, place);
         perspectivePresenter.start(view.getPerspectiveViewContainer(), eventBus, place);
-       // eventPollingManager.start();
+        // Periodic polling backs up the live push connection: if the network
+        // drops or the connection glitches, the poll (every 10s, see
+        // EventPollingPeriodProvider) fills the gap. The live push covers
+        // anything time-sensitive.
+        eventPollingManager.start();
         eventBus.addHandlerToSource(LargeNumberOfChangesEvent.LARGE_NUMBER_OF_CHANGES,
                                     projectId,
                                     largeNumberOfChangesHandler);

--- a/webprotege-gwt-ui-client/src/test/java/edu/stanford/bmir/protege/web/client/events/ChangeRequestEventAwaiterTest.java
+++ b/webprotege-gwt-ui-client/src/test/java/edu/stanford/bmir/protege/web/client/events/ChangeRequestEventAwaiterTest.java
@@ -24,18 +24,11 @@ public class ChangeRequestEventAwaiterTest {
     public void setUp() {
         // Override scheduleFallback so the GWT Timer (JS-only) is never
         // invoked from the JVM, and so the fallback path can be exercised
-        // deterministically. Override requestImmediatePoll for the same
-        // reason — its production implementation calls into
-        // EventPollingManager which depends on GWT-only types.
-        awaiter = new ChangeRequestEventAwaiter(() -> { throw new UnsupportedOperationException("test should not invoke"); }) {
+        // deterministically.
+        awaiter = new ChangeRequestEventAwaiter() {
             @Override
             protected void scheduleFallback(Runnable callback) {
                 pendingFallback = callback;
-            }
-
-            @Override
-            protected void requestImmediatePoll() {
-                // no-op for tests
             }
         };
     }


### PR DESCRIPTION
## Summary

The connection that pushes live project updates to the browser used to quietly drop while a user was still working in a project, and the periodic backup check was switched off. The result was that changes made on the server — for example by someone else editing the same project in another tab — never showed up without a manual page reload. The test suite also had to fire an extra request on every change just to keep itself green.

This branch keeps the live connection open for as long as the project is open, closes it cleanly when leaving, turns the periodic backup check back on, and removes the extra request the tests no longer need.

Verified: two tabs on the same project now see each other's edits instantly without a reload, and the full test suite passes without the old workaround.