### PR TITLE
Stop removed annotations, parents, and deleted classes from coming back

### DIFF
--- a/playwright/support/selectors.ts
+++ b/playwright/support/selectors.ts
@@ -310,6 +310,8 @@ export const TagsPage = {
   row: '.wp-value-list__row',
   labelInput: 'input[placeholder="Label"]',
   descriptionInput: 'input[placeholder="Description"]',
+  /** Per-row delete control of any ValueListFlexEditorContainer row —
+   * shared by tags, prefixes, and the frame editor's list sections. */
   deleteButton: '.wp-value-list__delete-button',
 } as const;
 

--- a/playwright/tests/21-entity-removals.spec.ts
+++ b/playwright/tests/21-entity-removals.spec.ts
@@ -1,0 +1,137 @@
+import { Page } from '@playwright/test';
+import { test, expect } from '../support/fixtures';
+import {
+  addPrimitiveValue,
+  addPropertyValue,
+  COMMIT_DELAY_MS,
+} from '../support/frameEditor';
+import {
+  CreateEntityDialog,
+  FrameEditor,
+  Hierarchy,
+  TagsPage,
+} from '../support/selectors';
+
+/**
+ * Regression pin for #191: removed annotations/parents and deleted classes
+ * must STAY removed in the UI. Project events arrive over two concurrent
+ * paths (websocket push + polling safety net); before the dispatch guard
+ * in EventPollingManager, a late-delivered older event window could be
+ * replayed, re-adding removed hierarchy edges and resurrecting deleted
+ * classes on screen even though the server data was correct. The
+ * deliberate multi-poll-tick wait here gives any replay a chance to
+ * happen before we assert.
+ */
+
+async function createClassUnder(
+  page: Page,
+  parentLabel: string,
+  newLabel: string,
+): Promise<void> {
+  await page.locator(Hierarchy.treeNode(parentLabel)).first().click();
+  await page.locator(Hierarchy.toolbar.create).first().click();
+  await expect(page.locator(CreateEntityDialog.root)).toBeVisible();
+  await page.locator(CreateEntityDialog.name).fill(newLabel);
+  await page.locator(CreateEntityDialog.submit).click();
+  await expect(page.locator(Hierarchy.treeNode(newLabel))).toBeVisible({
+    timeout: 15_000,
+  });
+}
+
+/** Remove a frame-editor list row matched by its text and let the
+ * debounced frame commit land. */
+async function removeFrameRow(
+  page: Page,
+  sectionLabel: string,
+  rowText: string,
+): Promise<void> {
+  const row = page
+    .locator(FrameEditor.section(sectionLabel))
+    .locator(FrameEditor.row)
+    .filter({ hasText: rowText });
+  await expect(row).toHaveCount(1);
+  await row.locator(TagsPage.deleteButton).click();
+  await expect(
+    page
+      .locator(FrameEditor.section(sectionLabel))
+      .locator(FrameEditor.row)
+      .filter({ hasText: rowText }),
+  ).toHaveCount(0, { timeout: 15_000 });
+  await page.waitForTimeout(COMMIT_DELAY_MS);
+  await page.waitForLoadState('networkidle');
+}
+
+test.describe('entity removals stay removed', () => {
+  test('ER1: removed annotation, removed parent, and deleted class stay gone across poll ticks and a reload', async ({
+    page,
+    project,
+  }) => {
+    // The deliberate multi-poll-tick wait plus several debounced frame
+    // commits do not fit the default 60s budget.
+    test.setTimeout(180_000);
+
+    await createClassUnder(page, 'owl:Thing', 'Vehicle');
+    await createClassUnder(page, 'owl:Thing', 'Machine');
+    await createClassUnder(page, 'Vehicle', 'Car');
+    await createClassUnder(page, 'owl:Thing', 'Disposable');
+
+    // Delete a leaf class (C8 pattern).
+    await page.locator(Hierarchy.treeNode('Disposable')).first().click();
+    await page.locator(Hierarchy.toolbar.delete).first().click();
+    const confirm = page.locator('role=button >> text=/OK|Delete|Yes/').first();
+    if (await confirm.isVisible().catch(() => false)) await confirm.click();
+    await expect(page.locator(Hierarchy.treeNode('Disposable'))).toHaveCount(0, {
+      timeout: 15_000,
+    });
+    await page.waitForLoadState('networkidle');
+
+    // Give Car an extra parent and an annotation, then remove both.
+    // Keep Car selected from here on — the point is to observe the SAME
+    // rendered frame across the wait, not a freshly re-fetched one.
+    await page.locator(Hierarchy.treeNode('Car')).first().click();
+    await addPrimitiveValue(page, 'Parents', 'Machine');
+    await addPropertyValue(page, 'Annotations', 'rdfs:comment', 'ToBeRemoved');
+
+    await removeFrameRow(page, 'Annotations', 'ToBeRemoved');
+    await removeFrameRow(page, 'Parents', 'Machine');
+
+    // Sit through at least two polling ticks (10s period): before the
+    // event-replay guard this is the window in which a late poll could
+    // re-fire old AddEdge/frame events and bring everything back.
+    await page.waitForTimeout(25_000);
+
+    const annotationRows = page
+      .locator(FrameEditor.section('Annotations'))
+      .locator(FrameEditor.row);
+    const parentRows = page
+      .locator(FrameEditor.section('Parents'))
+      .locator(FrameEditor.row);
+    await expect(annotationRows.filter({ hasText: 'ToBeRemoved' })).toHaveCount(0);
+    await expect(parentRows.filter({ hasText: 'Machine' })).toHaveCount(0);
+    await expect(page.locator(Hierarchy.treeNode('Disposable'))).toHaveCount(0);
+    await expect(page.locator(Hierarchy.treeNode('Car'))).toBeVisible();
+
+    // And the removals hold across a full reload (server truth).
+    await page.reload();
+    await expect(page.locator(Hierarchy.treeNode('owl:Thing'))).toBeVisible({
+      timeout: 30_000,
+    });
+    await expect(page.locator(Hierarchy.treeNode('Disposable'))).toHaveCount(0);
+    await page.locator(Hierarchy.treeNode('Car')).first().click();
+    await expect(page.locator(FrameEditor.annotationsSection)).toBeVisible({
+      timeout: 15_000,
+    });
+    await expect(
+      page
+        .locator(FrameEditor.section('Annotations'))
+        .locator(FrameEditor.row)
+        .filter({ hasText: 'ToBeRemoved' }),
+    ).toHaveCount(0);
+    await expect(
+      page
+        .locator(FrameEditor.section('Parents'))
+        .locator(FrameEditor.row)
+        .filter({ hasText: 'Machine' }),
+    ).toHaveCount(0);
+  });
+});

