### PR TITLE
Drop the websocket-era plumbing now that events ride Server-Sent Events

### DIFF
--- a/playwright/docker-compose.yml
+++ b/playwright/docker-compose.yml
@@ -69,7 +69,7 @@ services:
     networks: [wp]
 
   webprotege-gwt-api-gateway:
-    image: protegeproject/webprotege-gwt-api-gateway:3.0.3
+    image: protegeproject/webprotege-gwt-api-gateway:3.0.4
     # Spring Security fetches the OIDC discovery doc at startup from
     # http://${SERVER_HOST}/keycloak/.../.well-known/openid-configuration,
     # which routes back through nginx. Nginx is downstream of this service
@@ -115,7 +115,6 @@ services:
       SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWK_SET_URI: http://webprotege-keycloak:8080/keycloak/realms/webprotege/protocol/openid-connect/certs
       spring.servlet.multipart.max-file-size: 300MB
       spring.servlet.multipart.max-request-size: 300MB
-      WEBPROTEGE_ALLOWEDORIGIN: http://${SERVER_HOST:-localhost}
       webprotege.rabbit.timeout: 600000
     networks: [wp]
     extra_hosts:
@@ -137,7 +136,6 @@ services:
       minio.endPoint: http://minio:9000
       KEYCLOAK_AUTH_URL: http://${SERVER_HOST:-localhost}/keycloak/
       webprotege.gwt-api-gateway.endPoint: http://webprotege-gwt-api-gateway:7777
-      webprotege.websocketUrl: ws://${SERVER_HOST:-localhost}/wsapps
       webprotege.logoutUrl: http://${SERVER_HOST:-localhost}/webprotege/logout
       webprotege.fileUploadurl: http://${SERVER_HOST:-localhost}
       webprotege.keycloakLogoutUrl: http://${SERVER_HOST:-localhost}/keycloak/realms/webprotege/protocol/openid-connect/logout

--- a/playwright/tests/21-entity-removals.spec.ts
+++ b/playwright/tests/21-entity-removals.spec.ts
@@ -14,12 +14,12 @@ import {
 
 /**
  * Regression pin for #191: removed annotations/parents and deleted classes
- * must STAY removed in the UI. Project events arrive over two concurrent
- * paths (websocket push + polling safety net); before the dispatch guard
- * in EventPollingManager, a late-delivered older event window could be
+ * must STAY removed in the UI. Project events arrive over an SSE stream whose
+ * reconnect catch-up can replay an older event window; without the dispatch
+ * guard in ProjectEventDispatcher, a late-delivered older window could be
  * replayed, re-adding removed hierarchy edges and resurrecting deleted
  * classes on screen even though the server data was correct. The
- * deliberate multi-poll-tick wait here gives any replay a chance to
+ * deliberate multi-tick wait here gives any replay a chance to
  * happen before we assert.
  */
 

--- a/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/dispatch/DispatchServiceManager.java
+++ b/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/dispatch/DispatchServiceManager.java
@@ -251,35 +251,9 @@ public class DispatchServiceManager {
                 ResultCache resultCache = getResultCache(((HasProjectId) action).getProjectId(), eventBus);
                 resultCache.cacheResult((Action<R>) action, (R) result.getResult());
             }
-//            dispatchEvents(result.getResult());
             delegate.onSuccess(result.getResult());
         }
     }
