### PR TITLE
Anchor at the current head on project open instead of replaying all history

### DIFF
--- a/playwright/.gitignore
+++ b/playwright/.gitignore
@@ -5,3 +5,4 @@ playwright-report/
 test-results/
 blob-report/
 playwright/.cache/
+perf-results/

--- a/playwright/package.json
+++ b/playwright/package.json
@@ -7,6 +7,7 @@
     "test": "playwright test",
     "test:headed": "playwright test --headed",
     "test:smoke": "playwright test scenarios/regression-smoke",
+    "test:perf": "playwright test -c playwright.perf.config.ts",
     "test:airplane": "playwright test scenarios/airplane-ontology",
     "report": "playwright show-report",
     "stack:up": "docker compose up -d --wait",

--- a/playwright/perf/ui-baseline.perf.ts
+++ b/playwright/perf/ui-baseline.perf.ts
@@ -1,0 +1,320 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { Page } from '@playwright/test';
+import { test, expect } from '../support/fixtures';
+import { CreateEntityDialog, Hierarchy, ProjectView } from '../support/selectors';
+
+/**
+ * UI performance baseline for epic #303 (WebSocket/STOMP -> SSE).
+ *
+ * Three user-perceived metrics, measured against whatever stack is running:
+ *   1. Acting-user latency: create-class dialog submit -> new row in own tree.
+ *   2. Propagation delay: user A submits -> the row appears in user B's tree.
+ *   3. Project-open time, plus the size/duration of the project-events
+ *      history request that the 10s polling timer fires after open (#301).
+ *
+ * Results are printed, attached to the HTML report, and written as JSON to
+ * test-results/perf/ so before/after runs can be diffed. Run via
+ * `npm run test:perf` (workers=1, retries=0 — see playwright.perf.config.ts).
+ *
+ * Note for before/after comparisons: the project fixture installs a
+ * MutationObserver error gate on the page. Its overhead is small and constant
+ * and it is present in every run using this harness, so comparisons remain
+ * valid — but do not compare against numbers gathered without the fixture.
+ */
+
+const STORAGE_STATE = path.join(__dirname, '..', '.auth', 'storageState.json');
+// Not under test-results/ — Playwright wipes that directory at the start of
+// every run, which would destroy earlier metrics when re-running one test.
+const RESULTS_DIR = path.join(__dirname, '..', 'perf-results');
+
+const LATENCY_ITERATIONS = 15;
+const PROPAGATION_ITERATIONS = 12;
+const OPEN_ITERATIONS = 5;
+const SEED_CLASS_COUNT = 25;
+// The first poll fires one full polling period (~10s) after project open, so
+// each open-iteration parks this long to catch the history request.
+const POLL_CAPTURE_WINDOW_MS = 13_000;
+
+test.describe.configure({ mode: 'serial' });
+
+interface MetricStats {
+  n: number;
+  medianMs: number;
+  p90Ms: number;
+  minMs: number;
+  maxMs: number;
+  samplesMs: number[];
+}
+
+function statsOf(samples: number[]): MetricStats {
+  const sorted = [...samples].sort((a, b) => a - b);
+  const at = (q: number) => sorted[Math.min(sorted.length - 1, Math.floor(q * sorted.length))];
+  return {
+    n: sorted.length,
+    medianMs: Math.round(at(0.5)),
+    p90Ms: Math.round(at(0.9)),
+    minMs: Math.round(sorted[0]),
+    maxMs: Math.round(sorted[sorted.length - 1]),
+    samplesMs: samples.map((s) => Math.round(s)),
+  };
+}
+
+function saveResults(name: string, data: unknown): void {
+  fs.mkdirSync(RESULTS_DIR, { recursive: true });
+  fs.writeFileSync(path.join(RESULTS_DIR, `${name}.json`), JSON.stringify(data, null, 2));
+}
+
+function runMetadata() {
+  return {
+    baseUrl: process.env.WEBPROTEGE_BASE_URL ?? 'http://localhost',
+    capturedAt: new Date().toISOString(),
+  };
+}
+
+/** Same 12 lines as tests/03-classes.spec.ts — duplicated per suite precedent. */
+async function createClassUnder(page: Page, parentLabel: string, newLabel: string): Promise<void> {
+  await page.locator(Hierarchy.treeNode(parentLabel)).first().click();
+  await page.locator(Hierarchy.toolbar.create).first().click();
+  await expect(page.locator(CreateEntityDialog.root)).toBeVisible();
+  await page.locator(CreateEntityDialog.name).fill(newLabel);
+  await page.locator(CreateEntityDialog.submit).click();
+  await expect(page.locator(Hierarchy.treeNode(newLabel))).toBeVisible({
+    timeout: 15_000,
+  });
+}
+
+/**
+ * Arm in-page timestamps: t0 on the dialog's primary-button click, t1 when a
+ * tree row containing `label` first appears. Both are epoch-based
+ * (performance.timeOrigin + performance.now()) so they can be compared across
+ * pages on the same machine. In-page measurement avoids Playwright RPC/poll
+ * jitter, which is comparable in size to sub-second latencies.
+ */
+async function armSubmitProbe(page: Page, label: string): Promise<void> {
+  await page.evaluate((newLabel) => {
+    const w = window as any;
+    w.__perf = { t0: 0, t1: 0 };
+    if (w.__perfClick) document.removeEventListener('click', w.__perfClick, true);
+    w.__perfClick = (e: Event) => {
+      const target = e.target as HTMLElement | null;
+      if (w.__perf.t0 === 0 && target?.closest('.wp-modal button.wp-btn--dialog.wp-btn--primary')) {
+        w.__perf.t0 = performance.timeOrigin + performance.now();
+      }
+    };
+    document.addEventListener('click', w.__perfClick, true);
+    if (w.__perfObs) w.__perfObs.disconnect();
+    w.__perfObs = new MutationObserver(() => {
+      for (const row of document.querySelectorAll('.gt-tree__row')) {
+        if (row.textContent && row.textContent.includes(newLabel)) {
+          w.__perf.t1 = performance.timeOrigin + performance.now();
+          w.__perfObs.disconnect();
+          return;
+        }
+      }
+    });
+    w.__perfObs.observe(document.body, { childList: true, subtree: true });
+  }, label);
+}
+
+/** Arm only the appearance half of the probe (for the observing page B). */
+async function armAppearanceProbe(page: Page, label: string): Promise<void> {
+  await page.evaluate((newLabel) => {
+    const w = window as any;
+    w.__perf = { t0: 0, t1: 0 };
+    if (w.__perfObs) w.__perfObs.disconnect();
+    w.__perfObs = new MutationObserver(() => {
+      for (const row of document.querySelectorAll('.gt-tree__row')) {
+        if (row.textContent && row.textContent.includes(newLabel)) {
+          w.__perf.t1 = performance.timeOrigin + performance.now();
+          w.__perfObs.disconnect();
+          return;
+        }
+      }
+    });
+    w.__perfObs.observe(document.body, { childList: true, subtree: true });
+  }, label);
+}
+
+const readPerf = (page: Page) => page.evaluate(() => (window as any).__perf as { t0: number; t1: number });
+
+test('P1: acting-user latency — create-class submit to own tree update', async ({ page, project }, testInfo) => {
+  const samples: number[] = [];
+  for (let i = 0; i < LATENCY_ITERATIONS; i++) {
+    const label = `PerfLat_${i}`;
+    // Open and fill the dialog BEFORE arming, so the only primary-button
+    // click after arming is the submit we want to time.
+    await page.locator(Hierarchy.treeNode('owl:Thing')).first().click();
+    await page.locator(Hierarchy.toolbar.create).first().click();
+    await expect(page.locator(CreateEntityDialog.root)).toBeVisible();
+    await page.locator(CreateEntityDialog.name).fill(label);
+    await armSubmitProbe(page, label);
+    await page.locator(CreateEntityDialog.submit).click();
+    await page.waitForFunction(() => (window as any).__perf.t1 > 0, undefined, { timeout: 20_000 });
+    const { t0, t1 } = await readPerf(page);
+    expect(t0, 'submit click was not captured').toBeGreaterThan(0);
+    samples.push(t1 - t0);
+  }
+  const result = { metric: 'acting-user-latency', ...runMetadata(), stats: statsOf(samples) };
+  console.log(JSON.stringify(result, null, 2));
+  await testInfo.attach('acting-user-latency', { body: JSON.stringify(result, null, 2), contentType: 'application/json' });
+  saveResults('acting-user-latency', result);
+});
+
+test('P2: propagation delay — user A edit to user B tree update', async ({ page, browser, project }, testInfo) => {
+  // Second session as the same user, reusing the saved storage state — both
+  // sessions receive project events; no sharing setup needed.
+  const contextB = await browser.newContext({ storageState: STORAGE_STATE });
+  const pageB = await contextB.newPage();
+
+  // Transport diagnostics on B: websocket frames on /wsapps, and completed
+  // GetProjectEventsAction polls. Registered before goto so the socket opened
+  // during bootstrap is captured. Node Date.now() is comparable to the pages'
+  // epoch stamps on the same machine to within ms.
+  const wsFrameTimes: number[] = [];
+  pageB.on('websocket', (ws) => {
+    if (!/wsapps/.test(ws.url())) return;
+    ws.on('framereceived', () => wsFrameTimes.push(Date.now()));
+  });
+  // GWT-RPC bodies are obfuscated in production compiles, so individual
+  // actions can't be identified; count every dispatch round-trip instead.
+  // On the passive page B these are only the 10s poll ticks and the
+  // TranslateEventListAction round-trip a websocket frame triggers.
+  const pollDoneTimes: number[] = [];
+  pageB.on('response', (response) => {
+    if (!/dispatchservice/i.test(response.request().url())) return;
+    pollDoneTimes.push(Date.now());
+  });
+
+  await pageB.goto(project.url);
+  await expect(pageB.locator(ProjectView.root)).toBeVisible({ timeout: 30_000 });
+  await expect(pageB.locator(Hierarchy.treeNode('owl:Thing'))).toBeVisible({ timeout: 15_000 });
+
+  // Warmup edit: proves B's tree is live (and reveals owl:Thing's children)
+  // before measurement starts. Falls back to selecting the root if the row
+  // does not surface on its own.
+  await armAppearanceProbe(pageB, 'PerfProp_warm');
+  await createClassUnder(page, 'owl:Thing', 'PerfProp_warm');
+  try {
+    await pageB.waitForFunction(() => (window as any).__perf.t1 > 0, undefined, { timeout: 30_000 });
+  } catch {
+    await pageB.locator(Hierarchy.treeNode('owl:Thing')).first().click();
+    await pageB.waitForFunction(() => (window as any).__perf.t1 > 0, undefined, { timeout: 15_000 });
+  }
+
+  const samples: Array<{ deltaMs: number; wsFramesInWindow: number; dispatchRoundTripsInWindow: number }> = [];
+  for (let i = 0; i < PROPAGATION_ITERATIONS; i++) {
+    const label = `PerfProp_${i}`;
+    await armAppearanceProbe(pageB, label);
+    await page.locator(Hierarchy.treeNode('owl:Thing')).first().click();
+    await page.locator(Hierarchy.toolbar.create).first().click();
+    await expect(page.locator(CreateEntityDialog.root)).toBeVisible();
+    await page.locator(CreateEntityDialog.name).fill(label);
+    await armSubmitProbe(page, label);
+    await page.locator(CreateEntityDialog.submit).click();
+    await expect(page.locator(Hierarchy.treeNode(label))).toBeVisible({ timeout: 15_000 });
+    // Worst case today is the 10s polling safety net; allow head-room.
+    await pageB.waitForFunction(() => (window as any).__perf.t1 > 0, undefined, { timeout: 30_000 });
+    const { t0 } = await readPerf(page);
+    const { t1 } = await readPerf(pageB);
+    expect(t0, 'submit click was not captured on A').toBeGreaterThan(0);
+    samples.push({
+      deltaMs: t1 - t0,
+      wsFramesInWindow: wsFrameTimes.filter((t) => t >= t0 - 50 && t <= t1 + 50).length,
+      dispatchRoundTripsInWindow: pollDoneTimes.filter((t) => t >= t0 - 50 && t <= t1 + 50).length,
+    });
+  }
+  await contextB.close();
+
+  const result = {
+    metric: 'propagation-delay',
+    ...runMetadata(),
+    stats: statsOf(samples.map((s) => s.deltaMs)),
+    // Propagation under STOMP+polling is expected to be bimodal; the raw
+    // per-sample transport diagnostics make the split interpretable.
+    samples,
+  };
+  console.log(JSON.stringify(result, null, 2));
+  await testInfo.attach('propagation-delay', { body: JSON.stringify(result, null, 2), contentType: 'application/json' });
+  saveResults('propagation-delay', result);
+});
+
+test('P3: project-open time and event-history request', async ({ page, project }, testInfo) => {
+  // Seed history with sequential creates — each is its own revision/event
+  // batch (a single bulk create would collapse into one revision).
+  for (let i = 0; i < SEED_CLASS_COUNT; i++) {
+    await createClassUnder(page, 'owl:Thing', `PerfSeed_${String(i).padStart(2, '0')}`);
+  }
+
+  // The production GWT compile obfuscates RPC type names (verified: request
+  // bodies carry hash tokens like "8a", never "GetProjectEventsAction"), so
+  // requests cannot be identified by body content. Instead, capture every
+  // dispatchservice round-trip: the page is parked idle after ready, so any
+  // request initiated during the park window is timer-driven — i.e. the
+  // project-events poll. The full-history response is the largest of those.
+  interface EventsRequestSample {
+    sinceNavMs: number;
+    requestMs: number;
+    bytes: number;
+  }
+  let navStart = 0;
+  let dispatchSamples: EventsRequestSample[] = [];
+  page.on('response', async (response) => {
+    const req = response.request();
+    if (!/dispatchservice/i.test(req.url())) return;
+    try {
+      dispatchSamples.push({
+        sinceNavMs: Date.now() - navStart,
+        requestMs: Math.round(response.request().timing().responseEnd),
+        bytes: (await response.body()).byteLength,
+      });
+    } catch {
+      // Body unavailable after navigation — skip the sample.
+    }
+  });
+
+  const opens: Array<{ kind: 'warmup' | 'measured'; readyMs: number; historyRequest?: EventsRequestSample; parkedRequests?: EventsRequestSample[] }> = [];
+  for (let i = 0; i <= OPEN_ITERATIONS; i++) {
+    dispatchSamples = [];
+    // about:blank first forces a genuine GWT re-bootstrap without a Keycloak
+    // round-trip (a hard reload can bounce through Keycloak and drop the
+    // deep-link hash).
+    await page.goto('about:blank');
+    navStart = Date.now();
+    await page.goto(project.url);
+    await expect(page.locator(ProjectView.root)).toBeVisible({ timeout: 30_000 });
+    await expect(page.locator(Hierarchy.treeNode('owl:Thing'))).toBeVisible({ timeout: 15_000 });
+    const readyMs = Date.now() - navStart;
+    expect(page.url(), 'landed off the project (Keycloak bounce?)').toContain(project.url.split('#')[1].split('/')[1]);
+    // Park to catch the polling timer's first (full-history) request, which
+    // fires one full period after open — not at open.
+    await page.waitForTimeout(POLL_CAPTURE_WINDOW_MS);
+    // Poll ticks are the requests initiated while parked (well after ready).
+    const parked = dispatchSamples.filter((s) => s.sinceNavMs > readyMs + 2_000);
+    const history = [...parked].sort((a, b) => b.bytes - a.bytes)[0];
+    opens.push({
+      kind: i === 0 ? 'warmup' : 'measured',
+      readyMs,
+      historyRequest: history,
+      parkedRequests: parked,
+    });
+  }
+
+  const measured = opens.filter((o) => o.kind === 'measured');
+  expect(
+    measured.some((o) => o.historyRequest),
+    'no GetProjectEventsAction request captured — postData filter or park window is wrong',
+  ).toBeTruthy();
+  const result = {
+    metric: 'project-open',
+    ...runMetadata(),
+    seedClassCount: SEED_CLASS_COUNT,
+    readyStats: statsOf(measured.map((o) => o.readyMs)),
+    historyRequestBytes: statsOf(measured.filter((o) => o.historyRequest).map((o) => o.historyRequest!.bytes)),
+    historyRequestMs: statsOf(measured.filter((o) => o.historyRequest).map((o) => o.historyRequest!.requestMs)),
+    opens,
+  };
+  console.log(JSON.stringify(result, null, 2));
+  await testInfo.attach('project-open', { body: JSON.stringify(result, null, 2), contentType: 'application/json' });
+  saveResults('project-open', result);
+});