--- a/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/editor/AnnotationPropertyFrameEditorManager.java
+++ b/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/editor/AnnotationPropertyFrameEditorManager.java
@@ -5,6 +5,7 @@ import edu.stanford.bmir.protege.web.shared.frame.AnnotationPropertyFrame;
 import edu.stanford.bmir.protege.web.shared.frame.GetAnnotationPropertyFrameAction;
 import edu.stanford.bmir.protege.web.shared.frame.GetAnnotationPropertyFrameResult;
 import edu.stanford.bmir.protege.web.shared.frame.UpdateAnnotationPropertyFrameAction;
+import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
 
 import javax.inject.Inject;
 
@@ -44,9 +45,11 @@ public class AnnotationPropertyFrameEditorManager implements EditorManager<OWLEn
     }
 
     @Override
-    public UpdateAnnotationPropertyFrameAction createUpdateObjectAction(AnnotationPropertyFrame pristineObject, AnnotationPropertyFrame editedObject, OWLEntityContext editorContext) {
+    public UpdateAnnotationPropertyFrameAction createUpdateObjectAction(AnnotationPropertyFrame pristineObject, AnnotationPropertyFrame editedObject, OWLEntityContext editorContext,
+                                                                        ChangeRequestId changeRequestId) {
         return UpdateAnnotationPropertyFrameAction.create(editorContext.getProjectId(),
                                                           pristineObject.toPlainFrame(),
-                                                          editedObject.toPlainFrame());
+                                                          editedObject.toPlainFrame(),
+                                                          changeRequestId);
     }
 }

--- a/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/editor/ClassFrameEditorManager.java
+++ b/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/editor/ClassFrameEditorManager.java
@@ -6,6 +6,7 @@ import edu.stanford.bmir.protege.web.shared.dispatch.actions.UpdateClassFrameAct
 import edu.stanford.bmir.protege.web.shared.frame.ClassFrame;
 import edu.stanford.bmir.protege.web.shared.frame.GetClassFrameResult;
 import edu.stanford.bmir.protege.web.shared.frame.UpdateFrameAction;
+import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
 
 import javax.inject.Inject;
 
@@ -40,10 +41,12 @@ public class ClassFrameEditorManager implements EditorManager<OWLEntityContext, 
     }
 
     @Override
-    public UpdateFrameAction createUpdateObjectAction(ClassFrame pristineObject, ClassFrame editedObject, OWLEntityContext editorContext) {
+    public UpdateFrameAction createUpdateObjectAction(ClassFrame pristineObject, ClassFrame editedObject, OWLEntityContext editorContext,
+                                                      ChangeRequestId changeRequestId) {
         return UpdateClassFrameAction.create(editorContext.getProjectId(),
                                              pristineObject.toPlainFrame(),
-                                             editedObject.toPlainFrame());
+                                             editedObject.toPlainFrame(),
+                                             changeRequestId);
     }
 
     @Override

--- a/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/editor/DataPropertyFrameEditorManager.java
+++ b/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/editor/DataPropertyFrameEditorManager.java
@@ -2,6 +2,7 @@ package edu.stanford.bmir.protege.web.client.editor;
 
 import edu.stanford.bmir.protege.web.client.frame.DataPropertyFrameEditor;
 import edu.stanford.bmir.protege.web.shared.frame.*;
+import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
 
 import javax.inject.Inject;
 
@@ -36,10 +37,12 @@ public class DataPropertyFrameEditorManager implements EditorManager<OWLEntityCo
     }
 
     @Override
