### PR TITLE
Extend sharing e2e test to verify the write path actually persists (fixes #289)

### DIFF
--- a/playwright/docker-compose.yml
+++ b/playwright/docker-compose.yml
@@ -44,7 +44,7 @@ services:
     networks: [wp]
 
   webprotege-keycloak:
-    image: protegeproject/webprotege-keycloak:2.0.1
+    image: protegeproject/webprotege-keycloak:2.0.3
     depends_on:
       rabbitmq:
         condition: service_healthy
@@ -148,7 +148,7 @@ services:
       - "${SERVER_HOST:-localhost}:host-gateway"
 
   webprotege-authorization-service:
-    image: protegeproject/webprotege-authorization-service:3.0.9
+    image: protegeproject/webprotege-authorization-service:3.0.10
     depends_on:
       webprotege-keycloak:
         condition: service_healthy
@@ -165,7 +165,7 @@ services:
     networks: [wp]
 
   webprotege-user-management-service:
-    image: protegeproject/webprotege-user-management-service:1.0.10
+    image: protegeproject/webprotege-user-management-service:1.0.12
     depends_on:
       webprotege-keycloak:
         condition: service_healthy
@@ -254,7 +254,7 @@ services:
     networks: [wp]
 
   webprotege-backend-service:
-    image: protegeproject/webprotege-backend-service:5.0.8
+    image: protegeproject/webprotege-backend-service:5.0.16
     user: root
     depends_on:
       mongo:

--- a/playwright/tests/15-sharing-permissions.spec.ts
+++ b/playwright/tests/15-sharing-permissions.spec.ts
@@ -1,29 +1,43 @@
-import { Page } from '@playwright/test';
+import { Locator, Page } from '@playwright/test';
 import { test, expect, projectIdOf } from '../support/fixtures';
 import {
   COLLAB_USER,
   KEYCLOAK_DEFAULTS,
+  TEST_USER,
   ensureTestUser,
 } from '../support/keycloak';
 import { Hierarchy, ProjectView, Sharing } from '../support/selectors';
 
 /**
- * Sharing UI and permission enforcement.
+ * Sharing UI, persistence, and permission enforcement.
  *
- * SCOPE NOTE: this deployment's sharing WRITE path is broken — after a
- * SetProjectSharingSettings apply, the sharing page reloads with an empty
- * people list (the stored settings no longer render), so a shared user
- * never actually gains access. Persistence of a share and VIEW-only
- * capability gating therefore cannot be asserted green here. What is
- * reliable and covered below: the add-person editor UI, and the
- * authorization gate that denies a user with no access (which needs no
- * write). The sharing page opening + link-sharing toggle are covered by
- * 10-sharing.spec.ts.
+ * This file used to stop short of clicking Apply because the sharing
+ * write-path was known-broken on this deployment (see GH #289). Several
+ * backend fixes have since landed that this suite now guards against
+ * regressing: an owner could lose their own access on save, a broken user
+ * lookup could make every save fail outright with a spurious "duplicate
+ * user" error, and sharing with someone who has never registered used to
+ * just silently vanish instead of staying visible (that person is now
+ * emailed and gains access automatically once they register and verify).
+ * SH2 and SH3 assert the first and last of those directly.
+ *
+ * SH2 in particular is what it is — a fresh login actually opening the
+ * project, not just a row appearing in the sharing settings — because that
+ * exact assertion is what caught two independent, previously-hidden
+ * NullPointerExceptions in webprotege-authorization-service that made
+ * every capability check fail for an ordinary collaborator (a role-
+ * hierarchy-cycle logging crash, and a JWT-roles-extraction crash for
+ * anyone with no "webprotege" client roles - which is nearly everyone
+ * except admins). Checking only the sharing-settings row would have
+ * missed both. The `project` fixture also fails any test outright if a
+ * backend error surfaces during it, so a regression in the "duplicate
+ * user" style is caught even if no assertion here happens to target it.
  */
 
 test.beforeAll(async () => {
   // A plain realm user with no webprotege client roles and no share on any
-  // project — used to prove the access gate denies non-collaborators.
+  // project — used to prove the access gate denies non-collaborators, and
+  // reused as the person shared with in SH2 once granted.
   await ensureTestUser(KEYCLOAK_DEFAULTS, COLLAB_USER, []);
 });
 
@@ -33,6 +47,70 @@ async function loginAs(page: Page, user = COLLAB_USER): Promise<void> {
   await page.locator('#password').fill(user.password);
   await page.locator('#kc-login').click();
   await page.waitForURL(/#projects\/list/, { timeout: 30_000 });
+}
+
+/** Clicks Apply and waits for the save round-trip to complete before returning. */
+async function applyAndAwaitSave(page: Page): Promise<void> {
+  await Promise.all([
+    page.waitForResponse((response) => /dispatchservice/i.test(response.url())),
+    page.locator(Sharing.applyButton).click(),
+  ]);
+}
+
+/**
+ * Finds the sharing-page row whose person field currently holds `value`.
+ * Polls rather than a single pass: the rows re-render asynchronously as
+ * the page's data loads. Throws if `value` never shows up within
+ * `timeout` — the failure mode a pre-#177 regression would hit, since an
+ * unresolved entry used to be silently dropped rather than kept.
+ */
+async function findPersonRowByValue(
+  page: Page,
+  value: string,
+  timeout = 15_000,
+): Promise<Locator> {
+  const deadline = Date.now() + timeout;
+  for (;;) {
+    const rows = page.locator(Sharing.personRow);
+    const count = await rows.count();
+    for (let i = 0; i < count; i++) {
+      const row = rows.nth(i);
+      const input = row.locator(Sharing.personInput).first();
+      if ((await input.count()) > 0 && (await input.inputValue()) === value) {
+        return row;
+      }
+    }
+    if (Date.now() > deadline) {
+      throw new Error(
+        `No sharing row found with person value "${value}" after ${timeout}ms`,
+      );
+    }
+    await page.waitForTimeout(300);
+  }
+}
+
+/** Types `value` into the sharing page's trailing blank row and commits it. */
+async function addPersonRow(
+  page: Page,
+  value: string,
+  permission: 'VIEW' | 'COMMENT' | 'EDIT' | 'MANAGE',
+): Promise<void> {
+  const rowsBefore = await page.locator(Sharing.personRow).count();
+  const blankRow = page.locator(Sharing.personRow).last();
+  const input = blankRow.locator(Sharing.personInput).first();
+  await input.click();
+  // The oracle fires per keyup, so pressSequentially (not fill); Escape
+  // dismisses the completion popup and Tab blurs to commit the row value.
+  await input.pressSequentially(value, { delay: 30 });
+  await page.keyboard.press('Escape');
+  await page.keyboard.press('Tab');
+  // The value-list runs in AUTOMATIC mode, so committing the row appends a
+  // fresh trailing blank — the list grows by one.
+  await expect(page.locator(Sharing.personRow)).toHaveCount(rowsBefore + 1, {
+    timeout: 15_000,
+  });
+  const committedRow = page.locator(Sharing.personRow).nth(rowsBefore - 1);
+  await committedRow.locator(Sharing.permissionSelect).selectOption(permission);
 }
 
 test.describe('sharing and permissions', () => {
@@ -65,10 +143,12 @@ test.describe('sharing and permissions', () => {
     }
   });
 
-  test('SH2: the sharing page accepts a new person row with a permission', async ({
+  test('SH2: sharing with a registered user persists, grants access, and the owner keeps theirs', async ({
     page,
     project,
+    browser,
   }) => {
+    test.setTimeout(90_000);
     const projectId = projectIdOf(project);
 
     await page.locator(Sharing.topBarButton).click();
@@ -76,38 +156,113 @@ test.describe('sharing and permissions', () => {
     await expect(page.locator(Sharing.personRow).last()).toBeVisible({
       timeout: 15_000,
     });
-    const rowsBefore = await page.locator(Sharing.personRow).count();
 
-    // Type a username into the trailing blank row's SuggestBox. The oracle
-    // fires per keyup, so pressSequentially (not fill); Escape dismisses
-    // the completion popup and Tab blurs to commit the row value.
-    const blankRow = page.locator(Sharing.personRow).last();
-    const input = blankRow.locator(Sharing.personInput).first();
-    await input.click();
-    await input.pressSequentially(COLLAB_USER.username, { delay: 30 });
-    await page.keyboard.press('Escape');
-    await page.keyboard.press('Tab');
-
-    // The value-list runs in AUTOMATIC mode, so committing the row appends
-    // a fresh trailing blank — the list grows by one, and our row is the
-    // one just before the new blank.
-    await expect(page.locator(Sharing.personRow)).toHaveCount(rowsBefore + 1, {
-      timeout: 15_000,
-    });
-    const committedRow = page.locator(Sharing.personRow).nth(rowsBefore - 1);
+    await addPersonRow(page, COLLAB_USER.username, 'EDIT');
     // The SuggestBox keeps the typed text as its live value (GWT sets the
     // value property, not the attribute, so assert with toHaveValue).
-    await expect(committedRow.locator(Sharing.personInput)).toHaveValue(
-      COLLAB_USER.username,
-    );
-    // The row exposes the permission selector (values are the enum names).
-    await committedRow.locator(Sharing.permissionSelect).selectOption('EDIT');
-    await expect(committedRow.locator(Sharing.permissionSelect)).toHaveValue(
-      'EDIT',
-    );
+    await expect(
+      (await findPersonRowByValue(page, COLLAB_USER.username)).locator(
+        Sharing.personInput,
+      ),
+    ).toHaveValue(COLLAB_USER.username);
 
-    // NOTE: not applied — the SetProjectSharingSettings write-path is
-    // broken on this deployment (see the file header), so persistence is
-    // deliberately not asserted.
+    await applyAndAwaitSave(page);
+
+    // Verify persistence from a brand-new session rather than reloading
+    // this tab: a hard reload round-trips through Keycloak's silent SSO
+    // renewal and can drop the deep-link hash, landing back on the
+    // project list for reasons unrelated to sharing at all. A fresh login
+    // has no client-side state to fall back on, so it can only be
+    // rendering what the backend actually has stored. This also proves
+    // the owner still has their own access after the save (the scenario
+    // GH backend-service#176 fixed) — a locked-out owner would fail the
+    // very first assertion below.
+    const ownerCtx = await browser.newContext({
+      storageState: { cookies: [], origins: [] },
+    });
+    try {
+      const ownerPage = await ownerCtx.newPage();
+      await loginAs(ownerPage, TEST_USER);
+      await ownerPage.goto(project.url);
+      await expect(ownerPage.locator(ProjectView.root)).toBeVisible({
+        timeout: 30_000,
+      });
+      await ownerPage.locator(Sharing.topBarButton).click();
+      await expect(ownerPage.locator(Sharing.personRow).last()).toBeVisible({
+        timeout: 15_000,
+      });
+      const persistedRow = await findPersonRowByValue(
+        ownerPage,
+        COLLAB_USER.username,
+      );
+      await expect(persistedRow.locator(Sharing.permissionSelect)).toHaveValue(
+        'EDIT',
+      );
+    } finally {
+      await ownerCtx.close();
+    }
+
+    // The collaborator now actually has access — proves the grant landed
+    // on the identity that logs in, not just that a row renders.
+    const collabCtx = await browser.newContext({
+      storageState: { cookies: [], origins: [] },
+    });
+    try {
+      const p2 = await collabCtx.newPage();
+      await loginAs(p2, COLLAB_USER);
+      await p2.goto(project.url);
+      await expect(p2.locator(ProjectView.root)).toBeVisible({ timeout: 30_000 });
+      await expect(p2.getByText('Forbidden')).toHaveCount(0);
+    } finally {
+      await collabCtx.close();
+    }
+  });
+
+  test('SH3: sharing with an unregistered email keeps the row visible afterwards', async ({
+    page,
+    project,
+    browser,
+  }) => {
+    const projectId = projectIdOf(project);
+    // A never-registered address in the reserved .invalid TLD (RFC 2606) —
+    // guaranteed not to exist, and never deliverable, so nothing outside
+    // this test can ever be affected by it.
+    const pendingEmail = `pending-${crypto.randomUUID().slice(0, 8)}@e2e.invalid`;
+
+    await page.locator(Sharing.topBarButton).click();
+    await expect(page).toHaveURL(new RegExp(`#projects/${projectId}/sharing`));
+    await expect(page.locator(Sharing.personRow).last()).toBeVisible({
+      timeout: 15_000,
+    });
+
+    await addPersonRow(page, pendingEmail, 'VIEW');
+    await applyAndAwaitSave(page);
+
+    // Fresh session, not the tab that made the save — proves the entry
+    // was actually persisted server-side rather than just reflecting
+    // local UI state that was never round-tripped. Before the
+    // pending-invitation fix, an unresolved entry was dropped silently on
+    // save and would simply not be here.
+    const ctx = await browser.newContext({
+      storageState: { cookies: [], origins: [] },
+    });
+    try {
+      const freshPage = await ctx.newPage();
+      await loginAs(freshPage, TEST_USER);
+      await freshPage.goto(project.url);
+      await expect(freshPage.locator(ProjectView.root)).toBeVisible({
+        timeout: 30_000,
+      });
+      await freshPage.locator(Sharing.topBarButton).click();
+      await expect(freshPage.locator(Sharing.personRow).last()).toBeVisible({
+        timeout: 15_000,
+      });
+      const pendingRow = await findPersonRowByValue(freshPage, pendingEmail);
+      await expect(pendingRow.locator(Sharing.permissionSelect)).toHaveValue(
+        'VIEW',
+      );
+    } finally {
+      await ctx.close();
+    }
   });
 });


### PR DESCRIPTION
## What this changes

There's an automated test that checks the "share this project with someone" feature. Until now, the test only checked that you could type in a person's name and pick a permission level — it stopped right before actually saving, because at the time this test was written, saving didn't reliably work.

That's since been fixed, so this test now goes all the way:

- It saves the change, then checks — using a completely fresh login, not just reloading the page — that the person really was added with the right permission.
- It logs in as that person and confirms they can now actually open the project.
- It checks that the project owner still has access to their own project afterward (sharing shouldn't ever lock out the owner).
- It also checks a related case: sharing with someone who hasn't signed up yet used to make their entry quietly disappear after a page reload. Now it stays visible, as expected.

## Why it matters

By making the test actually verify "can this person get in," instead of just "does a row show up on screen," it caught two real, previously unnoticed bugs in a different part of the system that were silently blocking ordinary collaborators from accessing shared projects (fixed separately in protegeproject/webprotege-authorization-service#38). A test that only checked the on-screen row would have missed both.

## Verification

Ran the whole test file against a local setup with the related fixes in place — all 3 tests pass in about 15 seconds, no flakiness or retries needed.