--- a/playwright/playwright.perf.config.ts
+++ b/playwright/playwright.perf.config.ts
@@ -1,0 +1,42 @@
+import { defineConfig, devices } from '@playwright/test';
+import * as path from 'path';
+
+const BASE_URL = process.env.WEBPROTEGE_BASE_URL ?? 'http://localhost';
+const STORAGE_STATE = path.join(__dirname, '.auth', 'storageState.json');
+
+/**
+ * Performance measurement runs. Kept apart from playwright.config.ts on
+ * purpose: retries would silently double-run a measurement and parallel
+ * workers would contaminate timings with CPU contention on the shared
+ * docker stack, so this config pins workers to 1 and retries to 0.
+ * Invoke with `npm run test:perf`.
+ */
+export default defineConfig({
+  testDir: './perf',
+  testMatch: /.*\.perf\.ts/,
+  fullyParallel: false,
+  retries: 0,
+  workers: 1,
+  reporter: [['list'], ['html', { open: 'never' }]],
+  globalSetup: require.resolve('./globalSetup'),
+  globalTeardown: require.resolve('./globalTeardown'),
+  // Seeding plus the parked polling windows push individual tests well
+  // past the normal 60s budget.
+  timeout: 420_000,
+  expect: { timeout: 10_000 },
+  use: {
+    baseURL: BASE_URL,
+    storageState: STORAGE_STATE,
+    trace: 'off',
+    screenshot: 'off',
+    video: 'off',
+    actionTimeout: 15_000,
+    navigationTimeout: 30_000,
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+});

--- a/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/events/EventPollingManager.java
+++ b/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/events/EventPollingManager.java
@@ -3,6 +3,8 @@ package edu.stanford.bmir.protege.web.client.events;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.user.client.Timer;
 import com.google.web.bindery.event.shared.EventBus;
+import edu.stanford.bmir.protege.web.client.dispatch.DispatchErrorMessageDisplay;
+import edu.stanford.bmir.protege.web.client.dispatch.DispatchServiceCallback;
 import edu.stanford.bmir.protege.web.client.dispatch.DispatchServiceManager;
 import edu.stanford.bmir.protege.web.client.user.LoggedInUserProvider;
 import edu.stanford.bmir.protege.web.shared.event.*;
@@ -46,15 +48,33 @@ public class EventPollingManager {
 
     private final ChangeRequestEventAwaiter eventAwaiter;
 
+    private final DispatchErrorMessageDisplay errorMessageDisplay;
+
+    /**
+     * True while a catch-up fetch for missed events is on the wire. Prevents a
+     * burst of gapped windows from starting a fetch per window.
+     */
+    private boolean catchUpInFlight = false;
+
+    /**
+     * The highest endTag observed on windows that arrived (and were discarded)
+     * while a catch-up fetch was in flight. If the fetch completes below this
+     * mark, one follow-up fetch is issued to cover the remainder.
+     */
+    private EventTag catchUpHighWaterMark = null;
+
     @Inject
     public EventPollingManager(@EventPollingPeriod int pollingPeriodInMS,
                                ProjectId projectId,
                                EventBus eventBus,
                                DispatchServiceManager dispatchServiceManager,
-                               LoggedInUserProvider loggedInUserProvider, ChangeRequestEventAwaiter eventAwaiter) {
+                               LoggedInUserProvider loggedInUserProvider,
+                               ChangeRequestEventAwaiter eventAwaiter,
+                               DispatchErrorMessageDisplay errorMessageDisplay) {
         this.eventBus = eventBus;
         this.loggedInUserProvider = loggedInUserProvider;
         this.eventAwaiter = eventAwaiter;
+        this.errorMessageDisplay = errorMessageDisplay;
         if(pollingPeriodInMS < 1) {
             throw new IllegalArgumentException("pollingPeriodInMS must be greater than 0");
         }
@@ -105,6 +125,20 @@ public class EventPollingManager {
             GWT.log("[Event Polling Manager] Skipping already-dispatched events (up to " + eventListEndTag + ")");
             return;
         }
+        if(eventList.getStartTag().getOrdinal() != nextTag.getOrdinal()) {
+            // The window does not continue from the bookmark: either it jumps
+            // ahead (events in between were lost somewhere upstream) or it
+            // partially overlaps what was already applied. Events carry no
+            // individual tags, so an overlapping window cannot be sliced --
+            // in both cases the only safe recovery is to discard this window
+            // and pull everything from the bookmark forward (#297).
+            handleNonContiguousWindow(eventList);
+            return;
+        }
+        applyWindow(eventList);
+    }
+
+    private void applyWindow(EventList<?> eventList) {
         try {
             for (WebProtegeEvent<?> event : eventList.getEvents()) {
                 if (event.getSource() != null) {
@@ -118,9 +152,67 @@ public class EventPollingManager {
         } catch (Exception e) {
             logger.log(Level.SEVERE, "Error while sending events " + e.getMessage());
         } finally {
-            // The guard above ensures this only ever moves the tag forward.
-            nextTag = eventListEndTag;
+            // The guards above ensure this only ever moves the tag forward.
+            nextTag = eventList.getEndTag();
         }
+    }
+
+    private void handleNonContiguousWindow(EventList<?> eventList) {
+        int gapSize = eventList.getStartTag().getOrdinal() - nextTag.getOrdinal();
+        GWT.log("[Event Polling Manager] Missed events detected.  Bookmark: " + nextTag
+                        + ", incoming window: " + eventList.getStartTag() + " to " + eventList.getEndTag()
+                        + ", gap size: " + gapSize);
+        logger.warning("Missed events detected for " + projectId + ".  Bookmark: " + nextTag
+                               + ", incoming window: " + eventList.getStartTag() + " to " + eventList.getEndTag()
+                               + ", gap size: " + gapSize);
+        if(catchUpInFlight) {
+            EventTag incomingEndTag = eventList.getEndTag();
+            if(catchUpHighWaterMark == null || incomingEndTag.getOrdinal() > catchUpHighWaterMark.getOrdinal()) {
+                catchUpHighWaterMark = incomingEndTag;
+            }
+            return;
+        }
+        startCatchUpFetch();
+    }
+
+    private void startCatchUpFetch() {
+        catchUpInFlight = true;
+        // The pull has no upper bound: it returns everything from the bookmark
+        // to the head, including the discarded window's events, so filling the
+        // gap and re-delivering the jumped-ahead window collapse into this one
+        // fetch. Its response starts exactly at the bookmark, so it passes the
+        // contiguity check and applies.
+        EventTag fetchedFrom = nextTag;
+        dispatchServiceManager.execute(GetProjectEventsAction.create(nextTag, projectId),
+                                       new DispatchServiceCallback<GetProjectEventsResult>(errorMessageDisplay) {
+            @Override
+            public void handleSuccess(GetProjectEventsResult result) {
+                // Clear the guard before re-entering dispatchEvents so the
+                // fetched window is not treated as having arrived mid-flight.
+                catchUpInFlight = false;
+                dispatchEvents(result.getEvents());
+                EventTag highWaterMark = catchUpHighWaterMark;
+                catchUpHighWaterMark = null;
+                boolean madeProgress = nextTag.getOrdinal() > fetchedFrom.getOrdinal();
+                if(madeProgress && highWaterMark != null && !nextTag.isGreaterOrEqualTo(highWaterMark)) {
+                    // Windows beyond the fetch's coverage arrived while it was
+                    // in flight; issue one follow-up to cover the remainder.
+                    // Without progress we stop instead: the missing events are
+                    // not in the archive (yet), and refetching immediately
+                    // would spin -- the next poll or pushed window retries.
+                    startCatchUpFetch();
+                }
+            }
+
+            @Override
+            public void handleErrorFinally(Throwable throwable) {
+                // Never leave the guard wedged: the next poll result or pushed
+                // window re-triggers catch-up.
+                catchUpInFlight = false;
+                catchUpHighWaterMark = null;
+                logger.log(Level.WARNING, "Catch-up fetch for missed events failed: " + throwable.getMessage());
+            }
+        });
     }
 
 }

--- a/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/events/EventPollingManager.java
+++ b/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/events/EventPollingManager.java
@@ -38,7 +38,14 @@ public class EventPollingManager {
 
     private Timer pollingTimer;
 
-    private EventTag nextTag = EventTag.getFirst();
+    /**
+     * The client's bookmark: the tag up to which project events have been
+     * applied. {@code null} until the open-time anchor (see
+     * {@link #requestAnchor()}) resolves. While unanchored the manager neither
+     * polls from a bookmark nor applies pushed windows, so opening a project
+     * never replays the entire archived history from ordinal zero (#301).
+     */
+    private EventTag nextTag = null;
 
     private final ProjectId projectId;
 
@@ -62,6 +69,13 @@ public class EventPollingManager {
      * mark, one follow-up fetch is issued to cover the remainder.
      */
     private EventTag catchUpHighWaterMark = null;
+
+    /**
+     * True while the open-time head anchor request is on the wire. Stops a poll
+     * tick from firing a second anchor before the first resolves. Cleared on
+     * both success and failure so a failed anchor is retried by the next poll.
+     */
+    private boolean anchorInFlight = false;
 
     @Inject
     public EventPollingManager(@EventPollingPeriod int pollingPeriodInMS,
@@ -94,6 +108,11 @@ public class EventPollingManager {
         if(pollingTimer.isRunning()) {
             return;
         }
+        // Open the delta channel at the current head before the periodic poll
+        // begins. Until this resolves the manager stays unanchored: polls and
+        // pushed windows are dropped rather than replaying the whole archive
+        // from ordinal zero (#301).
+        requestAnchor();
         pollingTimer.scheduleRepeating(pollingPeriodInMS);
     }
 
@@ -103,12 +122,56 @@ public class EventPollingManager {
 
 
     public void pollForProjectEvents() {
+        if(nextTag == null) {
+            // Not yet anchored -- the open-time anchor is still in flight or a
+            // previous attempt failed. Retry the anchor rather than asking for
+            // events from a bookmark we do not have (which would ask for the
+            // whole history from ordinal zero).
+            requestAnchor();
+            return;
+        }
         GWT.log("[Event Polling Manager] Polling for project events for " + projectId + " from " + nextTag);
         dispatchServiceManager.execute(GetProjectEventsAction.create(nextTag, projectId), (GetProjectEventsResult result) -> dispatchEvents(result.getEvents()));
     }
 
+    private void requestAnchor() {
+        if(nextTag != null || anchorInFlight) {
+            return;
+        }
+        anchorInFlight = true;
+        dispatchServiceManager.execute(GetProjectEventsAction.anchor(projectId),
+                                       new DispatchServiceCallback<GetProjectEventsResult>(errorMessageDisplay) {
+            @Override
+            public void handleSuccess(GetProjectEventsResult result) {
+                anchorInFlight = false;
+                // Anchor the bookmark at the current head. Set nextTag directly
+                // rather than routing the response through dispatchEvents: the
+                // anchor window is empty, and dispatchEvents' empty-list early
+                // return would leave the bookmark null forever.
+                nextTag = result.getEvents().getEndTag();
+                GWT.log("[Event Polling Manager] Anchored " + projectId + " at " + nextTag);
+            }
+
+            @Override
+            public void handleErrorFinally(Throwable throwable) {
+                // Leave nextTag null so the next poll re-attempts the anchor.
+                anchorInFlight = false;
+                logger.log(Level.WARNING, "Anchor fetch for project events failed: " + throwable.getMessage());
+            }
+        });
+    }
+
 
     public void dispatchEvents(EventList<?> eventList) {
+        if(nextTag == null) {
+            // Unanchored: a pushed or polled window arrived before the open-time
+            // anchor resolved. Dropping it is safe -- once anchored we start at
+            // the head and the poll safety net re-delivers anything after it.
+            // Applying it now would also dereference a null nextTag in the
+            // contiguity checks below (#297).
+            GWT.log("[Event Polling Manager] Dropping events received before anchor for " + projectId);
+            return;
+        }
         GWT.log("[Event Polling Manager] Retrieved " + eventList.getEvents().size() + " events from server. From " + eventList.getStartTag() + " to " + eventList.getEndTag() + " current next tag " + nextTag);
 
         if(eventList.isEmpty()) {

--- a/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/project/ProjectPresenter.java
+++ b/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/project/ProjectPresenter.java
@@ -134,15 +134,21 @@ public class ProjectPresenter implements HasDispose, HasProjectId {
     }
 
     private void handleProjectLoaded(@Nonnull AcceptsOneWidget container, @Nonnull EventBus eventBus, @Nonnull ProjectViewPlace place) {
+        // Open the project-events delta channel at the current head BEFORE the
+        // batched portlet state queries below are flushed. start() anchors the
+        // event stream at "now"; issuing it here -- outside the batch, so its
+        // request goes on the wire ahead of executeCurrentBatch() -- lets the
+        // state queries observe a snapshot at or after the anchor. If the
+        // anchor instead resolved after the state queries, an edit landing in
+        // between would be lost: the loaded state would predate it while the
+        // stream started after it. Polling also backs up the live push
+        // connection, filling any gap if the connection glitches (#301).
+        eventPollingManager.start();
+
         dispatchServiceManager.beginBatch();
         topBarPresenter.start(view.getTopBarContainer(), eventBus, place);
         linkBarPresenter.start(view.getPerspectiveLinkBarViewContainer(), eventBus, place);
         perspectivePresenter.start(view.getPerspectiveViewContainer(), eventBus, place);
-        // Periodic polling backs up the live push connection: if the network
-        // drops or the connection glitches, the poll (every 10s, see
-        // EventPollingPeriodProvider) fills the gap. The live push covers
-        // anything time-sensitive.
-        eventPollingManager.start();
         eventBus.addHandlerToSource(LargeNumberOfChangesEvent.LARGE_NUMBER_OF_CHANGES,
                                     projectId,
                                     largeNumberOfChangesHandler);

--- a/webprotege-gwt-ui-client/src/test/java/edu/stanford/bmir/protege/web/client/events/EventPollingManager_TestCase.java
+++ b/webprotege-gwt-ui-client/src/test/java/edu/stanford/bmir/protege/web/client/events/EventPollingManager_TestCase.java
@@ -3,18 +3,27 @@ package edu.stanford.bmir.protege.web.client.events;
 import com.google.common.collect.ImmutableList;
 import com.google.web.bindery.event.shared.Event;
 import com.google.web.bindery.event.shared.EventBus;
+import edu.stanford.bmir.protege.web.client.dispatch.DispatchErrorMessageDisplay;
+import edu.stanford.bmir.protege.web.client.dispatch.DispatchServiceCallback;
 import edu.stanford.bmir.protege.web.client.dispatch.DispatchServiceManager;
 import edu.stanford.bmir.protege.web.client.user.LoggedInUserProvider;
 import edu.stanford.bmir.protege.web.shared.event.EventList;
 import edu.stanford.bmir.protege.web.shared.event.EventTag;
+import edu.stanford.bmir.protege.web.shared.event.GetProjectEventsAction;
+import edu.stanford.bmir.protege.web.shared.event.GetProjectEventsResult;
 import edu.stanford.bmir.protege.web.shared.event.WebProtegeEvent;
 import edu.stanford.bmir.protege.web.shared.project.ProjectId;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.*;
 
 /**
@@ -43,6 +52,16 @@ public class EventPollingManager_TestCase {
     @Mock
     private ChangeRequestEventAwaiter eventAwaiter;
 
+    @Mock
+    private DispatchErrorMessageDisplay errorMessageDisplay;
+
+    @Captor
+    private ArgumentCaptor<GetProjectEventsAction> actionCaptor;
+
+    @Captor
+    @SuppressWarnings("rawtypes")
+    private ArgumentCaptor<DispatchServiceCallback> callbackCaptor;
+
     @Before
     public void setUp() {
         manager = new EventPollingManager(10_000,
@@ -50,7 +69,8 @@ public class EventPollingManager_TestCase {
                                           eventBus,
                                           dispatchServiceManager,
                                           loggedInUserProvider,
-                                          eventAwaiter);
+                                          eventAwaiter,
+                                          errorMessageDisplay);
     }
 
     @SuppressWarnings("unchecked")
@@ -128,5 +148,121 @@ public class EventPollingManager_TestCase {
         verify(eventBus).fireEvent(gwtEventA);
         verify(eventBus, never()).fireEvent(staleGwtEvent);
         verify(eventBus, never()).fireEvent(gwtEventC);
+    }
+
+    // ------------------------------------------------------------------
+    // #297: a window that does not continue exactly from the bookmark
+    // means events were missed. The window must not be applied; the
+    // missing span is recovered through a catch-up fetch from the
+    // bookmark, which supersedes the discarded window.
+    // ------------------------------------------------------------------
+
+    @SuppressWarnings("unchecked")
+    private DispatchServiceCallback<GetProjectEventsResult> capturedCatchUpCallback() {
+        verify(dispatchServiceManager, atLeastOnce()).execute(actionCaptor.capture(), callbackCaptor.capture());
+        return callbackCaptor.getValue();
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private static GetProjectEventsResult resultOf(EventList<WebProtegeEvent<?>> window) {
+        GetProjectEventsResult result = mock(GetProjectEventsResult.class);
+        when(result.getEvents()).thenReturn((EventList) window);
+        return result;
+    }
+
+    @Test
+    public void shouldNotApplyAGappedWindowAndShouldFetchFromTheBookmark() {
+        Event<?> appliedGwtEvent = mock(Event.class);
+        Event<?> gappedGwtEvent = mock(Event.class);
+        WebProtegeEvent<?> applied = eventBackedBy(appliedGwtEvent);
+        WebProtegeEvent<?> gapped = eventBackedBy(gappedGwtEvent);
+
+        manager.dispatchEvents(window(0, 5, applied));
+        // Jumps ahead: events 5..7 were lost somewhere upstream.
+        manager.dispatchEvents(window(7, 9, gapped));
+
+        verify(eventBus, never()).fireEvent(gappedGwtEvent);
+        capturedCatchUpCallback();
+        assertThat(actionCaptor.getValue().getSinceTag(), is(equalTo(EventTag.get(5))));
+    }
+
+    @Test
+    public void shouldApplyTheCatchUpResultAndResumeNormalDispatch() {
+        Event<?> recoveredGwtEvent = mock(Event.class);
+        Event<?> nextGwtEvent = mock(Event.class);
+        WebProtegeEvent<?> recovered = eventBackedBy(recoveredGwtEvent);
+        WebProtegeEvent<?> next = eventBackedBy(nextGwtEvent);
+
+        manager.dispatchEvents(window(0, 5, eventBackedBy(mock(Event.class))));
+        manager.dispatchEvents(window(7, 9, eventBackedBy(mock(Event.class))));
+
+        // The catch-up fetch returns everything from the bookmark to the
+        // head, including the discarded window's events.
+        capturedCatchUpCallback().onSuccess(resultOf(window(5, 9, recovered)));
+
+        verify(eventBus).fireEvent(recoveredGwtEvent);
+        // The bookmark advanced to 9, so a contiguous follow-on window applies.
+        manager.dispatchEvents(window(9, 11, next));
+        verify(eventBus).fireEvent(nextGwtEvent);
+    }
+
+    @Test
+    public void shouldRefetchInsteadOfApplyingAPartiallyOverlappingWindow() {
+        Event<?> overlappingGwtEvent = mock(Event.class);
+        WebProtegeEvent<?> overlapping = eventBackedBy(overlappingGwtEvent);
+
+        manager.dispatchEvents(window(0, 10, eventBackedBy(mock(Event.class))));
+        // Starts before the bookmark but ends past it: events are not
+        // individually tagged, so the unseen tail cannot be sliced out.
+        manager.dispatchEvents(window(6, 12, overlapping));
+
+        verify(eventBus, never()).fireEvent(overlappingGwtEvent);
+        capturedCatchUpCallback();
+        assertThat(actionCaptor.getValue().getSinceTag(), is(equalTo(EventTag.get(10))));
+    }
+
+    @Test
+    public void shouldNotStartASecondFetchWhileOneIsInFlightButShouldFollowUp() {
+        manager.dispatchEvents(window(0, 5, eventBackedBy(mock(Event.class))));
+        manager.dispatchEvents(window(7, 9, eventBackedBy(mock(Event.class))));
+        // A further window arrives while the fetch is on the wire.
+        manager.dispatchEvents(window(11, 13, eventBackedBy(mock(Event.class))));
+
+        verify(dispatchServiceManager, times(1)).execute(any(GetProjectEventsAction.class), any(DispatchServiceCallback.class));
+
+        // The fetch completes below the high-water mark (13), so exactly one
+        // follow-up fetch is issued from the advanced bookmark.
+        capturedCatchUpCallback().onSuccess(resultOf(window(5, 9, eventBackedBy(mock(Event.class)))));
+
+        verify(dispatchServiceManager, times(2)).execute(actionCaptor.capture(), callbackCaptor.capture());
+        assertThat(actionCaptor.getValue().getSinceTag(), is(equalTo(EventTag.get(9))));
+    }
+
+    @Test
+    public void shouldRecoverFromAFailedCatchUpFetch() {
+        manager.dispatchEvents(window(0, 5, eventBackedBy(mock(Event.class))));
+        manager.dispatchEvents(window(7, 9, eventBackedBy(mock(Event.class))));
+
+        capturedCatchUpCallback().onFailure(new RuntimeException("boom"));
+
+        // The in-flight guard was cleared, so the next gapped window starts a
+        // fresh fetch rather than being silently dropped.
+        manager.dispatchEvents(window(7, 9, eventBackedBy(mock(Event.class))));
+        verify(dispatchServiceManager, times(2)).execute(any(GetProjectEventsAction.class), any(DispatchServiceCallback.class));
+    }
+
+    @Test
+    public void shouldNotSpinWhenTheCatchUpFetchMakesNoProgress() {
+        manager.dispatchEvents(window(0, 5, eventBackedBy(mock(Event.class))));
+        manager.dispatchEvents(window(7, 9, eventBackedBy(mock(Event.class))));
+        // Another window arrives mid-flight, raising the high-water mark.
+        manager.dispatchEvents(window(11, 13, eventBackedBy(mock(Event.class))));
+
+        // The archive has not caught up yet: the fetch returns nothing and
+        // the bookmark does not advance. No immediate refetch -- the next
+        // poll or pushed window retries instead.
+        capturedCatchUpCallback().onSuccess(resultOf(EventList.create(EventTag.get(5), ImmutableList.of(), EventTag.get(5))));
+
+        verify(dispatchServiceManager, times(1)).execute(any(GetProjectEventsAction.class), any(DispatchServiceCallback.class));
     }
 }

--- a/webprotege-gwt-ui-client/src/test/java/edu/stanford/bmir/protege/web/client/events/EventPollingManager_TestCase.java
+++ b/webprotege-gwt-ui-client/src/test/java/edu/stanford/bmir/protege/web/client/events/EventPollingManager_TestCase.java
@@ -64,13 +64,37 @@ public class EventPollingManager_TestCase {
 
     @Before
     public void setUp() {
-        manager = new EventPollingManager(10_000,
-                                          ProjectId.getNil(),
-                                          eventBus,
-                                          dispatchServiceManager,
-                                          loggedInUserProvider,
-                                          eventAwaiter,
-                                          errorMessageDisplay);
+        manager = newManager();
+        // #301: the manager now opens unanchored (nextTag == null). Anchor it
+        // at tag 0 so the existing #191/#297 dispatch tests exercise the same
+        // bookmark they always started from; the reset() inside clears the
+        // anchor request so it does not perturb the dispatch-count assertions.
+        anchorAtHead(0);
+    }
+
+    private EventPollingManager newManager() {
+        return new EventPollingManager(10_000,
+                                       ProjectId.getNil(),
+                                       eventBus,
+                                       dispatchServiceManager,
+                                       loggedInUserProvider,
+                                       eventAwaiter,
+                                       errorMessageDisplay);
+    }
+
+    /**
+     * Drives {@link #manager}'s open-time head anchor to completion so it is
+     * bookmarked at {@code headTag}, then clears the mock's interaction history
+     * so the anchor request does not count towards the dispatch assertions in
+     * the tests that follow.
+     */
+    @SuppressWarnings("unchecked")
+    private void anchorAtHead(int headTag) {
+        manager.pollForProjectEvents();
+        ArgumentCaptor<DispatchServiceCallback> anchorCallback = ArgumentCaptor.forClass(DispatchServiceCallback.class);
+        verify(dispatchServiceManager).execute(any(GetProjectEventsAction.class), anchorCallback.capture());
+        anchorCallback.getValue().onSuccess(resultOf(EventList.create(EventTag.get(headTag), ImmutableList.of(), EventTag.get(headTag))));
+        reset(dispatchServiceManager);
     }
 
     @SuppressWarnings("unchecked")
@@ -262,6 +286,90 @@ public class EventPollingManager_TestCase {
         // the bookmark does not advance. No immediate refetch -- the next
         // poll or pushed window retries instead.
         capturedCatchUpCallback().onSuccess(resultOf(EventList.create(EventTag.get(5), ImmutableList.of(), EventTag.get(5))));
+
+        verify(dispatchServiceManager, times(1)).execute(any(GetProjectEventsAction.class), any(DispatchServiceCallback.class));
+    }
+
+    // ------------------------------------------------------------------
+    // #301: a freshly-opened project must not replay the whole archive.
+    // The manager opens unanchored and first asks only for the current head
+    // (an anchor request); it neither polls from a bookmark nor applies
+    // pushed windows until that anchor resolves.
+    // ------------------------------------------------------------------
+
+    @SuppressWarnings("unchecked")
+    private DispatchServiceCallback<GetProjectEventsResult> capturedAnchorCallback() {
+        verify(dispatchServiceManager, atLeastOnce()).execute(actionCaptor.capture(), callbackCaptor.capture());
+        return callbackCaptor.getValue();
+    }
+
+    @Test
+    public void shouldRequestTheHeadAnchorRatherThanPollingWhileUnanchored() {
+        EventPollingManager unanchored = newManager();
+
+        unanchored.pollForProjectEvents();
+
+        // The first request is the head anchor (latestOnly), not a since-tag
+        // poll that would drag down the entire history from ordinal zero.
+        verify(dispatchServiceManager).execute(actionCaptor.capture(), any(DispatchServiceCallback.class));
+        assertThat(actionCaptor.getValue().isLatestOnly(), is(true));
+        verify(eventBus, never()).fireEvent(any(Event.class));
+    }
+
+    @Test
+    public void shouldAnchorTheBookmarkAtTheResponseEndTag() {
+        EventPollingManager unanchored = newManager();
+        unanchored.pollForProjectEvents();
+
+        // The anchor response carries no events, only the current head (42).
+        capturedAnchorCallback().onSuccess(resultOf(EventList.create(EventTag.get(42), ImmutableList.of(), EventTag.get(42))));
+
+        // Bookmarked at 42: a window that continues from 42 now applies.
+        Event<?> gwtEvent = mock(Event.class);
+        unanchored.dispatchEvents(window(42, 45, eventBackedBy(gwtEvent)));
+        verify(eventBus).fireEvent(gwtEvent);
+    }
+
+    @Test
+    public void shouldDropWindowsArrivingBeforeTheAnchorWithoutWedging() {
+        EventPollingManager unanchored = newManager();
+
+        // A pushed window arrives before the manager has anchored.
+        Event<?> earlyGwtEvent = mock(Event.class);
+        unanchored.dispatchEvents(window(0, 5, eventBackedBy(earlyGwtEvent)));
+
+        verify(eventBus, never()).fireEvent(earlyGwtEvent);
+        // Dropping the window must not start any fetch...
+        verify(dispatchServiceManager, never()).execute(any(GetProjectEventsAction.class), any(DispatchServiceCallback.class));
+
+        // ...and the manager is not wedged: it still anchors and then dispatches.
+        unanchored.pollForProjectEvents();
+        capturedAnchorCallback().onSuccess(resultOf(EventList.create(EventTag.get(10), ImmutableList.of(), EventTag.get(10))));
+        Event<?> laterGwtEvent = mock(Event.class);
+        unanchored.dispatchEvents(window(10, 12, eventBackedBy(laterGwtEvent)));
+        verify(eventBus).fireEvent(laterGwtEvent);
+    }
+
+    @Test
+    public void shouldRetryTheAnchorAfterAFailure() {
+        EventPollingManager unanchored = newManager();
+        unanchored.pollForProjectEvents();
+
+        capturedAnchorCallback().onFailure(new RuntimeException("boom"));
+
+        // The in-flight guard was cleared and the bookmark is still unset, so
+        // the next poll issues a fresh anchor rather than giving up.
+        unanchored.pollForProjectEvents();
+        verify(dispatchServiceManager, times(2)).execute(any(GetProjectEventsAction.class), any(DispatchServiceCallback.class));
+    }
+
+    @Test
+    public void shouldNotIssueASecondAnchorWhileOneIsInFlight() {
+        EventPollingManager unanchored = newManager();
+
+        unanchored.pollForProjectEvents();
+        // A second poll tick fires before the anchor resolves.
+        unanchored.pollForProjectEvents();
 
         verify(dispatchServiceManager, times(1)).execute(any(GetProjectEventsAction.class), any(DispatchServiceCallback.class));
     }

--- a/webprotege-gwt-ui-server-core/src/main/java/edu/stanford/bmir/protege/web/server/dispatch/impl/DispatchServiceExecutorImpl.java
+++ b/webprotege-gwt-ui-server-core/src/main/java/edu/stanford/bmir/protege/web/server/dispatch/impl/DispatchServiceExecutorImpl.java
@@ -118,11 +118,11 @@ public class DispatchServiceExecutorImpl implements DispatchServiceExecutor {
                         .stream()
                         .map(e -> e.getKey() + ": " +  e.getValue())
                         .collect(Collectors.joining("  &&  "));
-                logger.info("Permission denied for {} when executing {}.  User: {}, Headers: {}, Token: {}", executionContext.getUserId(),
-                            action.getClass().getSimpleName(),
+                // The user's access token is a credential and must not be written to the log.
+                logger.info("Permission denied for {} when executing {}.  Headers: {}",
                             executionContext.getUserId(),
-                            headers,
-                            executionContext.getToken());
+                            action.getClass().getSimpleName(),
+                            headers);
                 throw new PermissionDeniedException("Permission denied (" + httpResponse.statusCode() + ")", executionContext.getUserId());
             }
             else if(httpResponse.statusCode() >= 400) {

--- a/webprotege-gwt-ui-server-core/src/test/java/edu/stanford/bmir/protege/web/shared/event/GetProjectEvents_Serialization_TestCase.java
+++ b/webprotege-gwt-ui-server-core/src/test/java/edu/stanford/bmir/protege/web/shared/event/GetProjectEvents_Serialization_TestCase.java
@@ -25,6 +25,15 @@ public class GetProjectEvents_Serialization_TestCase {
     }
 
     @Test
+    public void shouldSerializeAnchorActionWithLatestOnlyFlag() throws IOException {
+        // The latestOnly flag must survive the JSON-RPC hop to the
+        // event-history-service, otherwise the anchor request degrades into a
+        // full-history query (#301).
+        var action = GetProjectEventsAction.anchor(mockProjectId());
+        JsonSerializationTestUtil.testSerialization(action, Action.class);
+    }
+
+    @Test
     public void shouldSerializeResult() throws IOException {
         var result = GetProjectEventsResult.create(mockEventList());
         JsonSerializationTestUtil.testSerialization(result, Result.class);

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/event/GetProjectEventsAction.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/event/GetProjectEventsAction.java
@@ -1,5 +1,6 @@
 package edu.stanford.bmir.protege.web.shared.event;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.common.base.Objects;
 import edu.stanford.bmir.protege.web.shared.dispatch.Action;
@@ -26,22 +27,49 @@ public class GetProjectEventsAction implements Action<GetProjectEventsResult>, H
     private EventTag sinceTag;
 
     /**
+     * When {@code true} the request asks only for the current head position of
+     * the project's event stream: the service reads no history and returns an
+     * empty window whose start and end tags are both the head. This anchors a
+     * freshly-opened project at "now" instead of replaying the whole archive
+     * from ordinal zero. Absent or {@code false} on the wire means the normal
+     * since-tag catch-up query, so an old service simply ignores it (returning
+     * history) rather than failing.
+     */
+    @JsonProperty("latestOnly")
+    private boolean latestOnly;
+
+    /**
      * For serialization purposes only.
      */
     private GetProjectEventsAction() {
     }
 
-    private GetProjectEventsAction(@Nonnull EventTag sinceTag, @Nonnull ProjectId projectId) {
+    private GetProjectEventsAction(@Nonnull EventTag sinceTag, @Nonnull ProjectId projectId, boolean latestOnly) {
         this.sinceTag = checkNotNull(sinceTag);
         this.projectId = checkNotNull(projectId);
+        this.latestOnly = latestOnly;
     }
 
     public static GetProjectEventsAction create(@Nonnull EventTag sinceTag, @Nonnull ProjectId projectId) {
-        return new GetProjectEventsAction(sinceTag, projectId);
+        return new GetProjectEventsAction(sinceTag, projectId, false);
+    }
+
+    /**
+     * Creates an action that anchors at the current head of the project's event
+     * stream. The response carries no historical events, only the current
+     * position, so an opening client can begin receiving live updates from
+     * "now" without downloading and re-dispatching the entire archived history.
+     */
+    public static GetProjectEventsAction anchor(@Nonnull ProjectId projectId) {
+        return new GetProjectEventsAction(EventTag.getFirst(), projectId, true);
     }
 
     public EventTag getSinceTag() {
         return sinceTag;
+    }
+
+    public boolean isLatestOnly() {
+        return latestOnly;
     }
 
     @Nonnull
@@ -54,7 +82,7 @@ public class GetProjectEventsAction implements Action<GetProjectEventsResult>, H
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(sinceTag, projectId);
+        return Objects.hashCode(sinceTag, projectId, latestOnly);
     }
 
     @Override
@@ -67,13 +95,15 @@ public class GetProjectEventsAction implements Action<GetProjectEventsResult>, H
         }
         GetProjectEventsAction other = (GetProjectEventsAction) obj;
         return this.sinceTag.equals(other.sinceTag)
-                && this.projectId.equals(other.projectId);
+                && this.projectId.equals(other.projectId)
+                && this.latestOnly == other.latestOnly;
     }
 
     @Override
     public String toString() {
         return toStringHelper("GetProjectEventsAction")
                           .addValue(projectId)
-                          .add("since", sinceTag).toString();
+                          .add("since", sinceTag)
+                          .add("latestOnly", latestOnly).toString();
     }
 }

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/event/GetProjectEventsAction_CustomFieldSerializer.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/event/GetProjectEventsAction_CustomFieldSerializer.java
@@ -48,6 +48,14 @@ public class GetProjectEventsAction_CustomFieldSerializer extends CustomFieldSer
     public static GetProjectEventsAction instantiate(SerializationStreamReader streamReader) throws SerializationException {
         String projectName = streamReader.readString();
         int ordinal = streamReader.readInt();
+        // Read in the same order it is written by serialize(). Missing this
+        // read (or the matching write) silently drops the flag on the GWT-RPC
+        // hop from the browser to gwt-ui-server, so the client would keep
+        // replaying the whole history at open.
+        boolean latestOnly = streamReader.readBoolean();
+        if (latestOnly) {
+            return GetProjectEventsAction.anchor(ProjectId.get(projectName));
+        }
         return GetProjectEventsAction.create(EventTag.get(ordinal), ProjectId.get(projectName));
     }
 
@@ -70,6 +78,7 @@ public class GetProjectEventsAction_CustomFieldSerializer extends CustomFieldSer
     public static void serialize(SerializationStreamWriter streamWriter, GetProjectEventsAction instance) throws SerializationException {
         streamWriter.writeString(instance.getProjectId().getId());
         streamWriter.writeInt(instance.getSinceTag().getOrdinal());
+        streamWriter.writeBoolean(instance.isLatestOnly());
     }
 
 

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/event/LargeNumberOfChangesEvent.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/event/LargeNumberOfChangesEvent.java
@@ -8,6 +8,8 @@ import com.google.web.bindery.event.shared.Event;
 import edu.stanford.bmir.protege.web.shared.annotations.GwtSerializationConstructor;
 import edu.stanford.bmir.protege.web.shared.project.ProjectId;
 
+import java.util.Objects;
+
 /**
  * Matthew Horridge
  * Stanford Center for Biomedical Informatics Research
@@ -49,7 +51,7 @@ public class LargeNumberOfChangesEvent extends ProjectEvent<LargeNumberOfChanges
 
     @Override
     public int hashCode() {
-        return getProjectId().hashCode();
+        return Objects.hash(getProjectId(), eventId);
     }
 
     @Override
@@ -60,7 +62,11 @@ public class LargeNumberOfChangesEvent extends ProjectEvent<LargeNumberOfChanges
         if(!(obj instanceof LargeNumberOfChangesEvent)) {
             return false;
         }
+        // The event id must take part: handled-event sets use equality to drop
+        // the same signal arriving over both delivery paths, and comparing the
+        // project alone would also swallow every LATER signal for the project.
         LargeNumberOfChangesEvent other = (LargeNumberOfChangesEvent) obj;
-        return this.getProjectId().equals(other.getProjectId());
+        return this.getProjectId().equals(other.getProjectId())
+                && Objects.equals(this.eventId, other.eventId);
     }
 }

--- a/webprotege-gwt-ui-shared/src/test/java/edu/stanford/bmir/protege/web/shared/event/GetProjectEventsAction_LatestOnly_TestCase.java
+++ b/webprotege-gwt-ui-shared/src/test/java/edu/stanford/bmir/protege/web/shared/event/GetProjectEventsAction_LatestOnly_TestCase.java
@@ -1,0 +1,84 @@
+package edu.stanford.bmir.protege.web.shared.event;
+
+import com.google.gwt.user.client.rpc.SerializationException;
+import com.google.gwt.user.client.rpc.SerializationStreamReader;
+import com.google.gwt.user.client.rpc.SerializationStreamWriter;
+import edu.stanford.bmir.protege.web.shared.project.ProjectId;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Covers the {@code latestOnly} anchor flag added for
+ * protegeproject/webprotege-gwt-ui#301. Written in JUnit 5 because this module
+ * runs the JUnit-platform provider without a vintage engine, so JUnit 4 test
+ * classes here are silently skipped.
+ */
+public class GetProjectEventsAction_LatestOnly_TestCase {
+
+    @Test
+    public void anchorFactorySetsLatestOnly() {
+        GetProjectEventsAction action = GetProjectEventsAction.anchor(ProjectId.getNil());
+        assertThat(action.isLatestOnly()).isTrue();
+        assertThat(action.getSinceTag()).isEqualTo(EventTag.getFirst());
+    }
+
+    @Test
+    public void createFactoryLeavesLatestOnlyFalse() {
+        GetProjectEventsAction action = GetProjectEventsAction.create(EventTag.get(3), ProjectId.getNil());
+        assertThat(action.isLatestOnly()).isFalse();
+    }
+
+    @Test
+    public void latestOnlyIsPartOfEquality() {
+        // Same projectId and sinceTag: they must differ purely on the flag, or
+        // the JSON/GWT-RPC round-trip tests could not detect the flag dropping.
+        GetProjectEventsAction anchor = GetProjectEventsAction.anchor(ProjectId.getNil());
+        GetProjectEventsAction since = GetProjectEventsAction.create(EventTag.getFirst(), ProjectId.getNil());
+        assertThat(anchor).isNotEqualTo(since);
+        assertThat(anchor.hashCode()).isNotEqualTo(since.hashCode());
+    }
+
+    @Test
+    public void gwtRpcRoundTripPreservesAnchorFlag() throws SerializationException {
+        GetProjectEventsAction original = GetProjectEventsAction.anchor(ProjectId.getNil());
+        assertThat(gwtRpcRoundTrip(original)).isEqualTo(original);
+    }
+
+    @Test
+    public void gwtRpcRoundTripPreservesSinceTagWhenNotAnchoring() throws SerializationException {
+        GetProjectEventsAction original = GetProjectEventsAction.create(EventTag.get(7), ProjectId.getNil());
+        GetProjectEventsAction roundTripped = gwtRpcRoundTrip(original);
+        assertThat(roundTripped).isEqualTo(original);
+        assertThat(roundTripped.isLatestOnly()).isFalse();
+        assertThat(roundTripped.getSinceTag()).isEqualTo(EventTag.get(7));
+    }
+
+    /**
+     * Runs the action through the custom GWT-RPC serializer exactly as the wire
+     * does: {@code serialize} records the primitives, then {@code instantiate}
+     * reads them back in the same order.
+     */
+    private static GetProjectEventsAction gwtRpcRoundTrip(GetProjectEventsAction action) throws SerializationException {
+        SerializationStreamWriter writer = mock(SerializationStreamWriter.class);
+        GetProjectEventsAction_CustomFieldSerializer.serialize(writer, action);
+
+        ArgumentCaptor<String> stringCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<Integer> intCaptor = ArgumentCaptor.forClass(Integer.class);
+        ArgumentCaptor<Boolean> boolCaptor = ArgumentCaptor.forClass(Boolean.class);
+        verify(writer).writeString(stringCaptor.capture());
+        verify(writer).writeInt(intCaptor.capture());
+        verify(writer).writeBoolean(boolCaptor.capture());
+
+        SerializationStreamReader reader = mock(SerializationStreamReader.class);
+        when(reader.readString()).thenReturn(stringCaptor.getValue());
+        when(reader.readInt()).thenReturn(intCaptor.getValue());
+        when(reader.readBoolean()).thenReturn(boolCaptor.getValue());
+
+        return GetProjectEventsAction_CustomFieldSerializer.instantiate(reader);
+    }
+}

--- a/webprotege-gwt-ui-shared/src/test/java/edu/stanford/bmir/protege/web/shared/event/LargeNumberOfChangesEvent_TestCase.java
+++ b/webprotege-gwt-ui-shared/src/test/java/edu/stanford/bmir/protege/web/shared/event/LargeNumberOfChangesEvent_TestCase.java
@@ -1,0 +1,47 @@
+package edu.stanford.bmir.protege.web.shared.event;
+
+import edu.stanford.bmir.protege.web.shared.project.ProjectId;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+
+/**
+ * Equality on this event drives the client's handled-events dedup set: it must
+ * treat the SAME signal arriving over both delivery paths (push and poll) as
+ * one, while distinct later signals for the same project must not be swallowed
+ * — comparing the project alone made every prompt after the first vanish (#300).
+ */
+public class LargeNumberOfChangesEvent_TestCase {
+
+    private static final ProjectId PROJECT_ID = ProjectId.getNil();
+
+    @Test
+    public void shouldBeEqualForTheSameEventId() {
+        LargeNumberOfChangesEvent eventViaPush = new LargeNumberOfChangesEvent(EventId.get("event-a"), PROJECT_ID);
+        LargeNumberOfChangesEvent eventViaPoll = new LargeNumberOfChangesEvent(EventId.get("event-a"), PROJECT_ID);
+        assertThat(eventViaPush, is(equalTo(eventViaPoll)));
+        assertThat(eventViaPush.hashCode(), is(eventViaPoll.hashCode()));
+    }
+
+    @Test
+    public void shouldNotBeEqualForDistinctEventIdsInTheSameProject() {
+        LargeNumberOfChangesEvent firstSignal = new LargeNumberOfChangesEvent(EventId.get("event-a"), PROJECT_ID);
+        LargeNumberOfChangesEvent laterSignal = new LargeNumberOfChangesEvent(EventId.get("event-b"), PROJECT_ID);
+        assertThat(firstSignal, is(not(equalTo(laterSignal))));
+    }
+
+    @Test
+    public void shouldDedupTheSameSignalButKeepDistinctSignalsInAHandledSet() {
+        Set<LargeNumberOfChangesEvent> handled = new HashSet<>();
+        handled.add(new LargeNumberOfChangesEvent(EventId.get("event-a"), PROJECT_ID));
+
+        assertThat(handled.contains(new LargeNumberOfChangesEvent(EventId.get("event-a"), PROJECT_ID)), is(true));
+        assertThat(handled.contains(new LargeNumberOfChangesEvent(EventId.get("event-b"), PROJECT_ID)), is(false));
+    }
+}


### PR DESCRIPTION
The gwt-ui half of #301 (part of #303). Stacked on #311; retarget to `epic/303-sse` once that merges. Service half: protegeproject/webprotege-event-history-service (branch `feat/301-no-history-replay`).

Opening a project started the event bookmark at zero, so the first poll downloaded the project's entire archived history — unbounded growth with project age (the baseline showed 20KB for just 25 revisions, re-fetched on every open, plus the same payload dumped into the server log). The client now requests the current head position first (a new `latestOnly` flag on the events action, carried through both the Jackson and GWT-RPC hops) and starts polling from there: the event channel carries changes from the open onward, nothing else.

Ordering is load-bearing and preserved: the anchor goes on the wire before the batched portlet state queries, so state always reflects a snapshot at-or-after the anchor and no edit can vanish between history and live delivery. Mixed versions degrade gracefully (an old server's ignored flag costs one wasted download, never a replay burst).

Tests: 15/15 client (10 existing #191/#297 regressions + 5 anchor cases), 5/5 shared round-trip, 3/3 server-core serialization.