-    public UpdateFrameAction createUpdateObjectAction(DataPropertyFrame pristineObject, DataPropertyFrame editedObject, OWLEntityContext editorContext) {
+    public UpdateFrameAction createUpdateObjectAction(DataPropertyFrame pristineObject, DataPropertyFrame editedObject, OWLEntityContext editorContext,
+                                                      ChangeRequestId changeRequestId) {
         return UpdateDataPropertyFrameAction.create(editorContext.getProjectId(),
                                                     pristineObject.toPlainFrame(),
-                                                    editedObject.toPlainFrame());
+                                                    editedObject.toPlainFrame(),
+                                                    changeRequestId);
     }
 
     @Override

--- a/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/editor/EditorManager.java
+++ b/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/editor/EditorManager.java
@@ -3,6 +3,7 @@ package edu.stanford.bmir.protege.web.client.editor;
 import edu.stanford.bmir.protege.web.shared.dispatch.Action;
 import edu.stanford.bmir.protege.web.shared.dispatch.Result;
 import edu.stanford.bmir.protege.web.shared.frame.UpdateFrameAction;
+import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
 
 /**
  * Author: Matthew Horridge<br>
@@ -16,7 +17,8 @@ public interface EditorManager<C extends EditorCtx, V, A extends Action<R>, R ex
 
     EditorView<V> getView(C editorContext);
 
-    UpdateFrameAction createUpdateObjectAction(V pristineObject, V editedObject, C editorContext);
+    UpdateFrameAction createUpdateObjectAction(V pristineObject, V editedObject, C editorContext,
+                                               ChangeRequestId changeRequestId);
 
     A createAction(C editorContext);
 

--- a/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/editor/EditorPresenter.java
+++ b/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/editor/EditorPresenter.java
@@ -9,12 +9,14 @@ import com.google.gwt.user.client.ui.*;
 import edu.stanford.bmir.protege.web.client.dispatch.DispatchServiceManager;
 import edu.stanford.bmir.protege.web.client.permissions.LoggedInUserProjectCapabilityChecker;
 import edu.stanford.bmir.protege.web.client.progress.HasBusy;
+import edu.stanford.bmir.protege.web.client.uuid.UuidV4Provider;
 import edu.stanford.bmir.protege.web.shared.HasDispose;
 import edu.stanford.bmir.protege.web.shared.dispatch.Action;
 import edu.stanford.bmir.protege.web.shared.dispatch.Result;
 import edu.stanford.bmir.protege.web.shared.entity.EntityDisplay;
 import edu.stanford.bmir.protege.web.shared.event.WebProtegeEventBus;
 import edu.stanford.bmir.protege.web.shared.frame.UpdateFrameAction;
+import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
 import edu.stanford.bmir.protege.web.shared.project.ProjectId;
 
 import javax.annotation.Nonnull;
@@ -74,14 +76,18 @@ public class EditorPresenter implements HasDispose {
 
     private HasBusy hasBusy = busy -> {};
 
+    private final UuidV4Provider uuidV4Provider;
+
     @Inject
     public EditorPresenter(@Nonnull ProjectId projectId, DispatchServiceManager dispatchServiceManager,
                            ContextMapper contextMapper,
-                           LoggedInUserProjectCapabilityChecker capabilityChecker) {
+                           LoggedInUserProjectCapabilityChecker capabilityChecker,
+                           UuidV4Provider uuidV4Provider) {
         this.projectId = projectId;
         this.contextMapper = contextMapper;
         this.dispatchServiceManager = dispatchServiceManager;
         this.capabilityChecker = capabilityChecker;
+        this.uuidV4Provider = uuidV4Provider;
     }
 
     public void start(@Nonnull AcceptsOneWidget container, @Nonnull WebProtegeEventBus eventBus) {
@@ -163,7 +169,8 @@ public class EditorPresenter implements HasDispose {
         }
         final C editorCtx = editorState.getEditorContext();
         EditorManager<C, O, A, R> editorManager = editorState.getEditorManager();
-        UpdateFrameAction updateAction = editorManager.createUpdateObjectAction(pristineValue, editedValue, editorCtx);
+        ChangeRequestId changeRequestId = ChangeRequestId.get(uuidV4Provider.get());
+        UpdateFrameAction updateAction = editorManager.createUpdateObjectAction(pristineValue, editedValue, editorCtx, changeRequestId);
         setEditorState(editedValue, editorCtx, editorManager);
         dispatchServiceManager.execute(updateAction, result -> {});
     }

--- a/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/editor/NamedIndividualFrameEditorManager.java
+++ b/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/editor/NamedIndividualFrameEditorManager.java
@@ -5,6 +5,7 @@ import edu.stanford.bmir.protege.web.shared.dispatch.actions.GetNamedIndividualF
 import edu.stanford.bmir.protege.web.shared.dispatch.actions.GetNamedIndividualFrameResult;
 import edu.stanford.bmir.protege.web.shared.frame.UpdateNamedIndividualFrameAction;
 import edu.stanford.bmir.protege.web.shared.frame.NamedIndividualFrame;
+import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
 
 import javax.inject.Inject;
 
@@ -39,10 +40,12 @@ public class NamedIndividualFrameEditorManager implements EditorManager<OWLEntit
     }
 
     @Override
-    public UpdateNamedIndividualFrameAction createUpdateObjectAction(NamedIndividualFrame pristineObject, NamedIndividualFrame editedObject, OWLEntityContext editorContext) {
+    public UpdateNamedIndividualFrameAction createUpdateObjectAction(NamedIndividualFrame pristineObject, NamedIndividualFrame editedObject, OWLEntityContext editorContext,
+                                                                     ChangeRequestId changeRequestId) {
         return UpdateNamedIndividualFrameAction.create(editorContext.getProjectId(),
                                                        pristineObject.toPlainFrame(),
-                                                       editedObject.toPlainFrame());
+                                                       editedObject.toPlainFrame(),
+                                                       changeRequestId);
     }
 
     @Override

--- a/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/editor/ObjectPropertyFrameEditorManager.java
+++ b/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/editor/ObjectPropertyFrameEditorManager.java
@@ -5,6 +5,7 @@ import edu.stanford.bmir.protege.web.shared.frame.GetObjectPropertyFrameAction;
 import edu.stanford.bmir.protege.web.shared.frame.GetObjectPropertyFrameResult;
 import edu.stanford.bmir.protege.web.shared.frame.ObjectPropertyFrame;
 import edu.stanford.bmir.protege.web.shared.frame.UpdateObjectPropertyFrameAction;
+import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
 
 import javax.inject.Inject;
 
@@ -39,10 +40,12 @@ public class ObjectPropertyFrameEditorManager implements EditorManager<OWLEntity
     }
 
     @Override
-    public UpdateObjectPropertyFrameAction createUpdateObjectAction(ObjectPropertyFrame pristineObject, ObjectPropertyFrame editedObject, OWLEntityContext editorContext) {
+    public UpdateObjectPropertyFrameAction createUpdateObjectAction(ObjectPropertyFrame pristineObject, ObjectPropertyFrame editedObject, OWLEntityContext editorContext,
+                                                                    ChangeRequestId changeRequestId) {
         return UpdateObjectPropertyFrameAction.create(editorContext.getProjectId(),
                                                       pristineObject.toPlainFrame(),
-                                                      editedObject.toPlainFrame());
+                                                      editedObject.toPlainFrame(),
+                                                      changeRequestId);
     }
 
     @Override

--- a/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/events/EventPollingManager.java
+++ b/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/events/EventPollingManager.java
@@ -94,26 +94,32 @@ public class EventPollingManager {
         if(eventList.isEmpty()) {
             return;
         }
-        EventTag eventListStartTag = eventList.getStartTag();
-        if(nextTag.isGreaterOrEqualTo(eventListStartTag)) {
-            // We haven't missed any events - our next retrieval will be from where we got the event to.
+        EventTag eventListEndTag = eventList.getEndTag();
+        if(nextTag.isGreaterOrEqualTo(eventListEndTag)) {
+            // Events arrive over two concurrent paths -- the websocket push
+            // and the polling safety net -- both of which end up here. This
+            // window has already been dispatched via the other path (or is
+            // an older window arriving late), so replaying it would re-apply
+            // stale changes over newer ones: e.g. re-adding a removed parent
+            // to the hierarchy or resurrecting a deleted class (#191).
+            GWT.log("[Event Polling Manager] Skipping already-dispatched events (up to " + eventListEndTag + ")");
+            return;
         }
-        if (!eventList.isEmpty()) {
-            try {
-                for (WebProtegeEvent<?> event : eventList.getEvents()) {
-                    if (event.getSource() != null) {
-                        eventBus.fireEventFromSource(event.asGWTEvent(), event.getSource());
-                    } else {
-                        eventBus.fireEvent(event.asGWTEvent());
-                    }
+        try {
+            for (WebProtegeEvent<?> event : eventList.getEvents()) {
+                if (event.getSource() != null) {
+                    eventBus.fireEventFromSource(event.asGWTEvent(), event.getSource());
+                } else {
+                    eventBus.fireEvent(event.asGWTEvent());
                 }
-                // After dispatching the events handle in the one-shot event awaiter
-                eventAwaiter.handleEvents(eventList.getEvents());
-            } catch (Exception e) {
-                logger.log(Level.SEVERE, "Error while sending events " + e.getMessage());
-            } finally {
-                nextTag = eventList.getEndTag();
             }
+            // After dispatching the events handle in the one-shot event awaiter
+            eventAwaiter.handleEvents(eventList.getEvents());
+        } catch (Exception e) {
+            logger.log(Level.SEVERE, "Error while sending events " + e.getMessage());
+        } finally {
+            // The guard above ensures this only ever moves the tag forward.
+            nextTag = eventListEndTag;
         }
     }
 

--- a/webprotege-gwt-ui-client/src/test/java/edu/stanford/bmir/protege/web/client/events/EventPollingManager_TestCase.java
+++ b/webprotege-gwt-ui-client/src/test/java/edu/stanford/bmir/protege/web/client/events/EventPollingManager_TestCase.java
@@ -1,0 +1,132 @@
+package edu.stanford.bmir.protege.web.client.events;
+
+import com.google.common.collect.ImmutableList;
+import com.google.web.bindery.event.shared.Event;
+import com.google.web.bindery.event.shared.EventBus;
+import edu.stanford.bmir.protege.web.client.dispatch.DispatchServiceManager;
+import edu.stanford.bmir.protege.web.client.user.LoggedInUserProvider;
+import edu.stanford.bmir.protege.web.shared.event.EventList;
+import edu.stanford.bmir.protege.web.shared.event.EventTag;
+import edu.stanford.bmir.protege.web.shared.event.WebProtegeEvent;
+import edu.stanford.bmir.protege.web.shared.project.ProjectId;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.mockito.Mockito.*;
+
+/**
+ * Regression tests for #191: project events reach the client over two
+ * concurrent paths (websocket push and the polling safety net), both of
+ * which funnel into {@link EventPollingManager#dispatchEvents(EventList)}.
+ * A window of events that has already been dispatched must not be replayed
+ * when the other path delivers it again (or delivers an older window late) —
+ * replaying old hierarchy events re-adds removed parents/relationships and
+ * resurrects deleted classes in the UI.
+ */
+@RunWith(MockitoJUnitRunner.Silent.class)
+public class EventPollingManager_TestCase {
+
+    private EventPollingManager manager;
+
+    @Mock
+    private EventBus eventBus;
+
+    @Mock
+    private DispatchServiceManager dispatchServiceManager;
+
+    @Mock
+    private LoggedInUserProvider loggedInUserProvider;
+
+    @Mock
+    private ChangeRequestEventAwaiter eventAwaiter;
+
+    @Before
+    public void setUp() {
+        manager = new EventPollingManager(10_000,
+                                          ProjectId.getNil(),
+                                          eventBus,
+                                          dispatchServiceManager,
+                                          loggedInUserProvider,
+                                          eventAwaiter);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static WebProtegeEvent<?> eventBackedBy(Event<?> gwtEvent) {
+        WebProtegeEvent<Object> event = mock(WebProtegeEvent.class);
+        when(event.asGWTEvent()).thenReturn((Event<Object>) gwtEvent);
+        return event;
+    }
+
+    private static EventList<WebProtegeEvent<?>> window(int startTag, int endTag, WebProtegeEvent<?> event) {
+        return EventList.create(EventTag.get(startTag),
+                                ImmutableList.of(event),
+                                EventTag.get(endTag));
+    }
+
+    @Test
+    public void shouldDispatchAndAdvanceOnForwardProgression() {
+        Event<?> gwtEventA = mock(Event.class);
+        Event<?> gwtEventB = mock(Event.class);
+        WebProtegeEvent<?> eventA = eventBackedBy(gwtEventA);
+        WebProtegeEvent<?> eventB = eventBackedBy(gwtEventB);
+
+        manager.dispatchEvents(window(0, 5, eventA));
+        manager.dispatchEvents(window(5, 8, eventB));
+
+        verify(eventBus).fireEvent(gwtEventA);
+        verify(eventBus).fireEvent(gwtEventB);
+        verify(eventAwaiter, times(2)).handleEvents(any());
+    }
+
+    @Test
+    public void shouldNotReplayAWindowThatWasAlreadyDispatched() {
+        Event<?> gwtEvent = mock(Event.class);
+        WebProtegeEvent<?> event = eventBackedBy(gwtEvent);
+
+        // Same window arrives twice -- e.g. once over the websocket and
+        // once from a poll that was already in flight.
+        manager.dispatchEvents(window(0, 5, event));
+        manager.dispatchEvents(window(0, 5, event));
+
+        verify(eventBus, times(1)).fireEvent(gwtEvent);
+        verify(eventAwaiter, times(1)).handleEvents(any());
+    }
+
+    @Test
+    public void shouldDropAnOlderWindowArrivingAfterANewerOne() {
+        Event<?> newGwtEvent = mock(Event.class);
+        Event<?> staleGwtEvent = mock(Event.class);
+        WebProtegeEvent<?> newEvent = eventBackedBy(newGwtEvent);
+        WebProtegeEvent<?> staleEvent = eventBackedBy(staleGwtEvent);
+
+        // A slow poll issued before the websocket delivery returns late,
+        // carrying an older window of already-applied events.
+        manager.dispatchEvents(window(0, 10, newEvent));
+        manager.dispatchEvents(window(2, 5, staleEvent));
+
+        verify(eventBus, never()).fireEvent(staleGwtEvent);
+    }
+
+    @Test
+    public void shouldNotMoveTheTagBackwardWhenAnOlderWindowArrives() {
+        Event<?> gwtEventA = mock(Event.class);
+        Event<?> staleGwtEvent = mock(Event.class);
+        Event<?> gwtEventC = mock(Event.class);
+        WebProtegeEvent<?> eventA = eventBackedBy(gwtEventA);
+        WebProtegeEvent<?> staleEvent = eventBackedBy(staleGwtEvent);
+        WebProtegeEvent<?> eventC = eventBackedBy(gwtEventC);
+
+        manager.dispatchEvents(window(0, 10, eventA));
+        // Late-arriving older window: must not rewind the high-water mark...
+        manager.dispatchEvents(window(2, 5, staleEvent));
+        // ...otherwise this already-applied window would be replayed too.
+        manager.dispatchEvents(window(6, 10, eventC));
+
+        verify(eventBus).fireEvent(gwtEventA);
+        verify(eventBus, never()).fireEvent(staleGwtEvent);
+        verify(eventBus, never()).fireEvent(gwtEventC);
+    }
+}

--- a/webprotege-gwt-ui-server-core/src/test/java/edu/stanford/bmir/protege/web/shared/frame/UpdateAnnotationPropertyFrame_Serialization_TestCase.java
+++ b/webprotege-gwt-ui-server-core/src/test/java/edu/stanford/bmir/protege/web/shared/frame/UpdateAnnotationPropertyFrame_Serialization_TestCase.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableSet;
 import edu.stanford.bmir.protege.web.shared.dispatch.Action;
 import edu.stanford.bmir.protege.web.shared.dispatch.Result;
 import edu.stanford.bmir.protege.web.shared.match.JsonSerializationTestUtil;
+import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -34,7 +35,8 @@ public class UpdateAnnotationPropertyFrame_Serialization_TestCase {
                         ImmutableSet.of(),
                         ImmutableSet.of()
                 )
-        );
+        ,
+                ChangeRequestId.get("12345678-1234-1234-1234-123456789abc"));
         JsonSerializationTestUtil.testSerialization(action, Action.class);
     }
 }

