### PR TITLE
Fix OAuth callback bare 400 after a Keycloak required action

### DIFF
--- a/playwright/tests/01-auth.spec.ts
+++ b/playwright/tests/01-auth.spec.ts
@@ -115,4 +115,30 @@ test.describe('authentication', () => {
     await expect(page).toHaveURL(/#projects\/list/, { timeout: 30_000 });
     await expect(page.locator(ProjectList.root)).toBeVisible();
   });
+
+  test('A7: stale OAuth callback state recovers to a clean sign-in instead of a bare 400 (#290)', async ({
+    page,
+    context,
+    baseURL,
+  }) => {
+    // Simulates resuming a login after a Keycloak "required action" (e.g.
+    // email verification) interrupts and later completes it: the original
+    // login attempt has gone stale, so the authorization-code callback's
+    // `state` no longer matches the OAuth_Token_Request_State cookie the
+    // server has on file. Seed a cookie so the callback hits the actual
+    // mismatch check rather than the "no cookie at all" case.
+    await context.addCookies([
+      {
+        name: 'OAuth_Token_Request_State',
+        value: 'a-previous-login-attempts-state',
+        domain: new URL(baseURL ?? 'http://webprotege-local.edu').hostname,
+        path: '/',
+      },
+    ]);
+    await page.goto('/?state=stale-state&session_state=stale-session&code=stale-code');
+
+    // Before the fix this landed on Tomcat's raw "HTTP Status 400" page.
+    await expect(page).toHaveURL(/\/keycloak\/realms\/webprotege\/protocol\/openid-connect\/auth/);
+    await expect(page.locator(Login.username)).toBeVisible();
+  });
 });

--- a/webprotege-gwt-ui-server/src/main/webapp/WEB-INF/web.xml
+++ b/webprotege-gwt-ui-server/src/main/webapp/WEB-INF/web.xml
@@ -76,6 +76,20 @@
 		<location>/forbidden.jsp</location>
 	</error-page>
 
+	<!-- A 400 here is most often the Keycloak adapter rejecting an OAuth
+	     callback whose 'state' query param no longer matches the
+	     OAuth_Token_Request_State cookie: e.g. the login attempt went stale
+	     while a Keycloak required action (email verification, OTP setup, etc.)
+	     interrupted it, or a concurrent auth challenge overwrote the cookie.
+	     bad-request.jsp only redirects when the request itself looks like
+	     that OAuth callback (context root, 'code' and 'state' present); any
+	     other 400 in the app (e.g. ProjectDownloadServlet's malformed
+	     download-request check) keeps its genuine 400 status. -->
+	<error-page>
+		<error-code>400</error-code>
+		<location>/bad-request.jsp</location>
+	</error-page>
+
 	<servlet>
 		<servlet-name>LogoutServlet</servlet-name>
 		<servlet-class>edu.stanford.bmir.protege.web.server.app.LogoutServlet</servlet-class>

--- a/webprotege-gwt-ui-server/src/main/webapp/bad-request.jsp
+++ b/webprotege-gwt-ui-server/src/main/webapp/bad-request.jsp
@@ -1,0 +1,42 @@
+<%@ page contentType="text/html;charset=UTF-8" language="java" session="false" %>
+<%@ page import="javax.servlet.RequestDispatcher" %>
+<%@ page import="javax.servlet.http.HttpServletResponse" %>
+<%
+    // Reached whenever any endpoint in the app answers a request with
+    // HTTP 400. Only redirect when the request itself looks like the
+    // Keycloak OAuth callback (context root, with 'code' and 'state' query
+    // params): that shape is what a stale state-cookie mismatch produces,
+    // e.g. after a Keycloak required action (email verification, OTP
+    // setup, etc.) or a concurrent auth challenge overwrote the cookie of
+    // the login in progress. Anything else (e.g. ProjectDownloadServlet's
+    // malformed-download-request check) keeps its genuine 400 status
+    // instead of being silently redirected -- this page is a servlet-spec
+    // error-page target, not an OAuth-specific one, so it must not swallow
+    // unrelated 400s from elsewhere in the app.
+    String contextPath = request.getContextPath();
+    String requestUri = (String) request.getAttribute(RequestDispatcher.ERROR_REQUEST_URI);
+    boolean isCallbackShape = requestUri != null
+            && (requestUri.equals(contextPath) || requestUri.equals(contextPath + "/"))
+            && request.getParameter("code") != null
+            && request.getParameter("state") != null;
+
+    if (isCallbackShape) {
+        String target = contextPath + "/";
+        // no-store keeps a proxy from caching this transient bounce past
+        // the moment it applies.
+        response.setHeader("Cache-Control", "no-store");
+        response.sendRedirect(target);
+%><html>
+<head><title>Signing you in&hellip;</title></head>
+<body><p>Signing you in&hellip; if nothing happens, <a href="<%= target %>">click here</a>.</p></body>
+</html>
+<%
+    } else {
+        response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+%><html>
+<head><title>HTTP Status 400 &ndash; Bad Request</title></head>
+<body><h1>HTTP Status 400 &ndash; Bad Request</h1></body>
+</html>
+<%
+    }
+%>


### PR DESCRIPTION
## What was happening

If a login gets interrupted partway through — say Keycloak asks the user to verify their email first — and the user finishes that step and comes back, WebProtégé fails to log them in. Instead they land on a plain, ugly "HTTP Status 400 – Bad Request" page from Tomcat, even though they did everything right.

## Why

Keycloak keeps track of an in-progress login using a cookie (`OAuth_Token_Request_State`). By the time a "required action" like email verification finishes, that cookie no longer matches what Keycloak sends back, so the login adapter rejects the request outright with a bare 400 page instead of just retrying.

## The fix

Tomcat lets you map error codes to a custom page, the same way this app already turns a 403 into a nicer "forbidden" page. This adds the same idea for 400s: a new `bad-request.jsp` that checks whether the failed request actually looks like this OAuth callback (i.e. hitting the site's root URL with `code` and `state` parameters). If so, it quietly redirects back to the homepage, which kicks off a fresh, working login — the user barely notices anything went wrong.

Any other 400 in the app (there's one other spot, an internal check in the file-download code) is left alone and still returns a normal 400, so nothing else is affected.

## Testing

Added an automated browser test that recreates the exact failure (a stale login state hitting the callback) and checks that it now recovers cleanly instead of showing the error page. Ran the full sign-in test suite against a real local deployment to confirm nothing else broke, and separately confirmed the unrelated download-error case still behaves as before.