-
-    // EVENTS ARE CURRENTLY REIMPLEMENTED WITH WEBSOCKETS
-
-//    private void dispatchEvents(Object result) {
-//        if(result instanceof HasEventList<?>) {
-//            EventList<? extends WebProtegeEvent<?>> eventList = ((HasEventList<? extends WebProtegeEvent<?>>) result).getEventList();
-//
-//            List<WebProtegeEvent> events = eventList.getEvents();
-//            // TODO: FIX - Should be dispatched by the project event manager otherwise we will get events from the
-//            // TODO: more than once!
-//            GWT.log("[Dispatch] Dispatching " + events.size() + " events");
-//            long t0 = TimeUtil.getCurrentTime();
-//            for(WebProtegeEvent<?> event : events) {
-//                GWT.log("[Dispatch] Dispatching event (" + event + ")");
-//                if(event.getSource() != null) {
-//                    eventBus.fireEventFromSource(event.asGWTEvent(), event.getSource());
-//                }
-//                else {
-//                    eventBus.fireEvent(event.asGWTEvent());
-//                }
-//            }
-//            long t1 = TimeUtil.getCurrentTime();
-//            GWT.log("[Dispatch] Dispatched events in " + (t1 - t0) + " ms");
-//        }
-//    }
 
     private void handleError(final Throwable throwable, final Action<?> action, final DispatchServiceCallback<?> callback) {
         if(throwable instanceof StatusCodeException) {

--- a/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/events/ProjectEventStreamManager.java
+++ b/webprotege-gwt-ui-client/src/main/java/edu/stanford/bmir/protege/web/client/events/ProjectEventStreamManager.java
@@ -19,10 +19,9 @@ import java.util.logging.Logger;
 
 /**
  * Owns the browser-native {@link com.google.gwt.core.client.JavaScriptObject
- * EventSource} that streams project change events from the gateway, replacing
- * the StompJs WebSocket subscription (#306). Received frames are fed, unchanged,
- * into {@link ProjectEventDispatcher} through the same
- * {@link TranslateEventListAction} round-trip the WebSocket path used, so no new
+ * EventSource} that streams project change events from the gateway (#306).
+ * Received frames are fed, unchanged, into {@link ProjectEventDispatcher}
+ * through a {@link TranslateEventListAction} round-trip, so no new
  * deserialization happens on the client.
  *
  * <h3>Connecting</h3>

--- a/webprotege-gwt-ui-client/src/main/module-dev.gwt.xml
+++ b/webprotege-gwt-ui-client/src/main/module-dev.gwt.xml
@@ -51,11 +51,6 @@
 
     <set-property name="locale" value="en"/>
 
-<!--    <set-property name="webprotege.brokerUrl" value="ws://webprotege-local.edu/wsapps"/>
-    <set-property name="webprotege.reconnectDelay" value="5000"/>
-    <set-property name="webprotege.heartbeatIncoming" value="4000"/>
-    <set-property name="webprotege.heartbeatOutgoing" value="4000"/>-->
-
     <extend-configuration-property name="rpc.blacklist" value="+com.google.web.bindery.event.shared.Event"/>
 
     <set-configuration-property name="devModeUrlWhitelistRegexp" value="http://(webprotege-local\.edu|localhost|127\.0\.0\.1)(:\d+)?/.*" />

--- a/webprotege-gwt-ui-client/src/main/module.gwt.xml
+++ b/webprotege-gwt-ui-client/src/main/module.gwt.xml
@@ -55,11 +55,6 @@
     <extend-property name="locale" values="sl"/>
     <extend-property name="locale" values="pt"/>
 
-<!--    <set-property name="webprotege.brokerUrl" value="ws://webprotege-local.edu/wsapps"/>
-    <set-property name="webprotege.reconnectDelay" value="5000"/>
-    <set-property name="webprotege.heartbeatIncoming" value="4000"/>
-    <set-property name="webprotege.heartbeatOutgoing" value="4000"/>-->
-
     <extend-configuration-property name="rpc.blacklist" value="+com.google.web.bindery.event.shared.Event"/>
 
     <set-configuration-property name="devModeUrlWhitelistRegexp" value="http://(webprotege-local\.edu|localhost|127\.0\.0\.1)(:\d+)?/.*" />

--- a/webprotege-gwt-ui-server-core/src/main/java/edu/stanford/bmir/protege/web/server/dispatch/impl/DispatchServiceExecutorImpl.java
+++ b/webprotege-gwt-ui-server-core/src/main/java/edu/stanford/bmir/protege/web/server/dispatch/impl/DispatchServiceExecutorImpl.java
@@ -70,8 +70,7 @@ public class DispatchServiceExecutorImpl implements DispatchServiceExecutor {
                 }
             }
             if(action instanceof GetUserInfoAction) {
-                var websocketUrl = getWebSocketUrl();
-                GetUserInfoResult result = GetUserInfoResult.create(executionContext.getToken(), websocketUrl != null ? websocketUrl : "ws://webprotege-local.edu/wsapps");
+                GetUserInfoResult result = GetUserInfoResult.create(executionContext.getToken());
                 return DispatchServiceResultContainer.create(result);
             }
             var result = sendRequest(action, executionContext);
@@ -88,15 +87,6 @@ public class DispatchServiceExecutorImpl implements DispatchServiceExecutor {
             logger.error("An error occurred whilst executing an action", e);
             throw new ActionExecutionException(e.getMessage());
         }
-    }
-
-    private static String getWebSocketUrl() {
-        String env = System.getenv("WEBPROTEGE_WEBSOCKET_URL");
-        if(env != null) {
-            return env;
-        }
-        // Legacy naming
-        return System.getenv("webprotege.websocketUrl" );
     }
 
     private <A extends Action<R>, R extends Result> R sendRequest(A action,

--- a/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/dispatch/actions/GetUserInfoResult.java
+++ b/webprotege-gwt-ui-shared/src/main/java/edu/stanford/bmir/protege/web/shared/dispatch/actions/GetUserInfoResult.java
@@ -18,8 +18,6 @@ public class GetUserInfoResult implements Result, Serializable, IsSerializable {
 
     private String token;
 
-    private String websocketUrl;
-
 
     @GwtSerializationConstructor
     public GetUserInfoResult(){
@@ -29,21 +27,15 @@ public class GetUserInfoResult implements Result, Serializable, IsSerializable {
 
     @JsonCreator
     @NotNull
-    public static GetUserInfoResult create(@JsonProperty("token") String token, @JsonProperty("websocketUrl") String websocketUrl) {
+    public static GetUserInfoResult create(@JsonProperty("token") String token) {
         GetUserInfoResult response = new GetUserInfoResult();
         response.token = token;
-        response.websocketUrl = websocketUrl;
         return response;
     }
 
 
     public String getToken() {
         return token;
-    }
-
-
-    public String getWebsocketUrl() {
-        return websocketUrl;
     }
 
     public void setToken(String token) {


### PR DESCRIPTION
The client half of #308, the epic's final cleanup. `GetUserInfoResult` loses its websocket URL (the token stays — uploads and forms use it), the server stops reading the websocket env vars and the hardcoded `ws://` fallback, stale websocket-era comments are gone (the #191 stale-window rationale survives in `ProjectEventDispatcher`, where the dedup logic lives now), and the e2e stack drops the websocket env/origin settings while bumping the gateway pin to 3.0.4 (the fan-out flag release, protegeproject/webprotege-gwt-api-gateway#51).

Companions: gateway and nginx PRs remove the server side and the dead proxy route. Each PR is independently deployable — nothing has called `/wsapps` since the EventSource client shipped.

Tests: shared-core 121, shared 66, server-core 514, all green; client and webapp modules compile clean. Grep gates: no stomp/sockjs/wsapps/websocket survivors in any module.