--- a/webprotege-gwt-ui-server-core/src/test/java/edu/stanford/bmir/protege/web/shared/frame/UpdateClassFrame_Serialization_TestCase.java
+++ b/webprotege-gwt-ui-server-core/src/test/java/edu/stanford/bmir/protege/web/shared/frame/UpdateClassFrame_Serialization_TestCase.java
@@ -5,6 +5,7 @@ import edu.stanford.bmir.protege.web.shared.dispatch.Action;
 import edu.stanford.bmir.protege.web.shared.dispatch.Result;
 import edu.stanford.bmir.protege.web.shared.dispatch.actions.UpdateClassFrameAction;
 import edu.stanford.bmir.protege.web.shared.match.JsonSerializationTestUtil;
+import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -31,7 +32,8 @@ public class UpdateClassFrame_Serialization_TestCase {
                                                            mockOWLClass(),
                                                            ImmutableSet.of(),
                                                            ImmutableSet.of()
-                                                   ));
+                                                   ),
+                ChangeRequestId.get("12345678-1234-1234-1234-123456789abc"));
         JsonSerializationTestUtil.testSerialization(action, Action.class);
     }
 }

--- a/webprotege-gwt-ui-server-core/src/test/java/edu/stanford/bmir/protege/web/shared/frame/UpdateDataPropertyFrame_Serialization_TestCase.java
+++ b/webprotege-gwt-ui-server-core/src/test/java/edu/stanford/bmir/protege/web/shared/frame/UpdateDataPropertyFrame_Serialization_TestCase.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableSet;
 import edu.stanford.bmir.protege.web.shared.dispatch.Action;
 import edu.stanford.bmir.protege.web.shared.dispatch.Result;
 import edu.stanford.bmir.protege.web.shared.match.JsonSerializationTestUtil;
+import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -33,7 +34,8 @@ public class UpdateDataPropertyFrame_Serialization_TestCase {
                                                                   ImmutableSet.of(),
                                                                   ImmutableSet.of(),
                                                                   true
-                                                          ));
+                                                          ),
+                ChangeRequestId.get("12345678-1234-1234-1234-123456789abc"));
         JsonSerializationTestUtil.testSerialization(action, Action.class);
     }
 }

--- a/webprotege-gwt-ui-server-core/src/test/java/edu/stanford/bmir/protege/web/shared/frame/UpdateNamedIndividualFrame_Serialization_TestCase.java
+++ b/webprotege-gwt-ui-server-core/src/test/java/edu/stanford/bmir/protege/web/shared/frame/UpdateNamedIndividualFrame_Serialization_TestCase.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableSet;
 import edu.stanford.bmir.protege.web.shared.dispatch.Action;
 import edu.stanford.bmir.protege.web.shared.dispatch.Result;
 import edu.stanford.bmir.protege.web.shared.match.JsonSerializationTestUtil;
+import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -30,7 +31,8 @@ public class UpdateNamedIndividualFrame_Serialization_TestCase {
                                                                      mockOWLNamedIndividual(), ImmutableSet.of(),
                                                                      ImmutableSet.of(),
                                                                      ImmutableSet.of()
-                                                             ));
+                                                             ),
+                ChangeRequestId.get("12345678-1234-1234-1234-123456789abc"));
         JsonSerializationTestUtil.testSerialization(action, Action.class);
     }
 }

--- a/webprotege-gwt-ui-server-core/src/test/java/edu/stanford/bmir/protege/web/shared/frame/UpdateObjectPropertyFrame_Serialization_TestCase.java
+++ b/webprotege-gwt-ui-server-core/src/test/java/edu/stanford/bmir/protege/web/shared/frame/UpdateObjectPropertyFrame_Serialization_TestCase.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableSet;
 import edu.stanford.bmir.protege.web.shared.dispatch.Action;
 import edu.stanford.bmir.protege.web.shared.dispatch.Result;
 import edu.stanford.bmir.protege.web.shared.match.JsonSerializationTestUtil;
+import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -36,7 +37,8 @@ public class UpdateObjectPropertyFrame_Serialization_TestCase {
                         ImmutableSet.of(),
                         ImmutableSet.of()
                 )
-        );
+        ,
+                ChangeRequestId.get("12345678-1234-1234-1234-123456789abc"));
         JsonSerializationTestUtil.testSerialization(action, Action.class);
     }
 }

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/dispatch/actions/UpdateClassFrameAction.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/dispatch/actions/UpdateClassFrameAction.java
@@ -9,6 +9,7 @@ import edu.stanford.bmir.protege.web.shared.annotations.GwtSerializationConstruc
 import edu.stanford.bmir.protege.web.shared.frame.PlainAnnotationPropertyFrame;
 import edu.stanford.bmir.protege.web.shared.frame.PlainClassFrame;
 import edu.stanford.bmir.protege.web.shared.frame.UpdateFrameAction;
+import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
 import edu.stanford.bmir.protege.web.shared.project.ProjectId;
 
 import javax.annotation.Nonnull;
@@ -27,8 +28,9 @@ public abstract class UpdateClassFrameAction extends UpdateFrameAction<UpdateCla
     @JsonCreator
     public static UpdateClassFrameAction create(@JsonProperty("projectId") ProjectId projectId,
                                                 @JsonProperty("from") PlainClassFrame from,
-                                                @JsonProperty("to") PlainClassFrame to) {
-        return new AutoValue_UpdateClassFrameAction(projectId, from, to);
+                                                @JsonProperty("to") PlainClassFrame to,
+                                                @JsonProperty("changeRequestId") ChangeRequestId changeRequestId) {
+        return new AutoValue_UpdateClassFrameAction(projectId, from, to, changeRequestId);
     }
 
     @Nonnull
@@ -40,4 +42,7 @@ public abstract class UpdateClassFrameAction extends UpdateFrameAction<UpdateCla
 
     @Override
     public abstract PlainClassFrame getTo();
+
+    @Override
+    public abstract ChangeRequestId getChangeRequestId();
 }

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/frame/UpdateAnnotationPropertyFrameAction.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/frame/UpdateAnnotationPropertyFrameAction.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.auto.value.AutoValue;
 import com.google.common.annotations.GwtCompatible;
 import edu.stanford.bmir.protege.web.shared.annotations.GwtSerializationConstructor;
+import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
 import edu.stanford.bmir.protege.web.shared.project.ProjectId;
 
 import javax.annotation.Nonnull;
@@ -24,8 +25,9 @@ public abstract class UpdateAnnotationPropertyFrameAction extends UpdateFrameAct
     @JsonCreator
     public static UpdateAnnotationPropertyFrameAction create(@JsonProperty("projectId") ProjectId projectId,
                                                              @JsonProperty("from") PlainAnnotationPropertyFrame from,
-                                                             @JsonProperty("to") PlainAnnotationPropertyFrame to) {
-        return new AutoValue_UpdateAnnotationPropertyFrameAction(projectId, from, to);
+                                                             @JsonProperty("to") PlainAnnotationPropertyFrame to,
+                                                             @JsonProperty("changeRequestId") ChangeRequestId changeRequestId) {
+        return new AutoValue_UpdateAnnotationPropertyFrameAction(projectId, from, to, changeRequestId);
     }
 
     @Nonnull
@@ -37,4 +39,7 @@ public abstract class UpdateAnnotationPropertyFrameAction extends UpdateFrameAct
 
     @Override
     public abstract PlainAnnotationPropertyFrame getTo();
+
+    @Override
+    public abstract ChangeRequestId getChangeRequestId();
 }

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/frame/UpdateDataPropertyFrameAction.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/frame/UpdateDataPropertyFrameAction.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.auto.value.AutoValue;
 import com.google.common.annotations.GwtCompatible;
+import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
 import edu.stanford.bmir.protege.web.shared.project.HasProjectId;
 import edu.stanford.bmir.protege.web.shared.project.ProjectId;
 
@@ -24,8 +25,9 @@ public abstract class UpdateDataPropertyFrameAction extends UpdateFrameAction<Up
     @JsonCreator
     public static UpdateDataPropertyFrameAction create(@JsonProperty("projectId") ProjectId projectId,
                                                 @JsonProperty("from") PlainDataPropertyFrame from,
-                                                @JsonProperty("to") PlainDataPropertyFrame to) {
-        return new AutoValue_UpdateDataPropertyFrameAction(projectId, from, to);
+                                                @JsonProperty("to") PlainDataPropertyFrame to,
+                                                @JsonProperty("changeRequestId") ChangeRequestId changeRequestId) {
+        return new AutoValue_UpdateDataPropertyFrameAction(projectId, from, to, changeRequestId);
     }
 
     @Nonnull
@@ -37,4 +39,7 @@ public abstract class UpdateDataPropertyFrameAction extends UpdateFrameAction<Up
 
     @Override
     public abstract PlainDataPropertyFrame getTo();
+
+    @Override
+    public abstract ChangeRequestId getChangeRequestId();
 }

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/frame/UpdateFrameAction.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/frame/UpdateFrameAction.java
@@ -2,6 +2,7 @@ package edu.stanford.bmir.protege.web.shared.frame;
 
 import edu.stanford.bmir.protege.web.shared.dispatch.AbstractHasProjectAction;
 import edu.stanford.bmir.protege.web.shared.dispatch.Result;
+import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
 import edu.stanford.bmir.protege.web.shared.project.ProjectId;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -17,4 +18,11 @@ public abstract class UpdateFrameAction<R extends Result> extends AbstractHasPro
     public abstract PlainEntityFrame getFrom();
 
     public abstract PlainEntityFrame getTo();
+
+    /**
+     * Identifies this change request. The backend requires it on every frame
+     * update: without one, computing the hierarchy-changed events for edits
+     * that touch parents fails server-side and the whole edit is rejected.
+     */
+    public abstract ChangeRequestId getChangeRequestId();
 }

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/frame/UpdateNamedIndividualFrameAction.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/frame/UpdateNamedIndividualFrameAction.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.auto.value.AutoValue;
 import com.google.common.annotations.GwtCompatible;
+import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
 import edu.stanford.bmir.protege.web.shared.project.ProjectId;
 
 import javax.annotation.Nonnull;
@@ -24,8 +25,9 @@ public abstract class UpdateNamedIndividualFrameAction extends UpdateFrameAction
     @JsonCreator
     public static UpdateNamedIndividualFrameAction create(@JsonProperty("projectId") ProjectId projectId,
                                                        @JsonProperty("from") PlainNamedIndividualFrame from,
-                                                       @JsonProperty("to") PlainNamedIndividualFrame to) {
-        return new AutoValue_UpdateNamedIndividualFrameAction(projectId, from, to);
+                                                       @JsonProperty("to") PlainNamedIndividualFrame to,
+                                                       @JsonProperty("changeRequestId") ChangeRequestId changeRequestId) {
+        return new AutoValue_UpdateNamedIndividualFrameAction(projectId, from, to, changeRequestId);
     }
 
     @Nonnull
@@ -37,4 +39,7 @@ public abstract class UpdateNamedIndividualFrameAction extends UpdateFrameAction
 
     @Override
     public abstract PlainNamedIndividualFrame getTo();
+
+    @Override
+    public abstract ChangeRequestId getChangeRequestId();
 }

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/frame/UpdateObjectPropertyFrameAction.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/frame/UpdateObjectPropertyFrameAction.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.auto.value.AutoValue;
 import com.google.common.annotations.GwtCompatible;
+import edu.stanford.bmir.protege.web.shared.perspective.ChangeRequestId;
 import edu.stanford.bmir.protege.web.shared.project.ProjectId;
 
 import javax.annotation.Nonnull;
@@ -24,8 +25,9 @@ public abstract class UpdateObjectPropertyFrameAction extends UpdateFrameAction<
     @JsonCreator
     public static UpdateObjectPropertyFrameAction create(@JsonProperty("projectId") ProjectId projectId,
                                                        @JsonProperty("from") PlainObjectPropertyFrame from,
-                                                       @JsonProperty("to") PlainObjectPropertyFrame to) {
-        return new AutoValue_UpdateObjectPropertyFrameAction(projectId, from, to);
+                                                       @JsonProperty("to") PlainObjectPropertyFrame to,
+                                                       @JsonProperty("changeRequestId") ChangeRequestId changeRequestId) {
+        return new AutoValue_UpdateObjectPropertyFrameAction(projectId, from, to, changeRequestId);
     }
 
     @Nonnull
@@ -37,4 +39,7 @@ public abstract class UpdateObjectPropertyFrameAction extends UpdateFrameAction<
 
     @Override
     public abstract PlainObjectPropertyFrame getTo();
+
+    @Override
+    public abstract ChangeRequestId getChangeRequestId();
 }


### PR DESCRIPTION
## Summary

Things a user removed could quietly come back on screen. Removing a parent through the entity editor silently failed — the change looked applied, then reappeared after a refresh — and in some situations the browser could replay old updates over newer ones, bringing back removed parents and relationships or resurrecting deleted classes, even though the data on the server was correct.

Two separate problems caused this, and both are fixed here: the browser now tells the server which change each edit belongs to (without that, edits touching parents were being rejected outright), and updates that have already been applied are no longer applied again when they arrive a second time over a different route.

A new test pins the behaviour down: remove an annotation, remove a parent, delete a class, wait through a couple of update cycles and a page reload, and confirm none of them come back.

Refs #191 — one aspect of the original report (stale data surviving a full page reload) could not be reproduced here and may involve the server side, so this doesn't claim to close the ticket outright.